### PR TITLE
Fix two lintian errors

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: bladerf
 Priority: extra
 Maintainer: Ryan Tucker <rtucker@gmail.com>
 Build-Depends: debhelper (>=9), cmake (>= 2.8.5), pkg-config, doxygen, libusb-1.0-0-dev (>= 1.0.12), libtecla1-dev, libncurses5-dev, git, help2man, python
-Standards-Version: 3.9.2
+Standards-Version: 3.9.4
 Section: comm
 Homepage: http://www.nuand.com/bladeRF
 Vcs-Git: git://github.com/Nuand/bladeRF.git

--- a/debian/copyright
+++ b/debian/copyright
@@ -91,7 +91,6 @@ Comment: This is a *slightly* modified version of the file written by
          Hendrik Sattler, from the OpenOBEX project (licensed GPLv2/LGPL).
          (If this is not correct, please contact us so we can attribute the
          author appropriately.)
-
          https://github.com/zuckschwerdt/openobex/blob/master/CMakeModules/FindLibUSB.cmake
          http://dev.zuckschwerdt.org/openobex/
 
@@ -251,7 +250,7 @@ License: BSD-2-clause
  2. Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
     documentation and/or other materials provided with the distribution.
-
+ .
  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -275,7 +274,7 @@ License: BSD-3-clause
     documentation and/or other materials provided with the distribution.
  3. The name of the author may not be used to endorse or promote products
     derived from this software without specific prior written permission.
-
+ .
  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
  AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL


### PR DESCRIPTION
W: bladerf source: syntax-error-in-dep5-copyright line 95: Continuation line outside a paragraph.
W: bladerf source: ancient-standards-version 3.9.2 (current is 3.9.4)

My laptop (with saucy) is somewhat pickier than my old lucid desktop.
Surprise, surprise.
