### PR TITLE
Quoted CMAKE_C_FLAGS to fix build issue

### DIFF
--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -82,7 +82,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
     # the GenerateExportHeader module appears to break for C-only projects:
     #
     # http://www.cmake.org/pipermail/cmake-commits/2012-August/013142.html
-    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -fvisibility=hidden)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
 endif()
 
 ################################################################################


### PR DESCRIPTION
The missing quotes caused a linebreak in CMAKE_C_FLAGS. make then ran two commands

cc <other flags>
-fvisibility=hidden <source>

causing a broken build:

Scanning dependencies of target libbladerf_sharedScanning dependencies of target libbladerf_shared
[  3%] Building C object libraries/libbladeRF/CMakeFiles/libbladerf_shared.dir/src/backend.c.o
cc: fatal error: no input files
compilation terminated.
/bin/sh: -fvisibility=hidden: command not found
make[2]: **\* [libraries/libbladeRF/CMakeFiles/libbladerf_shared.dir/src/backend.c.o] Error 127
make[1]: **\* [libraries/libbladeRF/CMakeFiles/libbladerf_shared.dir/all] Error 2
make: **\* [all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...

[  3%] Building C object libraries/libbladeRF/CMakeFiles/libbladerf_shared.dir/src/backend.c.o
cc: fatal error: no input files
compilation terminated.
/bin/sh: -fvisibility=hidden: command not found
make[2]: **\* [libraries/libbladeRF/CMakeFiles/libbladerf_shared.dir/src/backend.c.o] Error 127
make[1]: **\* [libraries/libbladeRF/CMakeFiles/libbladerf_shared.dir/all] Error 2
make: **\* [all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
