### PR TITLE
Allow #-style comments in bladeRF-cli

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/cmd.c
+++ b/host/utilities/bladeRF-cli/src/cmd/cmd.c
@@ -380,6 +380,9 @@ int cmd_handle(struct cli_state *s, const char *line)
     }
 
     if (argc > 0) {
+	/* ignore comments */
+	if (*argv[0] == '#') return ret;
+
         cmd = get_cmd(argv[0]);
 
         if (cmd) {


### PR DESCRIPTION
- Input lines starting with '#' are treated as comments both from scripts and
  when using the program interactively.
- Leading spaces before the '#' character are allowed.
