### PR TITLE
bladeRF-flash: cast callback fn to proper type

### DIFF
--- a/host/utilities/bladeRF-flash/src/main.c
+++ b/host/utilities/bladeRF-flash/src/main.c
@@ -235,7 +235,7 @@ static int init_event_counts(libusb_context *ctx,
             0,
             vender_id, product_id,
             LIBUSB_HOTPLUG_MATCH_ANY,
-            count_events,
+            (libusb_hotplug_callback_fn)count_events,
             data,
             NULL);
 


### PR DESCRIPTION
Fixes werrors:

/bladerf/bladeRF/host/utilities/bladeRF-flash/src/main.c:240:13:
    error: passing argument 7 of 'libusb_hotplug_register_callback'
    from incompatible pointer type [-Werror]
/usr/i686-w64-mingw32/include/libusb-1.0/libusb.h:1928:17:
    note: expected 'libusb_hotplug_callback_fn' but argument is of type
    'int (*)(struct libusb_context *, struct libusb_device *, enum libusb_hotplug_event,  void *)'
