### PR TITLE
Byte order dependency in extract_field()

### DIFF
--- a/host/libraries/libbladeRF/src/bladerf_priv.c
+++ b/host/libraries/libbladeRF/src/bladerf_priv.c
@@ -124,7 +124,7 @@ static int extract_field(char *ptr, int len, char *field,
         if (c == 0xff) // flash and OTP are 0xff if they've never been written to
             break;
 
-        a1 = *(unsigned short *)(&ub[c+1]);  // read checksum
+        a1 = LE16_TO_HOST(*(unsigned short *)(&ub[c+1]));  // read checksum
         a2 = crc16mp(0, ub, c+1);  // calculated checksum
 
         if (a1 == a2) {


### PR DESCRIPTION
Shouldn't some byteorder swapping happen here, or am I missing something obvious?

https://github.com/Nuand/bladeRF/blob/master/host/libraries/libbladeRF/src/bladerf_priv.c#L127
