### PR TITLE
Fix cmake_minimum_required (CMAKE_CURRENT_LIST_DIR is >=2.8.3)

### DIFF
--- a/fx3_firmware/CMakeLists.txt
+++ b/fx3_firmware/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.3)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../host/cmake/modules)
 set(VERSION_INFO_MAJOR 1)


### PR DESCRIPTION
Hello, I am the last person on earth using CMake 2.8.0
