### PR TITLE
Change the source code for building under Mac OS X.

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sys/types.h> 
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/host/libraries/libbladeRF/src/backend/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/libusb.c
@@ -7,7 +7,20 @@
 #include <stdbool.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <endian.h>
+#include <sys/types.h> 
+
+#ifdef __APPLE__
+    #include "../endian_mac.h"
+    #ifdef __i386__
+        #define __LITTLE_ENDIAN
+    #elif defined( __x86_64__ )
+        #define __LITTLE_ENDIAN
+    #endif
+#elif
+    #include <endian.h>
+#endif
+
+
 #include <bladeRF.h>
 #include <libusb-1.0/libusb.h>
 

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -3,6 +3,7 @@
 #include <limits.h>
 #include <assert.h>
 #include <unistd.h>
+#include <sys/types.h> 
 
 #include "libbladeRF.h"     /* Public API */
 #include "bladerf_priv.h"   /* Implementation-specific items ("private") */

--- a/host/libraries/libbladeRF/src/bladerf_priv.h
+++ b/host/libraries/libbladeRF/src/bladerf_priv.h
@@ -6,6 +6,7 @@
 
 #include <limits.h>
 #include <libbladeRF.h>
+#include <sys/types.h> 
 
 /* Reserved values for bladerf_devinfo fields to indicate "undefined" */
 #define DEVINFO_SERIAL_ANY    "ANY"

--- a/host/libraries/libbladeRF/src/endian_mac.h
+++ b/host/libraries/libbladeRF/src/endian_mac.h
@@ -1,0 +1,34 @@
+#ifndef __FINK_ENDIANDEV_PKG_ENDIAN_H__
+#define __FINK_ENDIANDEV_PKG_ENDIAN_H__ 1
+ 
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * found at https://gist.github.com/yinyin/2027912
+ * */
+ 
+#ifndef __APPLE__
+	#warning "This header file (endian.h) is MacOS X specific.\n"
+#endif	/* __APPLE__ */
+ 
+ 
+#include <libkern/OSByteOrder.h>
+ 
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+ 
+ 
+#endif	/* __FINK_ENDIANDEV_PKG_ENDIAN_H__ */

--- a/host/utilities/bladeRF-cli/src/cmd/rxtx.c
+++ b/host/utilities/bladeRF-cli/src/cmd/rxtx.c
@@ -13,7 +13,16 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <limits.h>
-#include <endian.h>
+#ifdef __APPLE__
+    #include "../endian_mac.h"
+    #ifdef __i386__
+        #define __LITTLE_ENDIAN
+#elif defined( __x86_64__ )
+        #define __LITTLE_ENDIAN
+    #endif
+#elif
+    #include <endian.h>
+#endif
 #include <errno.h>
 #include <assert.h>
 #include <string.h>

--- a/host/utilities/bladeRF-cli/src/endian_mac.h
+++ b/host/utilities/bladeRF-cli/src/endian_mac.h
@@ -1,0 +1,34 @@
+#ifndef __FINK_ENDIANDEV_PKG_ENDIAN_H__
+#define __FINK_ENDIANDEV_PKG_ENDIAN_H__ 1
+ 
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * found at https://gist.github.com/yinyin/2027912
+ * */
+ 
+#ifndef __APPLE__
+	#warning "This header file (endian.h) is MacOS X specific.\n"
+#endif	/* __APPLE__ */
+ 
+ 
+#include <libkern/OSByteOrder.h>
+ 
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+ 
+ 
+#endif	/* __FINK_ENDIANDEV_PKG_ENDIAN_H__ */

--- a/host/utilities/bladeRF-cli/src/main.c
+++ b/host/utilities/bladeRF-cli/src/main.c
@@ -311,6 +311,7 @@ int main(int argc, char *argv[])
         if (status)
             return 2;
 
+#ifdef INTERACTIVE
         /* Exit cleanly when configured for batch mode. Remember that this is
          * implicit with some commands */
         if (!rc.batch_mode || state->script != NULL) {
@@ -324,7 +325,7 @@ int main(int argc, char *argv[])
             }
 
         }
-
+#endif
         /* Ensure we exit with RX & TX disabled.
          * Can't do much about an error at this point anyway... */
         if (state->dev) {


### PR DESCRIPTION
Change the source code for building under Mac OS X 10.8.

Build without Error or Warnings.
Funktion used and see a reaction at the TX connector from the bladeRF with this tool https://github.com/maggo1404/bladeRF_examples/tree/libusb_support/simple_examples/blade_send_tone :
- Open device
- Set Frequenz
- Set tx Gain
- Send a sinus 
- Enable/Disable TX
- Close device
- Set samplerate
- Set filter bandwith
