### PR TITLE
Use correct library path on all systems

### DIFF
--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -28,6 +28,8 @@ configure_file(
     @ONLY
 )
 
+include(GNUInstallDirs)
+
 ################################################################################
 # Configuration options
 ################################################################################
@@ -160,7 +162,7 @@ set_target_properties(libbladerf_shared PROPERTIES SOVERSION ${VERSION_INFO_MAJO
 ################################################################################
 
 if(NOT DEFINED LIB_INSTALL_DIR)
-    set(LIB_INSTALL_DIR lib)
+    set(LIB_INSTALL_DIR             "${CMAKE_INSTALL_LIBDIR}" )
 endif()
 
 ################################################################################


### PR DESCRIPTION
- Fedora/RHEL uses /.../lib64/ for 64-bit and /.../lib/ for 32-bit
- Others use /.../lib/<arch>/
