### PR TITLE
Ensure dev-libbladeRF_sync works on OSX

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -126,6 +126,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
     set(BLADERF_OS_LINUX 1)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(BLADERF_OS_OSX 1)
+
+    # We also need to add some headers that the system will not provide
+    set(BLADERF_HOST_COMMON_INCLUDE_DIRS
+            ${BLADERF_HOST_COMMON_INCLUDE_DIRS}
+            ${CMAKE_CURRENT_LIST_DIR}/common/include/osx
+    )
+
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(BLADERF_OS_WINDOWS 1)
 

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -207,6 +207,12 @@ if(ENABLE_LIBBLADERF_SYNC)
         src/sync_worker.c
     )
 
+    if(BLADERF_OS_OSX)
+       set(LIBBLADERF_SOURCE ${LIBBLADERF_SOURCE}
+           ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
+       )
+    endif()
+
     if(MSVC)
         set(LIBBLADERF_SOURCE ${LIBBLADERF_SOURCE}
             ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c


### PR DESCRIPTION
- Add new include directory, as for windows
- Include common/osx/clock_gettime.c for libbladeRF
