### PR TITLE
bladeRF-cli: Make 'print <parameter>' output more consistent

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/printset.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset.c
@@ -710,8 +710,7 @@ int print_rxvga1(struct cli_state *state, int argc, char **argv)
         state->last_lib_error = status;
         rv = CLI_RET_LIBBLADERF;
     } else {
-        printf( "\n" );
-        printf( "  RXVGA1 Gain: %3ddB\n", gain );
+        printf( "RXVGA1 Gain: %3ddB\n", gain );
         printf( "\n" );
     }
 
@@ -750,8 +749,7 @@ int print_rxvga2(struct cli_state *state, int argc, char **argv)
         state->last_lib_error = status;
         rv = CLI_RET_LIBBLADERF;
     } else {
-        printf( "\n" );
-        printf( "  RXVGA2 Gain: %3ddB\n", gain );
+        printf( "RXVGA2 Gain: %3ddB\n", gain );
         printf( "\n" );
     }
 


### PR DESCRIPTION
Minor nit, but came up while debugging my setup earlier. Happy to change it the other way if preferred.
