### PR TITLE
[FX3] When in FPGA load and RF mode, transitions to U1/U2 should be rejected

### DIFF
--- a/fx3_firmware/bladeRF.c
+++ b/fx3_firmware/bladeRF.c
@@ -691,11 +691,17 @@ void CyFxbladeRFApplnUSBEventCB (CyU3PUsbEventType_t evtype, uint16_t evdata)
    This application does not have any state in which we should not allow U1/U2 transitions; and therefore
    the function always return CyTrue.
  */
-CyBool_t
-CyFxApplnLPMRqtCB (
+
+static CyBool_t allow_suspend = CyTrue;
+
+void NuandAllowSuspend(CyBool_t set_allow_suspend) {
+    allow_suspend = set_allow_suspend;
+}
+
+static CyBool_t CyFxApplnLPMRqtCB (
         CyU3PUsbLinkPowerMode link_mode)
 {
-    return CyTrue;
+    return allow_suspend;
 }
 
 void bladeRFInit(void)

--- a/fx3_firmware/bladeRF.h
+++ b/fx3_firmware/bladeRF.h
@@ -52,6 +52,7 @@ CyU3PReturnStatus_t CyFxSpiEraseSector(CyBool_t /* isErase */, uint8_t /* sector
 void NuandGPIOReconfigure(CyBool_t /* fullGpif */, CyBool_t /* warm */);
 void ClearDMAChannel(uint8_t ep, CyU3PDmaChannel * handle, uint32_t count, CyBool_t stall_only);
 void CyFxAppErrorHandler(CyU3PReturnStatus_t apiRetStatus);
+void NuandAllowSuspend(CyBool_t set_allow_suspend);
 
 extern uint32_t glAppMode;
 

--- a/fx3_firmware/fpga.c
+++ b/fx3_firmware/fpga.c
@@ -69,6 +69,8 @@ static void NuandFpgaConfigStart(void)
     CyU3PUSBSpeed_t usbSpeed = CyU3PUsbGetSpeed();
     static int first_call = 1;
 
+    NuandAllowSuspend(CyFalse);
+
     NuandGPIOReconfigure(CyTrue, !first_call);
     first_call = 0;
 
@@ -181,6 +183,7 @@ void NuandFpgaConfigStop(void)
 
     CyU3PGpifDisable(CyTrue);
 
+    NuandAllowSuspend(CyTrue);
     glAppMode = MODE_NO_CONFIG;
 }
 

--- a/fx3_firmware/rf.c
+++ b/fx3_firmware/rf.c
@@ -201,6 +201,7 @@ static void NuandRFLinkStart(void)
     CyU3PReturnStatus_t apiRetStatus = CY_U3P_SUCCESS;
     CyU3PUSBSpeed_t usbSpeed = CyU3PUsbGetSpeed();
 
+    NuandAllowSuspend(CyFalse);
     NuandGPIOReconfigure(CyTrue, CyTrue);
 
     /* Load the GPIF configuration for loading the RF transceiver */
@@ -371,6 +372,7 @@ static void NuandRFLinkStop (void)
     CyU3PGpifDisable(CyTrue);
 
     UartBridgeStop();
+    NuandAllowSuspend(CyTrue);
     glAppMode = MODE_NO_CONFIG;
 }
 


### PR DESCRIPTION
This pull request fixes #80.  The core problem can be understood by reading the CyU3PUsbLPMReqCb_t documentation in the FX3APIGuide.  Basically some USB3.0 controllers after completing "all work" will request a low power mode.  In the case of the bladeRF when in either FPGA load or RF mode, suspending is counter productive.  So this patch causes the FX3 to reject U1/U2 requests when in FPGA or RF mode.

This patch does not cause USB 3.0 CV to complain, so I think this is a compliant change.
