### PR TITLE
Rename Debian binary packages to match Debian-ish standard

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+bladerf (0.9.0-2) unstable; urgency=low
+
+  * Renaming binary packages; see a7d88d0 for more info
+
+ -- Ryan Tucker <rtucker@gmail.com>  Fri, 25 Oct 2013 20:48:48 -0400
+
+bladerf (0.9.0-1) unstable; urgency=low
+
+  * Update changelog to match minor version bump in commit 7a1b2c1
+
+ -- Ryan Tucker <rtucker@gmail.com>  Mon, 21 Oct 2013 19:30:38 -0400
+
 bladerf (0~20131006-1) UNRELEASED; urgency=low
 
   * Another experimental release

--- a/debian/control
+++ b/debian/control
@@ -28,8 +28,8 @@ Section: libdevel
 Architecture: any
 Multi-Arch: same
 Depends: libbladerf0 (= ${binary:Version}), libc6-dev | libc-dev, ${misc:Depends}
-XXX-Replaces: libbladerf0-dev (<< FIXMEFIXMEFIXME)
-XXX-Breaks: libbladerf0-dev (<< FIXMEFIXMEFIXME)
+Replaces: libbladerf0-dev (<< 0.9.0)
+Breaks: libbladerf0-dev (<< 0.9.0)
 Description: Interface to the nuand bladeRF software-defined radio device (header files)
  The nuand bladeRF is an open-source software-defined radio (SDR) system,
  comprised of an RF transceiver, a field-programmable gate array (FPGA),
@@ -45,8 +45,8 @@ Architecture: any
 Multi-Arch: foreign
 Depends: libbladerf0 (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: gnuradio
-XXX-Replaces: bladerf (<< FIXMEFIXMEFIXME)
-XXX-Breaks: bladerf (<< FIXMEFIXMEFIXME)
+Replaces: bladerf (<< 0.9.0)
+Breaks: bladerf (<< 0.9.0)
 Description: Interface to the nuand bladeRF software-defined radio device (tools)
  The nuand bladeRF is an open-source software-defined radio (SDR) system,
  comprised of an RF transceiver, a field-programmable gate array (FPGA),


### PR DESCRIPTION
A Debian Intent-To-Package (ITP) was filed without our knowledge, resulting in a source package being built against rev b80d31f.  This commit should put us in cahoots with their package names, so that a user can't accidentally install both and cause a singularity to destroy their computer.

Debian ITP: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=724967
Debian upload: https://ftp-master.debian.org/new/bladerf_0.6.2.1.b80d31f-1.html
