### PR TITLE
Remove ACDS 13.1 req from i2c component

### DIFF
--- a/hdl/fpga/ip/opencores/i2c/qsys/oc_i2c_master_hw.tcl
+++ b/hdl/fpga/ip/opencores/i2c/qsys/oc_i2c_master_hw.tcl
@@ -2,6 +2,9 @@
 # Sun Nov 24 13:25:09 EST 2013
 # DO NOT MODIFY
 
+# !!! 'package require' statement has been modified from the origial
+# !!! Component Editor generation, to permit building under multiple
+# !!! Quartus versions.
 
 # 
 # bladerf_oc_i2c_master "BladeRF OpenCores I2C Master" v1.0
@@ -10,9 +13,9 @@
 # 
 
 # 
-# request TCL package from ACDS 13.1
+# request TCL package from ACDS
 # 
-package require -exact qsys 13.1
+package require qsys
 
 
 # 


### PR DESCRIPTION
This should permit builds on older Quartuses again.

This may be the least-distasteful of three possibilities:

1) Generate the IP cores with the oldest version of Quartus we wish to support (bleh)
2) Find some vaguely-documented feature that allows us to turn off this version signature (bleh)
3) Hand-edit a "DO NOT MODIFY" file (bleh)
