### PR TITLE
Add Debian packages to download FPGA/FX3 images (#166)

### DIFF
--- a/debian/bladerf-firmware-fx3.dirs
+++ b/debian/bladerf-firmware-fx3.dirs
@@ -1,1 +1,1 @@
-/usr/share/bladerf/firmware
+/usr/share/Nuand/bladeRF

--- a/debian/bladerf-firmware-fx3.postinst
+++ b/debian/bladerf-firmware-fx3.postinst
@@ -2,7 +2,7 @@
 
 UPSTREAM='http://nuand.com/fx3/bladeRF_fw_v1.7.0.img'
 CHECKSUM='73ace21e693049e475cceb88bed900d7'
-IMGFILE=/usr/share/bladerf/firmware/bladeRF_fw.img
+IMGFILE=/usr/share/Nuand/bladeRF/bladeRF_fw.img
 
 checkfile () {
 	md5sum --check <<- EOMD5SUM

--- a/debian/bladerf-firmware-fx3.prerm
+++ b/debian/bladerf-firmware-fx3.prerm
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-IMGFILE=/usr/share/bladerf/firmware/bladeRF_fw.img
+IMGFILE=/usr/share/Nuand/bladeRF/bladeRF_fw.img
 
 if [ "$1" = "remove" -o "$1" = "purge" ]; then
 	echo "Deleting downloaded firmware: $IMGFILE"

--- a/debian/bladerf-fpga-hostedx115.dirs
+++ b/debian/bladerf-fpga-hostedx115.dirs
@@ -1,1 +1,1 @@
-/usr/share/bladerf/fpga
+/usr/share/Nuand/bladeRF

--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -2,7 +2,7 @@
 
 UPSTREAM='http://nuand.com/fpga/v0.0.5/hostedx115.rbf'
 CHECKSUM='d3ca5dc09115daf0bab731744b081165'
-RBFFILE=/usr/share/bladerf/fpga/hostedx115.rbf
+RBFFILE=/usr/share/Nuand/bladeRF/hostedx115.rbf
 
 checkfile () {
 	md5sum --check <<- EOMD5SUM

--- a/debian/bladerf-fpga-hostedx115.prerm
+++ b/debian/bladerf-fpga-hostedx115.prerm
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-RBFFILE=/usr/share/bladerf/fpga/hostedx115.rbf
+RBFFILE=/usr/share/Nuand/bladeRF/hostedx115.rbf
 
 if [ "$1" = "remove" -o "$1" = "purge" ]; then
 	echo "Deleting downloaded FPGA bitstream: $RBFFILE"

--- a/debian/bladerf-fpga-hostedx40.dirs
+++ b/debian/bladerf-fpga-hostedx40.dirs
@@ -1,1 +1,1 @@
-/usr/share/bladerf/fpga
+/usr/share/Nuand/bladeRF

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -2,7 +2,7 @@
 
 UPSTREAM='http://nuand.com/fpga/v0.0.5/hostedx40.rbf'
 CHECKSUM='a474050c832cbe528fb8635b36c36a34'
-RBFFILE=/usr/share/bladerf/fpga/hostedx40.rbf
+RBFFILE=/usr/share/Nuand/bladeRF/hostedx40.rbf
 
 checkfile () {
 	md5sum --check <<- EOMD5SUM

--- a/debian/bladerf-fpga-hostedx40.prerm
+++ b/debian/bladerf-fpga-hostedx40.prerm
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-RBFFILE=/usr/share/bladerf/fpga/hostedx40.rbf
+RBFFILE=/usr/share/Nuand/bladeRF/hostedx40.rbf
 
 if [ "$1" = "remove" -o "$1" = "purge" ]; then
 	echo "Deleting downloaded FPGA bitstream: $RBFFILE"

--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Description: nuand bladeRF FPGA bitstream downloader (hostedx40)
  This package will, at the time of installation, download an appropriate
  FPGA bitstream for using the nuand bladeRF in a hosted (USB-controlled)
  configuration.  The FPGA bitstream will be downloaded from
- http://nuand.com/fpga/ and saved to /usr/share/bladerf/fpga/.
+ http://nuand.com/fpga/ and saved to /usr/share/Nuand/bladeRF.
  .
  This bitstream is for the bladeRF x40 with the Altera Cyclone IV
  EP4CE40 FPGA.
@@ -88,7 +88,7 @@ Description: nuand bladeRF FPGA bitstream downloader (hostedx115)
  This package will, at the time of installation, download an appropriate
  FPGA bitstream for using the nuand bladeRF in a hosted (USB-controlled)
  configuration.  The FPGA bitstream will be downloaded from
- http://nuand.com/fpga/ and saved to /usr/share/bladerf/fpga/.
+ http://nuand.com/fpga/ and saved to /usr/share/Nuand/bladeRF.
  .
  This bitstream is for the bladeRF x115 with the Altera Cyclone IV
  EP4CE115 FPGA.
@@ -107,7 +107,7 @@ Description: nuand bladeRF firmware downloader (FX3)
  This package will, at the time of installation, download an appropriate
  firmware image for using the nuand bladeRF with a Cypress FX3 USB
  controller.  The image will be downloaded from http://nuand.com/fx3/
- and saved to /usr/share/bladerf/firmware/.
+ and saved to /usr/share/Nuand/bladeRF.
  .
  This bitstream will work for either the nuand bladeRF x40 or the x115.
  .

--- a/host/libraries/libbladeRF/src/file_ops.c
+++ b/host/libraries/libbladeRF/src/file_ops.c
@@ -154,7 +154,7 @@ static const struct search_path_entries search_paths[] = {
     { true,  "/.config/Nuand/bladeRF/" },
     { true,  "/.Nuand/bladeRF/" },
     { false, "/etc/Nuand/bladeRF/" },
-    { false, "/usr/share/bladerf/fpga/" },
+    { false, "/usr/share/Nuand/bladeRF/" },
 };
 
 static inline size_t get_home_dir(char *buf, size_t max_len)


### PR DESCRIPTION
Adds three new packages:

bladerf-firmware-fx3
bladerf-fpga-hostedx40
bladerf-fpga-hostedx115

When installed, these will download (hardcoded, alas) firmware and FPGA files from nuand.com and place them in /usr/share/bladerf.
