### PR TITLE
Made batch mode default, added switch for interactive, Issue #45

### DIFF
--- a/host/utilities/bladeRF-cli/src/main.c
+++ b/host/utilities/bladeRF-cli/src/main.c
@@ -19,7 +19,7 @@
 
 
 #ifdef INTERACTIVE
-#   define OPTSTR "d:bf:l:s:pLVh"
+#   define OPTSTR "d:bf:l:s:ipLVh"
 #else
 #   define OPTSTR "d:bf:l:pLVh"
 #endif
@@ -31,6 +31,7 @@ static const struct option longopts[] = {
     { "load-fpga",      required_argument,  0, 'l' },
 #ifdef INTERACTIVE
     { "script",         required_argument,  0, 's' },
+    { "interactive",    no_argument,        0, 'i' },
 #endif
     { "probe",          no_argument,        0, 'p' },
     { "lib-version",    no_argument,        0, 'L' },
@@ -57,7 +58,7 @@ struct rc_config {
 
 static void init_rc_config(struct rc_config *rc)
 {
-    rc->batch_mode = false;
+    rc->batch_mode = true;
     rc->flash_fw = false;
     rc->load_fpga = false;
     rc->probe = false;
@@ -115,8 +116,11 @@ int get_rc_config(int argc, char *argv[], struct rc_config *rc)
                     return -1;
                 }
                 break;
+            case 'i':
+                rc->batch_mode = false;
+                break;
 #endif
-
+            // Left in for backwards compatibility
             case 'b':
                 rc->batch_mode = true;
                 break;
@@ -155,8 +159,9 @@ void usage(const char *argv0)
     printf("  -p, --probe                      Probe for devices, print results, then exit.\n");
 #ifdef INTERACTIVE
     printf("  -s, --script <file>              Run provided script.\n");
+    printf("  -i, --interactive                Interactive mode.\n");
 #endif
-    printf("  -b, --batch                      Batch mode - do not enter interactive mode.\n");
+    printf("  -b, --batch                      Batch mode - for backwards compatibility.\n");
     printf("  -L, --lib-version                Print libbladeRF version and exit.\n");
     printf("  -V, --version                    Print CLI version and exit.\n");
     printf("  -h, --help                       Show this help text.\n");


### PR DESCRIPTION
Implements a -i --interactive switch if libtecla is configured and defaults to batch mode
https://github.com/Nuand/bladeRF/issues/45
