### PR TITLE
Added support for suffixes on numeric values (Issue #66)

### DIFF
--- a/host/common/include/conversions.h
+++ b/host/common/include/conversions.h
@@ -10,6 +10,15 @@
 #include "host_config.h"
 
 /**
+ * Represents an association between a string suffix for a numeric value and
+ * its multiplier. For example, "k" might correspond to 1000.
+ */
+typedef struct numeric_suffix {
+    const char *suffix;
+    int multiplier;
+} numeric_suffix;
+
+/**
  * String to integer conversion with range and error checking
  *
  *  @param  str     String to convert
@@ -65,5 +74,25 @@ uint64_t str2uint64(const char *str, uint64_t min, uint64_t max, bool *ok);
  * @return  Converted value on success, 0 on failure
  */
 double str2double(const char *str, double min, double max, bool *ok);
+
+/**
+ * Convert a string to an unsigned integer with range and error checking.
+ * Supports the use of decimal representations and suffixes in the string.
+ * For example, a string "2.4G" might be converted to 2400000000.
+ *
+ * @param[in]   str     String to convert
+ * @param[in]   min     Minimum allowed value (inclusive)
+ * @param[in]   max     Maximum allowed value (inclusive)
+ * @param[in]   suffixes    List of allowed suffixes and their multipliers
+ * @param[in]   num_suffixes    Number of suffixes in the list
+ * @param[out]  ok      If non-NULL, this is set to true if the conversion was
+ *                      successful, and false for an invalid or out of range
+ *                      value.
+ *
+ * @return  Converted value on success, 0 on failure
+ */
+unsigned int str2uint_suffix(const char *str, unsigned int min,
+        unsigned int max, const struct numeric_suffix suffixes[],
+        int num_suffixes, bool *ok);
 
 #endif

--- a/host/common/src/conversions.c
+++ b/host/common/src/conversions.c
@@ -104,3 +104,49 @@ double str2double(const char *str, double min, double max, bool *ok)
     return value;
 }
 
+unsigned int str2uint_suffix(const char *str, unsigned int min,
+        unsigned int max, const struct numeric_suffix suffixes[],
+        int num_suffixes, bool *ok)
+{
+    double value;
+    char *endptr;
+    int i;
+
+    errno = 0;
+    value = strtod(str, &endptr);
+
+    /* If a number could not be parsed at the beginning of the string */
+    if (errno != 0 || endptr == str) {
+        if (ok) {
+            *ok = false;
+        }
+        
+        return 0;
+    }
+
+    /* Loop through each available suffix */
+    for (i = 0; i < num_suffixes; i++) {
+        /* If the suffix appears at the end of the number */
+        if (!strcasecmp(endptr, suffixes[i].suffix)) {
+            /* Apply the multiplier */
+            value *= suffixes[i].multiplier;
+            break;
+        }
+    }
+
+    /* Check that the resulting value is in bounds */
+    if (value > max || value < min) {
+        if (ok) {
+            *ok = false;
+        }
+
+        return 0;
+    }
+
+    if (ok) {
+        *ok = true;
+    }
+
+    /* Truncate the floating point value to an integer and return it */
+    return (unsigned int)value;
+}

--- a/host/utilities/bladeRF-cli/src/cmd/printset.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset.c
@@ -18,6 +18,18 @@ struct printset_entry {
     const char *name;                   /*<< String associated with parameter */
 };
 
+static const struct numeric_suffix FREQ_SUFFIXES[] = {
+    { "G",      1000 * 1000 * 1000 },
+    { "GHz",    1000 * 1000 * 1000 },
+    { "M",      1000 * 1000 },
+    { "MHz",    1000 * 1000 },
+    { "k",      1000 } ,
+    { "kHz",    1000 }
+};
+
+static const int NUM_FREQ_SUFFIXES =
+        sizeof(FREQ_SUFFIXES) / sizeof(struct numeric_suffix);
+
 /* Declarations */
 PRINTSET_DECL(bandwidth)
 PRINTSET_DECL(config)
@@ -182,7 +194,8 @@ int set_bandwidth(struct cli_state *state, int argc, char **argv)
         }
 
         /* Parse bandwidth */
-        bw = str2uint( argv[3], 0, UINT_MAX, &ok );
+        bw = str2uint_suffix( argv[3], 0, UINT_MAX,
+                FREQ_SUFFIXES, NUM_FREQ_SUFFIXES, &ok );
         if( !ok ) {
             cli_err(state, argv[0], "Invalid bandwidth (%s)", argv[3]);
             rv = CMD_RET_INVPARAM;
@@ -192,7 +205,8 @@ int set_bandwidth(struct cli_state *state, int argc, char **argv)
     /* No module, just bandwidth */
     else if( argc == 3 ) {
         bool ok;
-        bw = str2uint( argv[2], 0, UINT_MAX, &ok );
+        bw = str2uint_suffix( argv[2], 0, UINT_MAX,
+                FREQ_SUFFIXES, NUM_FREQ_SUFFIXES, &ok );
         if( !ok ) {
             cli_err(state, argv[0], "Invalid bandwidth (%s)", argv[2]);
             rv = CMD_RET_INVPARAM;
@@ -331,7 +345,8 @@ int set_frequency(struct cli_state *state, int argc, char **argv)
     if( argc > 2 && rv == CMD_RET_OK ) {
         bool ok;
         /* Parse out frequency */
-        freq = str2uint( argv[argc-1], 225000000, 3900000000u, &ok );
+        freq = str2uint_suffix( argv[argc-1], 225000000, 3900000000u,
+                FREQ_SUFFIXES, NUM_FREQ_SUFFIXES, &ok );
 
         if( !ok ) {
             cli_err(state, argv[0], "Invalid frequency (%s)", argv[argc - 1]);
@@ -716,7 +731,8 @@ int set_samplerate(struct cli_state *state, int argc, char **argv)
     if( argc > 2 && rv == CMD_RET_OK ) {
         bool ok;
         unsigned int rate, actual;
-        rate = str2uint( argv[argc-1], 160000, 40000000, &ok );
+        rate = str2uint_suffix( argv[argc-1], 160000, 40000000,
+                FREQ_SUFFIXES, NUM_FREQ_SUFFIXES, &ok );
 
         if( !ok ) {
             cli_err(state, argv[0], "Invalid sample rate (%s)", argv[2]);


### PR DESCRIPTION
Added a new conversion function that accepts a list of suffix to
multiplier mappings, and applies the appropriate multiplier to the input
value. Utilized this new conversion function in the CLI for set
bandwidth, set samplerate, and set frequency.

Note that this also supports standard decimal formats, such as "2.4e9" and "1.23456789GHz".
