### PR TITLE
Add support for setting SMB clock output to arbitrary frequency

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -436,11 +436,11 @@ const char * CALL_CONV bladerf_backend_str(bladerf_backend backend);
 
 /** Maximum output frequency on SMB connector, if no expansion board attached.
  */
-#define BLADERF_SMB_FREQUENCY_MAX   (38400000UL * 66UL)
+#define BLADERF_SMB_FREQUENCY_MAX   200000000u
 
 /** Minimum output frequency on SMB connector, if no expansion board attached.
  */
-#define BLADERF_SMB_FREQUENCY_MIN   (BLADERF_SMB_FREQUENCY_MAX / (32 * 567))
+#define BLADERF_SMB_FREQUENCY_MIN   ((38400000u * 66u) / (32 * 567))
 
 /**
  * Specifies that scheduled retune should occur immediately when using

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -434,6 +434,14 @@ const char * CALL_CONV bladerf_backend_str(bladerf_backend backend);
 /** Maximum tunable frequency, in Hz */
 #define BLADERF_FREQUENCY_MAX       3800000000u
 
+/** Maximum output frequency on SMB connector, if no expansion board attached.
+ */
+#define BLADERF_SMB_FREQUENCY_MAX   (38400000UL * 66UL)
+
+/** Minimum output frequency on SMB connector, if no expansion board attached.
+ */
+#define BLADERF_SMB_FREQUENCY_MIN   (BLADERF_SMB_FREQUENCY_MAX / (32 * 567))
+
 /**
  * Specifies that scheduled retune should occur immediately when using
  * bladerf_schedule_retune().
@@ -869,6 +877,75 @@ int CALL_CONV bladerf_get_rational_sample_rate(
                                         struct bladerf *dev,
                                         bladerf_module module,
                                         struct bladerf_rational_rate *rate);
+
+/**
+ * Set the SMB connector output frequency in rational Hz
+ *
+ * @param[in]   dev         Device handle
+ * @param[in]   rate        Rational frequency
+ * @param[out]  actual      If non-NULL, this is written with the actual
+ *                          rational frequency achieved.
+ *
+ * This clock should not be set if an expansion board is connected.
+ * The frequency must be between \ref BLADERF_SMB_FREQUENCY_MIN and
+ * \ref BLADERF_SMB_FREQUENCY_MAX.
+ *
+ * @return 0 on success,
+ *         BLADERF_ERR_INVAL for an invalid frequency,
+ *         or a value from \ref RETCODES list on failure.
+ */
+API_EXPORT
+int CALL_CONV bladerf_set_rational_smb_frequency(
+                                        struct bladerf *dev,
+                                        struct bladerf_rational_rate *rate,
+                                        struct bladerf_rational_rate *actual);
+
+/**
+ * Set the SMB connector output frequency in Hz. Note that this requires the
+ * frequency is an integer value of Hz. Use
+ * bladerf_set_rational_smb_frequency() for more arbitrary values.
+ *
+ * @param[in]   dev         Device handle
+ * @param[in]   rate        Frequency
+ * @param[out]  actual      If non-NULL. this is written with the actual
+ *                          frequency achieved.
+ *
+ * This clock should not be set if an expansion board is connected.
+ * The frequency must be between \ref BLADERF_SMB_FREQUENCY_MIN and
+ * \ref BLADERF_SMB_FREQUENCY_MAX.
+ *
+ * @return 0 on success,
+ *         BLADERF_ERR_INVAL for an invalid frequency,
+ *         or a value from \ref RETCODES list on other failures
+ */
+API_EXPORT
+int CALL_CONV bladerf_set_smb_frequency(struct bladerf *dev,
+                                        uint32_t rate, uint32_t *actual);
+
+/**
+ * Read the SMB connector output frequency in rational Hz
+ *
+ * @param[in]   dev         Device handle
+ * @param[out]  rate        Pointer to returned rational frequency
+ *
+ * @return 0 on success, value from \ref RETCODES list upon failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_rational_smb_frequency(
+                                        struct bladerf *dev,
+                                        struct bladerf_rational_rate *rate);
+
+/**
+ * Read the SMB connector output frequency in Hz
+ *
+ * @param[in]   dev         Device handle
+ * @param[out]  rate        Pointer to returned frequency
+ *
+ * @return 0 on success, value from \ref RETCODES list upon failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_smb_frequency(struct bladerf *dev,
+                                        unsigned int *rate);
 
 /**
  * Set the value of the specified configuration parameter

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -490,6 +490,54 @@ int bladerf_get_sample_rate(struct bladerf *dev, bladerf_module module,
     return status;
 }
 
+int bladerf_set_rational_smb_frequency(struct bladerf *dev,
+                                       struct bladerf_rational_rate *rate,
+                                       struct bladerf_rational_rate *actual)
+{
+    int status;
+    MUTEX_LOCK(&dev->ctrl_lock);
+
+    status = si5338_set_rational_smb_freq(dev, rate, actual);
+
+    MUTEX_UNLOCK(&dev->ctrl_lock);
+    return status;
+}
+
+int bladerf_set_smb_frequency(struct bladerf *dev,
+                              uint32_t rate, uint32_t *actual)
+{
+    int status;
+    MUTEX_LOCK(&dev->ctrl_lock);
+
+    status = si5338_set_smb_freq(dev, rate, actual);
+
+    MUTEX_UNLOCK(&dev->ctrl_lock);
+    return status;
+}
+
+int bladerf_get_rational_smb_frequency(struct bladerf *dev,
+                                       struct bladerf_rational_rate *rate)
+{
+    int status;
+    MUTEX_LOCK(&dev->ctrl_lock);
+
+    status = si5338_get_rational_smb_freq(dev, rate);
+
+    MUTEX_UNLOCK(&dev->ctrl_lock);
+    return status;
+}
+
+int bladerf_get_smb_frequency(struct bladerf *dev, unsigned int *rate)
+{
+    int status;
+    MUTEX_LOCK(&dev->ctrl_lock);
+
+    status = si5338_get_smb_freq(dev, rate);
+
+    MUTEX_UNLOCK(&dev->ctrl_lock);
+    return status;
+}
+
 int bladerf_get_sampling(struct bladerf *dev, bladerf_sampling *sampling)
 {
     int status = 0;

--- a/host/libraries/libbladeRF/src/si5338.h
+++ b/host/libraries/libbladeRF/src/si5338.h
@@ -39,5 +39,9 @@ int si5338_set_sample_rate(struct bladerf *dev, bladerf_module module, uint32_t 
 int si5338_get_sample_rate(struct bladerf *dev, bladerf_module module, unsigned int *rate);
 int si5338_set_rational_sample_rate(struct bladerf *dev, bladerf_module module, struct bladerf_rational_rate *rate, struct bladerf_rational_rate *actual);
 int si5338_get_rational_sample_rate(struct bladerf *dev, bladerf_module module, struct bladerf_rational_rate *rate);
+int si5338_set_smb_freq(struct bladerf *dev, uint32_t rate, uint32_t *actual);
+int si5338_get_smb_freq(struct bladerf *dev, unsigned int *rate);
+int si5338_set_rational_smb_freq(struct bladerf *dev, struct bladerf_rational_rate *rate, struct bladerf_rational_rate *actual);
+int si5338_get_rational_smb_freq(struct bladerf *dev, struct bladerf_rational_rate *rate);
 
 #endif

--- a/host/utilities/bladeRF-cli/src/cmd/doc/cmd_help.h.in
+++ b/host/utilities/bladeRF-cli/src/cmd/doc/cmd_help.h.in
@@ -350,7 +350,7 @@
 
 
 #define CLI_CMD_HELPTEXT_mimo \
-  "Usage: mimo [master | slave]\n" \
+  "Usage: mimo [master [frequency] | slave]\n" \
   "\n" \
   "Modify device MIMO operation.\n" \
   "\n" \


### PR DESCRIPTION
* Refactored si5338.c a little to reuse the multisynth related functions for both CLK3A (the SMB output and extension board clock) and the original CLK1/2 going to the LMS for sampling.
* Added new functions to si5338.c to get/set rational/integer frequencies for CLK3A
* Expose those functions in bladerf.c and export to the libbladeRF.h API
* Extend "mimo master" command in bladeRF-cli to support an optional frequency

I've tested locally against an oscilloscope and this works as expected for me, though I can only measure up to ~100MHz output clocks directly.

Very open to suggestions and changes - this is mostly based on a quick chat on IRC after I implemented setting the SMB to 10MHz in a quick C program to solve my particular need.