### PR TITLE
Fix mixed-up between --version and --lib-version

### DIFF
--- a/host/utilities/bladeRF-cli/src/main.c
+++ b/host/utilities/bladeRF-cli/src/main.c
@@ -173,11 +173,11 @@ int get_rc_config(int argc, char *argv[], struct rc_config *rc)
                 break;
 
             case 1:
-                rc->show_version = true;
+                rc->show_lib_version = true;
                 break;
 
             case 2:
-                rc->show_lib_version = true;
+                rc->show_version = true;
                 break;
 
             default:


### PR DESCRIPTION
--version was reporting the libbladeRF version, while --lib-version was reporting the bladeRF-cli version.

This caused no end to the confusion for me.
