### PR TITLE
fixup debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 bladerf (2015.06-rc1) unstable; urgency=low
 
+  [ Jon Szymaniak ]
   * FPGA, libbladeRF: Configurable tuning modes: host and fpga
   * FPGA, libbladeRF: Scheduled retune: retune module at specified sample timestamp
   * FPGA, libbladeRF: Quick retune: retune using previously identified tuning parameters
@@ -7,9 +8,19 @@ bladerf (2015.06-rc1) unstable; urgency=low
   * bladeRF-cli: Added semicolon command separator support
   * bladeRF-cli: Added 'print trimdac' implementation
 
- -- Jon Szymaniak <jon.szymaniak@gmail.com>  Tue, 30 Jun 2015 22:11:06 -0400
+  [ Ryan Tucker ]
+  * Fixup debian/changelog for rc1 
+
+ -- Ryan Tucker <rtucker@gmail.com>  Wed, 01 Jul 2015 20:07:04 -0400
+
+bladerf (2015.02) unstable; urgency=low
+
+  * Build fixes
+
+ -- Jon Szymaniak <jon.szymaniak@gmail.com>  Sat, 28 Feb 2015 15:58:39 -0500
 
 bladerf (2015.01-rc2) unstable; urgency=low
+
   * Fixed issue #95, which prevented device from being opened after an application crash
   * Fixes for undesired XB-200 signal attenuation and LMS signal integrity issues
   * Added BLADERF_LOG_LEVEL support and optional libbladeRF syslog support


### PR DESCRIPTION
Bring 2015.02 entry back, run through dch to bump timestamp
and clean up formatting.

stray lines wander in
entire revisions gone
there's an app for this