### PR TITLE
Update oc_i2c_master_hw.tcl

### DIFF
--- a/hdl/fpga/ip/opencores/i2c/qsys/oc_i2c_master_hw.tcl
+++ b/hdl/fpga/ip/opencores/i2c/qsys/oc_i2c_master_hw.tcl
@@ -53,7 +53,7 @@ add_parameter ARST_LVL STD_LOGIC 0 ""
 set_parameter_property ARST_LVL DEFAULT_VALUE 0
 set_parameter_property ARST_LVL DISPLAY_NAME ARST_LVL
 set_parameter_property ARST_LVL WIDTH ""
-set_parameter_property ARST_LVL TYPE STD_LOGIC
+set_parameter_property ARST_LVL TYPE INTEGER
 set_parameter_property ARST_LVL UNITS None
 set_parameter_property ARST_LVL ALLOWED_RANGES 0:1
 set_parameter_property ARST_LVL DESCRIPTION ""


### PR DESCRIPTION
On Quartus 13.1 the generation of the nios_system.v file from a variable type of STD_LOGIC will result in a verilog line of:
    i2c_master_top #(
        .ARST_LVL ('1')
    ) oc_i2c_master_0 (
which will stop the build of the bitstream. Changing the interface property of the ARST_LVL parameter to integer would solve thie issue.
Change:
add_parameter ARST_LVL STD_LOGIC 0 ""
...
set_parameter_property ARST_LVL TYPE STD_LOGIC
To
add_parameter ARST_LVL STD_LOGIC 0 ""
...
set_parameter_property ARST_LVL TYPE INTEGER
