### PR TITLE
debian: allow libtecla-dev to satisfy build deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,10 @@
 Source: bladerf
 Priority: extra
 Maintainer: Ryan Tucker <rtucker@gmail.com>
-Build-Depends: debhelper (>=9), cmake (>= 2.8.5), pkg-config, doxygen, libusb-1.0-0-dev (>= 1.0.12), libtecla1-dev, libncurses5-dev, git, help2man, pandoc
-Standards-Version: 3.9.4
+Build-Depends: debhelper (>=9), cmake (>= 2.8.5), pkg-config, doxygen,
+ libusb-1.0-0-dev (>= 1.0.12), libtecla-dev | libtecla1-dev, libncurses5-dev,
+ git, help2man, pandoc
+Standards-Version: 3.9.5
 Section: comm
 Homepage: http://www.nuand.com/bladeRF
 Vcs-Git: git://github.com/Nuand/bladeRF.git


### PR DESCRIPTION
Ubuntu vivid (and I believe Debian) has renamed libtecla1-dev to
just plain libtecla-dev.  Either is OK for our purposes.

Also bump standards version to 3.9.5, and wrap the Build-Depends
line for clarity.
