### PR TITLE
build_bladerf.sh: fix quartus 13.0+ support

### DIFF
--- a/hdl/quartus/build_bladerf.sh
+++ b/hdl/quartus/build_bladerf.sh
@@ -106,7 +106,7 @@ if [ $? -ne 0 ] || [ ! -d "$quartus_sh_path" ]; then
 fi
 
 # Ensure the NIOS II EDS dir is in PATH by checking for a known script
-niosscript="`which nios2-build-project`"
+niosscript="`which nios2-terminal`"
 if [ $? -ne 0 ] || [ ! -f "$niosscript" ]; then
     echo -e "\nError: The NIOS II EDS 'bin' directory does not appear to be in your PATH\n" >&2
     exit 1


### PR DESCRIPTION
nios2-build-project does not seem to exist in 13.0 and later.
So, look for nios2-terminal instead.

This is a somewhat lame workaround, but it seems to do the trick.
