### PR TITLE
Assorted fixes for problems found via USB30CV and USB20CV

### DIFF
--- a/firmware_common/bladeRF.h
+++ b/firmware_common/bladeRF.h
@@ -1,3 +1,5 @@
+#ifndef _BLADERF_FIRMWARE_COMMON_H_
+#define _BLADERF_FIRMWARE_COMMON_H_
 
 #define BLADERF_IOCTL_BASE      'N'
 #define BLADE_QUERY_VERSION     _IOR(BLADERF_IOCTL_BASE, 0, struct bladeRF_version)
@@ -111,3 +113,10 @@ struct uart_cmd {
         unsigned short word;
     };
 };
+
+/* Interface numbers */
+#define USB_IF_CONFIG       3
+#define USB_IF_RF_LINK      1
+#define USB_IF_SPI_FLASH    2
+
+#endif /* _BLADERF_FIRMWARE_COMMON_H_ */

--- a/fx3_firmware/bladeRF.h
+++ b/fx3_firmware/bladeRF.h
@@ -14,7 +14,7 @@
 #define BLADE_THREAD_STACK       (0x0400)
 #define BLADE_THREAD_PRIORITY    (8)
 
-// interface #0
+// interface #3
 #define BLADE_FPGA_EP_PRODUCER          0x02
 #define BLADE_FPGA_CONFIG_SOCKET        CY_U3P_UIB_SOCKET_PROD_2
 

--- a/fx3_firmware/cyfxbladeRFusbdscr.c
+++ b/fx3_firmware/cyfxbladeRFusbdscr.c
@@ -83,7 +83,7 @@ const uint8_t CyFxUSBSSConfigDscr[] __attribute__ ((aligned (32))) =
     /* Configuration descriptor */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_CONFIG_DESCR,        /* Configuration descriptor type */
-    0x72,0x00,                      /* Length of this descriptor and all sub descriptors */
+    0x7B,0x00,                      /* Length of this descriptor and all sub descriptors */
     0x01,                           /* Number of interfaces */
     0x01,                           /* Configuration number */
     0x00,                           /* COnfiguration string index */
@@ -91,35 +91,19 @@ const uint8_t CyFxUSBSSConfigDscr[] __attribute__ ((aligned (32))) =
     0x64,                           /* Max power consumption of device (in 8mA unit) : 200mA */
 
 
-    /* Interface descriptor #0*/
+
+    /* Interface descriptor #0, alt interface #0, Nothing */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
     0x00,                           /* Interface number */
     0x00,                           /* Alternate setting number */
-    0x01,                           /* Number of end points */
+    0x00,                           /* Number of end points */
     0xFF,                           /* Interface class */
     0x00,                           /* Interface sub class */
     0x00,                           /* Interface protocol code */
     0x00,                           /* Interface descriptor string index */
 
-    /* Endpoint descriptor for producer EP */
-    0x07,                           /* Descriptor size */
-    CY_U3P_USB_ENDPNT_DESCR,        /* Endpoint descriptor type */
-    BLADE_FPGA_EP_PRODUCER,              /* Endpoint address and description */
-    CY_U3P_USB_EP_BULK,             /* Bulk endpoint type */
-    0x00,0x04,                      /* Max packet size = 1024 bytes */
-    0x00,                           /* Servicing interval for data transfers : 0 for bulk */
-
-    /* Super speed endpoint companion descriptor for producer EP */
-    0x06,                           /* Descriptor size */
-    CY_U3P_SS_EP_COMPN_DESCR,       /* SS endpoint companion descriptor type */
-    0x01,                           /* Max no. of packets in a burst : 0: burst 1 packet at a time */
-    0x00,                           /* Max streams for bulk EP = 0 (No streams) */
-    0x00,0x00,                      /* Service interval for the EP : 0 for bulk */
-
-
-
-    /* Interface descriptor #1 */
+    /* Interface descriptor #0, alt interface #1, RF */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
     0x00,                           /* Interface number */
@@ -191,7 +175,7 @@ const uint8_t CyFxUSBSSConfigDscr[] __attribute__ ((aligned (32))) =
     0x00,0x00,                      /* Service interval for the EP : 0 for bulk */
 
 
-    /* Interface descriptor #2*/
+    /* Interface descriptor #0, alt interface #2, FX3 firmware */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
     0x00,                           /* Interface number */
@@ -217,30 +201,12 @@ const uint8_t CyFxUSBSSConfigDscr[] __attribute__ ((aligned (32))) =
     0x00,                           /* Max streams for bulk EP = 0 (No streams) */
     0x00,0x00,                      /* Service interval for the EP : 0 for bulk */
 
-
-
-
-};
-
-/* Standard high speed configuration descriptor */
-const uint8_t CyFxUSBHSConfigDscr[] __attribute__ ((aligned (32))) =
-{
-    /* Configuration descriptor */
-    0x09,                           /* Descriptor size */
-    CY_U3P_USB_CONFIG_DESCR,        /* Configuration descriptor type */
-    0x4E,0x00,                      /* Length of this descriptor and all sub descriptors */
-    0x01,                           /* Number of interfaces */
-    0x01,                           /* Configuration number */
-    0x00,                           /* COnfiguration string index */
-    0x80,                           /* Config characteristics - bus powered */
-    0x64,                           /* Max power consumption of device (in 2mA unit) : 200mA */
-
-    /* Interface descriptor #0 */
+    /* Interface descriptor #0, alt interface #3, FPGA load */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
     0x00,                           /* Interface number */
-    0x00,                           /* Alternate setting number */
-    0x01,                           /* Number of endpoints */
+    0x03,                           /* Alternate setting number */
+    0x01,                           /* Number of end points */
     0xFF,                           /* Interface class */
     0x00,                           /* Interface sub class */
     0x00,                           /* Interface protocol code */
@@ -251,10 +217,42 @@ const uint8_t CyFxUSBHSConfigDscr[] __attribute__ ((aligned (32))) =
     CY_U3P_USB_ENDPNT_DESCR,        /* Endpoint descriptor type */
     BLADE_FPGA_EP_PRODUCER,              /* Endpoint address and description */
     CY_U3P_USB_EP_BULK,             /* Bulk endpoint type */
-    0x00,0x02,                      /* Max packet size = 512 bytes */
+    0x00,0x04,                      /* Max packet size = 1024 bytes */
     0x00,                           /* Servicing interval for data transfers : 0 for bulk */
 
-    /* Interface descriptor #1 */
+    /* Super speed endpoint companion descriptor for producer EP */
+    0x06,                           /* Descriptor size */
+    CY_U3P_SS_EP_COMPN_DESCR,       /* SS endpoint companion descriptor type */
+    0x01,                           /* Max no. of packets in a burst : 0: burst 1 packet at a time */
+    0x00,                           /* Max streams for bulk EP = 0 (No streams) */
+    0x00,0x00,                      /* Service interval for the EP : 0 for bulk */
+};
+
+/* Standard high speed configuration descriptor */
+const uint8_t CyFxUSBHSConfigDscr[] __attribute__ ((aligned (32))) =
+{
+    /* Configuration descriptor */
+    0x09,                           /* Descriptor size */
+    CY_U3P_USB_CONFIG_DESCR,        /* Configuration descriptor type */
+    0x57,0x00,                      /* Length of this descriptor and all sub descriptors */
+    0x01,                           /* Number of interfaces */
+    0x01,                           /* Configuration number */
+    0x00,                           /* COnfiguration string index */
+    0x80,                           /* Config characteristics - bus powered */
+    0x64,                           /* Max power consumption of device (in 2mA unit) : 200mA */
+
+    /* Interface descriptor #0, alt interface #0, Nothing */
+    0x09,                           /* Descriptor size */
+    CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
+    0x00,                           /* Interface number */
+    0x00,                           /* Alternate setting number */
+    0x00,                           /* Number of endpoints */
+    0xFF,                           /* Interface class */
+    0x00,                           /* Interface sub class */
+    0x00,                           /* Interface protocol code */
+    0x00,                           /* Interface descriptor string index */
+
+    /* Interface descriptor #0, alt interface #1, RF */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
     0x00,                           /* Interface number */
@@ -297,7 +295,7 @@ const uint8_t CyFxUSBHSConfigDscr[] __attribute__ ((aligned (32))) =
     0x00,0x02,                      /* Max packet size = 512 bytes */
     0x00,                           /* Servicing interval for data transfers : 0 for bulk */
 
-    /* Interface descriptor #2 */
+    /* Interface descriptor #0, alt interface #2, FX3 firmware */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
     0x00,                           /* Interface number */
@@ -315,6 +313,25 @@ const uint8_t CyFxUSBHSConfigDscr[] __attribute__ ((aligned (32))) =
     CY_U3P_USB_EP_BULK,             /* Bulk endpoint type */
     0x00,0x02,                      /* Max packet size = 512 bytes */
     0x00,                           /* Servicing interval for data transfers : 0 for bulk */
+
+    /* Interface descriptor #0, alt interface #3, FPGA load */
+    0x09,                           /* Descriptor size */
+    CY_U3P_USB_INTRFC_DESCR,        /* Interface Descriptor type */
+    0x00,                           /* Interface number */
+    0x03,                           /* Alternate setting number */
+    0x01,                           /* Number of endpoints */
+    0xFF,                           /* Interface class */
+    0x00,                           /* Interface sub class */
+    0x00,                           /* Interface protocol code */
+    0x00,                           /* Interface descriptor string index */
+
+    /* Endpoint descriptor for producer EP */
+    0x07,                           /* Descriptor size */
+    CY_U3P_USB_ENDPNT_DESCR,        /* Endpoint descriptor type */
+    BLADE_FPGA_EP_PRODUCER,              /* Endpoint address and description */
+    CY_U3P_USB_EP_BULK,             /* Bulk endpoint type */
+    0x00,0x02,                      /* Max packet size = 512 bytes */
+    0x00,                           /* Servicing interval for data transfers : 0 for bulk */
 };
 
 /* Standard full speed configuration descriptor */
@@ -323,7 +340,7 @@ const uint8_t CyFxUSBFSConfigDscr[] __attribute__ ((aligned (32))) =
     /* Configuration descriptor */
     0x09,                           /* Descriptor size */
     CY_U3P_USB_CONFIG_DESCR,        /* Configuration descriptor type */
-    0x20,0x00,                      /* Length of this descriptor and all sub descriptors */
+    0x27,0x00,                      /* Length of this descriptor and all sub descriptors */
     0x01,                           /* Number of interfaces */
     0x01,                           /* Configuration number */
     0x00,                           /* COnfiguration string index */

--- a/host/libraries/libbladeRF/src/bladerf_priv.h
+++ b/host/libraries/libbladeRF/src/bladerf_priv.h
@@ -19,11 +19,6 @@
 #define FLASH_NUM_SECTORS   4096
 #define FLASH_NUM_PAGES     (FLASH_NUM_SECTORS * (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE))
 
-/* Interface numbers */
-#define USB_IF_CONFIG       0
-#define USB_IF_RF_LINK      1
-#define USB_IF_SPI_FLASH    2
-
 typedef enum {
     ETYPE_ERRNO,
     ETYPE_LIBBLADERF,


### PR DESCRIPTION
- Move and use interface numbers
- Renumber USB_IF_CONFIG from 0 to 3
- Introduced 0 alt-interface as a NULL interface
- Fixed FS descriptor length
- Implemented GET_STATUS, SET_FEATURE, CLEAR_FEATURE w.r.t. halting bulk streams
- Added include guards for firmware_common/bladeRF.h
- Changed guard on suspend/resume requests to key on glUsbConfiguration instead
  of glUsbAltInterface.  This is because suspend/resume requests are on
  interfaces, not endpoints.
- Addresses github tickets #97, #98, #99
