### PR TITLE
In bladerf-cli async rx, buffer is submitted multiple times before completion.

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/rx.c
+++ b/host/utilities/bladeRF-cli/src/cmd/rx.c
@@ -301,7 +301,13 @@ static int rx_cmd_start(struct cli_state *s)
 
     if (status == 0) {
         pthread_mutex_lock(&s->rx->file_mgmt.file_lock);
-        s->rx->file_mgmt.file = fopen(s->rx->file_mgmt.path, "w");
+		if(s->rx->file_mgmt.format == RXTX_FMT_CSV_SC16Q12){
+			s->rx->file_mgmt.file = fopen(s->rx->file_mgmt.path, "w"); 
+		}
+		else {
+			/* RXTX_FMT_BIN_SC16Q12, open file in binary mode */
+			s->rx->file_mgmt.file = fopen(s->rx->file_mgmt.path, "wb");	
+		}
         if (!s->rx->file_mgmt.file) {
             set_last_error(&s->rx->last_error, ETYPE_ERRNO, errno);
             status = CMD_RET_FILEOP;


### PR DESCRIPTION
Fix RX buffer submission. Points next_idx to the last submitted buffer to libusb . Fixed issue where a buffer would otherwise be resubmitted multiple times to libusb. At initialization lusb_stream() in libusb.c submits stream->num_transfers buffers to libusb.

I haven't checked the TX buffer submission, it probably need similar fix.
