### PR TITLE
Dragorn cli fixes

### DIFF
--- a/linux/apps/src/cli/cmd/load.c
+++ b/linux/apps/src/cli/cmd/load.c
@@ -10,6 +10,8 @@ int cmd_load(struct cli_state *state, int argc, char **argv)
     int rv = CMD_RET_OK ;
     int librv;
 
+	char *expanded_path;
+
     if (!cli_device_is_opened(state)) {
         return CMD_RET_NODEV;
     } else if (cli_device_in_use(state)) {
@@ -18,25 +20,39 @@ int cmd_load(struct cli_state *state, int argc, char **argv)
 
     if ( argc == 3 ) {
         if( strcasecmp( argv[1], "fpga" ) == 0 ) {
-            printf("Loading fpga...\n");
-            librv = bladerf_load_fpga(state->dev, argv[2]);
+			if ((expanded_path = expand_file(argv[2])) == NULL) {
+				printf("Unable to expand FPGA file path");
+				rv = CMD_RET_INVPARAM;
+			} else {
+				printf("Loading fpga from %s...\n", expanded_path);
+				librv = bladerf_load_fpga(state->dev, expanded_path);
 
-            if (librv < 0) {
-                state->last_lib_error = librv;
-                rv = CMD_RET_LIBBLADERF;
-            } else {
-                printf("Done.\n");
-            }
+				if (librv < 0) {
+					state->last_lib_error = librv;
+					rv = CMD_RET_LIBBLADERF;
+				} else {
+					printf("Done.\n");
+				}
+
+				free(expanded_path);
+			}
         } else if( strcasecmp( argv[1], "fx3" ) == 0 ) {
-            printf("Flashing firmware...\n");
-            librv = bladerf_flash_firmware(state->dev, argv[2]);
+			if ((expanded_path = expand_file(argv[2])) == NULL) {
+				printf("Unable to expand firmware file path");
+				rv = CMD_RET_INVPARAM;
+			} else {
+				printf("Flashing firmware from %s...\n", expanded_path);
+				librv = bladerf_flash_firmware(state->dev, expanded_path);
 
-            if (librv < 0) {
-                state->last_lib_error = librv;
-                rv = CMD_RET_LIBBLADERF;
-            } else {
-                printf("Done. Cycle power on the device.\n");
-            }
+				if (librv < 0) {
+					state->last_lib_error = librv;
+					rv = CMD_RET_LIBBLADERF;
+				} else {
+					printf("Done. Cycle power on the device.\n");
+				}
+
+				free(expanded_path);
+			}
         } else {
             cli_err(state, argv[0],
                     "\"%s\" is not a valid programming target\n", argv[1]) ;

--- a/linux/apps/src/cli/cmd/rxtx.c
+++ b/linux/apps/src/cli/cmd/rxtx.c
@@ -170,7 +170,8 @@ static int set_sample_file_path(struct common_cfg *c, const char *file_path)
         free(c->file_path);
     }
 
-    c->file_path = strdup(file_path);
+    /* c->file_path = strdup(file_path); */
+	c->file_path = expand_file(file_path);
     if (!c->file_path) {
         status = CMD_RET_MEM;
     }

--- a/linux/apps/src/cli/common.c
+++ b/linux/apps/src/cli/common.c
@@ -7,6 +7,10 @@
 #include <limits.h>
 #include <pthread.h>
 
+#ifdef INTERACTIVE
+#include <libtecla.h>
+#endif
+
 #include "cmd.h"
 #include "cmd/rxtx.h"
 
@@ -206,3 +210,33 @@ char *to_path(FILE *f)
 
     return file_path;
 }
+
+#ifdef INTERACTIVE
+char *expand_file(const char *inpath) {
+	ExpandFile *ef = NULL;
+	FileExpansion *fe = NULL;
+	char *ret = NULL;
+
+	ef = new_ExpandFile();
+	if (!ef) 
+		return NULL;
+
+	fe = ef_expand_file(ef, inpath, strlen(inpath));
+
+	if (!fe)
+		return NULL;
+
+	if (fe->nfile <= 0)
+		return NULL;
+
+	ret = strdup(fe->files[0]);
+
+	del_ExpandFile(ef);
+
+	return ret;
+}
+#else
+char *expand_file(const char *inpath) {
+	return strdup(inpath);
+}
+#endif

--- a/linux/apps/src/cli/common.h
+++ b/linux/apps/src/cli/common.h
@@ -145,4 +145,18 @@ static inline unsigned int uint_max(unsigned int x, unsigned int y)
     return x > y ? x : y;
 }
 
+/* expand_file - tecla expansion, optional
+ 
+   Optionally expand tecla paths, if we're in interactive mode.  Unfortunately
+   we can't house this in the interactive module since we handle commands
+   here.
+
+   Caller is expected to free() the returned char *
+
+   A return value of NULL indicates some form of internal error
+
+   On non-interactive compiles this returns the same path
+*/
+char *expand_file(const char *inpath);
+
 #endif


### PR DESCRIPTION
Expand file paths in interactive mode; autocomplete returns shell-paths which were not properly expanded.  In non-interactive mode, does nothing.
