### PR TITLE
On non-Windows systems, send logs to syslog & stderr.

### DIFF
--- a/host/common/src/log.c
+++ b/host/common/src/log.c
@@ -24,6 +24,9 @@
  */
 #ifdef LOGGING_ENABLED
 #include <log.h>
+#if !defined(WIN32) && !defined(__CYGWIN__) && defined(LOG_SYSLOG_ENABLED)
+#include <syslog.h>
+#endif
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -38,7 +41,15 @@ void log_write(bladerf_log_level level, const char *format, ...)
 
         /* Write the log message */
         va_start(args, format);
+#if defined(WIN32) || defined(__CYGWIN__)
         vfprintf(stderr, format, args);
+#else
+#  if defined (LOG_SYSLOG_ENABLED)
+        vsyslog(LOG_USER, format, args);
+#  else
+        vfprintf(stderr, format, args);
+#  endif
+#endif
         va_end(args);
     }
 }

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -48,6 +48,8 @@ endif()
 
 option(ENABLE_LIBBLADERF_LOGGING "Enable log messages in libbladeRF." ON)
 
+option(ENABLE_LIBBLADERF_SYSLOG "Enable logging to syslog (non Windows only)" OFF)
+
 option(BUILD_LIBBLADERF_DOCUMENTATION "Build libbladeRF documentation. Requries Doxygen." ${BUILD_DOCUMENTATION})
 if(NOT ${BUILD_DOCUMENTATION})
     set(BUILD_LIBBLADERF_DOCUMENTATION OFF)
@@ -114,6 +116,10 @@ configure_file(
 ################################################################################
 if(ENABLE_LIBBLADERF_LOGGING)
     add_definitions(-DLOGGING_ENABLED)
+endif()
+
+if(ENABLE_LIBBLADERF_SYSLOG)
+    add_definitions(-DLOG_SYSLOG_ENABLED)
 endif()
 
 if(ENABLE_LOCK_CHECKS)
@@ -269,6 +275,7 @@ set(LIBBLADERF_SOURCE
         src/sync_worker.c
         src/tuning.c
         src/version_compat.c
+        src/init_fini.c
         ${BLADERF_HOST_COMMON_SOURCE_DIR}/sha256.c
         ${BLADERF_HOST_COMMON_SOURCE_DIR}/conversions.c
         ${BLADERF_HOST_COMMON_SOURCE_DIR}/log.c

--- a/host/libraries/libbladeRF/README.md
+++ b/host/libraries/libbladeRF/README.md
@@ -35,6 +35,7 @@ more information.
 | -DENABLE_BACKEND_CYAPI=\<ON/OFF\>a                | Enables (Windows-only) Cypress driver/library based backend. Default: ON if the FX3 SDK is available, OFF otherwise. |
 | -DENABLE_BACKEND_DUMMY=\<ON/OFF\>                 | Enables dummy backend support.  Only useful for some developers.  Default: OFF                                       |
 | -DENABLE_LIBBLADERF_LOGGING=\<ON/OFF\>            | Enable log messages.  Default: ON                                                                                    |
+| -DENABLE_LIBBLADERF_SYSLOG=\<ON/OFF\>             | Enable log messages to syslog. Non Windows systems only and if ENABLE_LIBBLADERF_LOGGING  Default: OFF               |
 | -DENABLE_LIBBLADERF_SYNC_LOG_VERBOSE=\<ON/OFF\>   | Enable log_verbose() calls in the sync interface's data path. Note that this may harm performance. Default: OFF      |
 | -DENABLE_LOCK_CHECKS=\<ON/OFF\>                   | Enable checks for lock acquistion failures (e.g., deadlock). Default: OFF                                            |
 | -DLIBUSB_PATH=\</path/to/libusb\>                 | Path to libusb files. This is generally only needed for Windows users who downloaded binary distributions.           |

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -1119,6 +1119,9 @@ void bladerf_version(struct bladerf_version *version)
 void bladerf_log_set_verbosity(bladerf_log_level level)
 {
     log_set_verbosity(level);
+#if defined(LOG_SYSLOG_ENABLED)
+    log_debug("Log verbosity has been set to: %d", level);
+#endif
 }
 
 /*------------------------------------------------------------------------------

--- a/host/libraries/libbladeRF/src/init_fini.c
+++ b/host/libraries/libbladeRF/src/init_fini.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (C) 2013 Nuand LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+#if !defined(WIN32) && !defined(__CYGWIN__) && defined(LOG_SYSLOG_ENABLED)
+#include <syslog.h>
+#endif
+#include "log.h"
+
+#if !defined(WIN32) && !defined(__CYGWIN__)
+#  if !defined(__clang__) && !defined(__GNUC__)
+#  error init/fini mechanism not known to work for your compiler.
+#  endif
+#define __init __attribute__((constructor))
+#define __fini __attribute__((destructor))
+#else
+/* Corresponding syntax for Windows (TBD) */
+#define __init
+#define __fini
+#endif
+
+/* Module initializers/deinitializers. When used as library (who don't have
+ * a natural entry/exit function) these are used to initialize
+ * deinitialize. Use to set predefined/default states and cleanup.
+ *
+ * This will work with shared libraries as well as with static as they get
+ * invoked by RTL load/unload, with or without C++ code (i.e. functions will
+ * play nice with C++ normal ctors/dtors).
+ *
+ * Keep log in to at least once per new build-/run-environment assert that
+ * the mechanism works.
+ */
+
+void __init __bladerf_init(void) {
+#if !defined(WIN32) && !defined(__CYGWIN__) && defined(LOG_SYSLOG_ENABLED)
+    openlog("bladeRF",
+        LOG_CONS | LOG_NDELAY  | LOG_NOWAIT | LOG_PERROR | LOG_PID, LOG_USER);
+    bladerf_log_set_verbosity(BLADERF_LOG_LEVEL_INFO);
+#endif
+
+    log_info("BladeRF host software initializing");
+}
+
+void __fini __bladerf_fini(void) {
+    log_info("BladeRF host software deinitializing");
+	fflush(NULL);
+#if !defined(WIN32) && !defined(__CYGWIN__) && defined(LOG_SYSLOG_ENABLED)
+    closelog();
+#endif
+}


### PR DESCRIPTION
OpenBTS and YateBTS fork a transceiver sub-process and redirect stderr and
stdout, which effectively hide any bladerf logs. For debugging time-critical
code, printf debugging (or logging) is simple yet practically essential.