### PR TITLE
build_bladerf: don't set QUARTUS_BINDIR on Linux

### DIFF
--- a/hdl/quartus/build_bladerf.sh
+++ b/hdl/quartus/build_bladerf.sh
@@ -99,8 +99,14 @@ if [ $? -ne 0 ] || [ ! -f "$quartus_sh" ]; then
 fi
 
 nios_system=../fpga/ip/altera/nios_system
-QUARTUS_BINDIR=$QUARTUS_ROOTDIR/bin
-export QUARTUS_BINDIR
+
+# 9a484b436: Windows-specific workaround for Quartus bug
+if [ "x$(uname)" != "xLinux" ]; then
+    QUARTUS_BINDIR=$QUARTUS_ROOTDIR/bin
+    export QUARTUS_BINDIR
+    echo "## Non-Linux OS Detected (Windows?)"
+    echo "## Forcing QUARTUS_BINDIR to ${QUARTUS_BINDIR}"
+fi
 
 # Error out at the first sign of trouble
 set -e


### PR DESCRIPTION
Turns out that Quartus doesn't have problems finding
JRE on Linux, unless we override it...
