### PR TITLE
bladeRF-cli: fix occasional CLI hangups

### DIFF
--- a/host/utilities/bladeRF-cli/src/common.c
+++ b/host/utilities/bladeRF-cli/src/common.c
@@ -72,22 +72,19 @@ cli_state_create_fail:
 void cli_state_destroy(struct cli_state *s)
 {
     if (s) {
-        if (s->rx) {
-            rxtx_shutdown(s->rx);
-            rxtx_data_free(s->rx);
-            s->rx = NULL;
-        }
+        if (cli_device_is_opened(s)) {
+            if (rxtx_task_running(s->rx)) {
+                rxtx_shutdown(s->rx);
+                rxtx_data_free(s->rx);
+            }
 
-        if (s->tx) {
-            rxtx_shutdown(s->tx);
-            rxtx_data_free(s->tx);
-            s->tx = NULL;
-        }
+            if (rxtx_task_running(s->tx)) {
+                rxtx_shutdown(s->tx);
+                rxtx_data_free(s->tx);
+            }
 
-        if (s->dev) {
             bladerf_close(s->dev);
         }
-
 
         free(s);
     }


### PR DESCRIPTION
Occasionally, bladeRF-cli --help or --version will hang and not exit properly.  This seems most common if I don't have my bladeRF plugged in.

I believe it was attempting to do rxtx_shutdown() even if there was no reason to do so (e.g. there was no bladeRF hardware connected).  Use convenience functions to determine if we need to do it.
