### PR TITLE
Fix Lintian udev-rule-in-etc error

### DIFF
--- a/debian/libbladerf0.install
+++ b/debian/libbladerf0.install
@@ -1,2 +1,2 @@
 usr/lib/*/lib*.so.*
-etc/udev/rules.d/*.rules
+lib/udev/rules.d/*.rules

--- a/debian/rules
+++ b/debian/rules
@@ -33,7 +33,11 @@ ifneq (,$(findstring 1ppa,$(DEB_VERSION_STRING)))
 endif
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DVERSION_INFO_OVERRIDE:STRING=$(VERSION_INFO_OVERRIDE) -DENABLE_HOST_BUILD=ON -DENABLE_FX3_BUILD=OFF -DBUILD_DOCUMENTATION=ON
+	dh_auto_configure -- 	-DVERSION_INFO_OVERRIDE:STRING=$(VERSION_INFO_OVERRIDE) \
+							-DENABLE_HOST_BUILD=ON \
+							-DENABLE_FX3_BUILD=OFF \
+							-DBUILD_DOCUMENTATION=ON \
+							-DUDEV_RULES_PATH=/lib/udev/rules.d
 
 %:
 	dh $@ 


### PR DESCRIPTION
Per the Rules, /etc is reserved for user-installed files.

http://lintian.debian.org/tags/udev-rule-in-etc.html

(Note: This just updates the debian packaging stuff -- I think /etc is probably just fine for when folks are compiling it themselves.)
