### PR TITLE
Add a libbladeRF helper function for setting the `rx_mux` setting in the FPGA

### DIFF
--- a/hdl/fpga/platforms/bladerf/vhdl/bladerf-hosted.vhd
+++ b/hdl/fpga/platforms/bladerf/vhdl/bladerf-hosted.vhd
@@ -121,6 +121,7 @@ architecture hosted_bladerf of bladerf is
 
     signal rx_sample_fifo   : fifo_t ;
     signal tx_sample_fifo   : fifo_t ;
+    signal rx_loopback_fifo : fifo_t ;
 
     type meta_fifo_tx_t is record
         aclr    :   std_logic ;
@@ -196,6 +197,11 @@ architecture hosted_bladerf of bladerf is
     signal rx_entropy_i     : signed(15 downto 0) := (others =>'0') ;
     signal rx_entropy_q     : signed(15 downto 0) := (others =>'0') ;
     signal rx_entropy_valid : std_logic := '0' ;
+
+    signal rx_loopback_i     : signed(15 downto 0) := (others =>'0') ;
+    signal rx_loopback_q     : signed(15 downto 0) := (others =>'0') ;
+    signal rx_loopback_valid : std_logic := '0' ;
+    signal rx_loopback_enabled : std_logic := '0' ;
 
     signal tx_sample_raw_i : signed(15 downto 0);
     signal tx_sample_raw_q : signed(15 downto 0);
@@ -493,6 +499,51 @@ begin
         wrusedw             => rx_meta_fifo.wused
       );
 
+
+    -- RX loopback fifo
+    rx_loopback_fifo.aclr <= '1' when rx_reset = '1' or tx_reset = '1' or rx_loopback_enabled = '0' else '0' ;
+    rx_loopback_fifo.wclock <= tx_clock ;
+    rx_loopback_fifo.wdata <= std_logic_vector(tx_sample_i & tx_sample_q) when rx_loopback_enabled = '1' else (others => '0') ; 
+    rx_loopback_fifo.wreq <= tx_sample_valid when rx_loopback_enabled = '1' else '0';
+
+    rx_loopback_fifo.rclock <= rx_clock ;
+    rx_loopback_fifo.rreq <= '1' when rx_loopback_enabled = '1' and rx_loopback_fifo.rempty = '0' else '0' ;
+
+    U_rx_loopack_fifo : entity work.rx_fifo
+      port map (
+        aclr                => rx_loopback_fifo.aclr,
+        data                => rx_loopback_fifo.wdata,
+        rdclk               => rx_loopback_fifo.rclock,
+        rdreq               => rx_loopback_fifo.rreq,
+        wrclk               => rx_loopback_fifo.wclock,
+        wrreq               => rx_loopback_fifo.wreq,
+        q                   => rx_loopback_fifo.rdata,
+        rdempty             => rx_loopback_fifo.rempty,
+        rdfull              => rx_loopback_fifo.rfull,
+        rdusedw             => rx_loopback_fifo.rused,
+        wrempty             => rx_loopback_fifo.wempty,
+        wrfull              => rx_loopback_fifo.wfull,
+        wrusedw             => rx_loopback_fifo.wused
+      );
+
+      rx_loopback_enabled <= '1' when rx_enable = '1' and tx_enable = '1' and rx_mux_mode = RX_MUX_DIGITAL_LOOPBACK else '0' ;
+      rx_loopback_i <= resize(signed(rx_loopback_fifo.rdata(31 downto 16)), rx_loopback_i'length) ;
+      rx_loopback_q <= resize(signed(rx_loopback_fifo.rdata(15 downto 0)), rx_loopback_q'length) ;
+
+      loopback_valid : process(rx_reset, rx_clock)
+      begin
+        if (rx_reset = '1') then
+            rx_loopback_valid <= '0';
+        elsif rising_edge(rx_clock) then
+             if (rx_loopback_fifo.rempty = '0') then
+                -- Delay fifo read request by one clock to indicate sample validity
+                rx_loopback_valid <= rx_loopback_fifo.rreq ;
+            else
+                rx_loopback_valid <= '0' ;
+            end if;
+        end if;
+    end process loopback_valid; 
+
     -- FX3 GPIF
     U_fx3_gpif : entity work.fx3_gpif
       port map (
@@ -715,9 +766,9 @@ begin
                     rx_mux_q <= rx_entropy_q ;
                     rx_mux_valid <= rx_entropy_valid ;
                 when RX_MUX_DIGITAL_LOOPBACK =>
-                    rx_mux_i <= tx_sample_raw_i ;
-                    rx_mux_q <= tx_sample_raw_q ;
-                    rx_mux_valid <= tx_sample_raw_valid ;
+                    rx_mux_i <= rx_loopback_i ;
+                    rx_mux_q <= rx_loopback_q ;
+                    rx_mux_valid <= rx_loopback_valid ;
                 when others =>
                     rx_mux_i <= (others =>'0') ;
                     rx_mux_q <= (others =>'0') ;

--- a/hdl/fpga/platforms/bladerf/vhdl/bladerf-hosted.vhd
+++ b/hdl/fpga/platforms/bladerf/vhdl/bladerf-hosted.vhd
@@ -75,6 +75,7 @@ architecture hosted_bladerf of bladerf is
     alias tx_clock  is c4_tx_clock ;
     alias rx_clock  is lms_rx_clock_out ;
 
+    -- Can be set from libbladeRF using bladerf_set_rx_mux()
     type rx_mux_mode_t is (RX_MUX_NORMAL, RX_MUX_12BIT_COUNTER, RX_MUX_32BIT_COUNTER, RX_MUX_ENTROPY, RX_MUX_DIGITAL_LOOPBACK) ;
 
     signal rx_mux_sel       : unsigned(2 downto 0) ;

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -540,6 +540,38 @@ typedef enum {
 
 } bladerf_loopback;
 
+/** 
+ * RX Mux modes
+ * Those values map directly to rx_mux_mode_t inside the FPGA's source
+ */
+typedef enum {
+    /**
+     * Normal operation
+     */
+    BLADERF_RX_MUX_NORMAL = 0,
+
+    /**
+     * Read samples from a 12 bit counter
+     */
+    BLADERF_RX_MUX_12BIT_COUNTER,
+
+    /**
+     * Read samples from a 32 bit counter
+     */
+    BLADERF_RX_MUX_32BIT_COUNTER,
+
+    /**
+     * Unused
+     */
+    BLADERF_RX_MUX_ENTROPY,
+
+    /**
+     * Read samples from the current tx sample.
+     * Warning: there is no clock synchronization mechanism between the tx and rx side, use with caution.
+     */
+    BLADERF_RX_MUX_DIGITAL_LOOPBACK
+
+} bladerf_rx_mux;
 
 /**
  * Rational sample rate representation
@@ -770,6 +802,30 @@ int CALL_CONV bladerf_set_loopback(struct bladerf *dev, bladerf_loopback l);
  */
 API_EXPORT
 int CALL_CONV bladerf_get_loopback(struct bladerf *dev, bladerf_loopback *l);
+
+
+/**
+ * Set the current RX Mux mode
+ * 
+ * @param       dev     Device handle
+ * @param       mux     Mux mode. 
+ *
+ * @returns 0 on success, value from \ref RETCODES list on failure.
+ */
+API_EXPORT
+int CALL_CONV bladerf_set_rx_mux(struct bladerf *dev, bladerf_rx_mux mux);
+
+
+/**
+ * Gets the current RX Mux mode
+ * 
+ * @param[in]   dev     Device handle
+ * @param[out]  l       Current RX Mux mode
+ * @returns 0 on success, value from \ref RETCODES list on failure.
+ */
+
+API_EXPORT
+int CALL_CONV bladerf_get_rx_mux(struct bladerf *dev, bladerf_rx_mux *mux);
 
 /**
  * Configure the device's sample rate, in Hz.  Note this requires the sample

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -3155,6 +3155,19 @@ int CALL_CONV bladerf_lms_get_dc_cals(struct bladerf *dev,
  */
 #define BLADERF_GPIO_COUNTER_ENABLE (1 << 9)
 
+
+/**
+ * Bit mask representing the rx mux selection
+ *
+ * @note This is set using bladerf_set_rx_mux()
+ */
+#define BLADERF_GPIO_RX_MUX_MASK ((1 << 8) | (1 << 9) | (1 << 10))
+
+/**
+ * Starting bit index of the rx mux value
+ */
+#define BLADERF_GPIO_RX_MUX_INDEX 8
+
 /**
  * Switch to use RX low band (300M - 1.5GHz)
  *

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -561,15 +561,9 @@ typedef enum {
     BLADERF_RX_MUX_32BIT_COUNTER,
 
     /**
-     * Unused
-     */
-    BLADERF_RX_MUX_ENTROPY,
-
-    /**
      * Read samples from the current tx sample.
-     * Warning: there is no clock synchronization mechanism between the tx and rx side, use with caution.
      */
-    BLADERF_RX_MUX_DIGITAL_LOOPBACK
+    BLADERF_RX_MUX_DIGITAL_LOOPBACK = 4
 
 } bladerf_rx_mux;
 

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -563,8 +563,10 @@ typedef enum {
     /**
      * Read samples from the current tx sample.
      */
-    BLADERF_RX_MUX_DIGITAL_LOOPBACK = 4
+    BLADERF_RX_MUX_DIGITAL_LOOPBACK = 4,
 
+
+    BLADERF_RX_MUX_INVALID
 } bladerf_rx_mux;
 
 /**

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -446,6 +446,11 @@ int bladerf_set_rx_mux(struct bladerf *dev, bladerf_rx_mux mux) {
     uint32_t config_gpio;
     int status;
 
+    if (mux >= BLADERF_RX_MUX_INVALID) {
+        log_debug("Invalid rx mux mode %d passed to bladerf_set_rx_mux()\n", (int)mux);
+        return BLADERF_ERR_RANGE;
+    }
+
     MUTEX_LOCK(&dev->ctrl_lock);
 
     if ((status = CONFIG_GPIO_READ(dev, &config_gpio))) {
@@ -481,6 +486,11 @@ int bladerf_get_rx_mux(struct bladerf *dev, bladerf_rx_mux *mux) {
 
     // right shift to the right position
     config_gpio >>= BLADERF_GPIO_RX_MUX_INDEX;
+
+    if (config_gpio >= BLADERF_RX_MUX_INVALID) {
+        log_debug("Invalid rx mux mode %d read from config gpio\n", (int)config_gpio);
+        return BLADERF_ERR_RANGE;
+    }
 
     *mux = (bladerf_rx_mux)config_gpio;
 

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -441,6 +441,46 @@ int bladerf_get_loopback(struct bladerf *dev, bladerf_loopback *l)
     return status;
 }
 
+
+int bladerf_set_rx_mux(struct bladerf *dev, bladerf_rx_mux mux) {
+    uint32_t config_gpio;
+    int status;
+
+    if ((status = bladerf_config_gpio_read(dev, &config_gpio))) {
+        return status;
+    }
+
+    // rx_mux_sel is a 3-bit value starting at bit 8
+    // clear value
+    config_gpio &= ~((1 << 8) | (1 << 9) | (1 << 10));
+    // set value
+    config_gpio |= mux << 8;
+
+    return bladerf_config_gpio_write(dev, config_gpio);
+}
+
+
+int bladerf_get_rx_mux(struct bladerf *dev, bladerf_rx_mux *mux) {
+    uint32_t config_gpio;
+    int status;
+
+    if ((status = bladerf_config_gpio_read(dev, &config_gpio))) {
+        return status;
+    }
+
+    // rx_mux_sel is a 3-bit value starting at bit 8
+    // pick the right bits
+    config_gpio &= ((1 << 8) | (1 << 9) | (1 << 10));
+
+    // right shift to the right position
+    config_gpio >>= 8;
+
+    *mux = (bladerf_rx_mux)config_gpio;
+
+    return status;
+}
+
+
 int bladerf_set_rational_sample_rate(struct bladerf *dev, bladerf_module module,
                                      struct bladerf_rational_rate *rate,
                                      struct bladerf_rational_rate *actual)

--- a/host/libraries/libbladeRF_test/test_ctrl/CMakeLists.txt
+++ b/host/libraries/libbladeRF_test/test_ctrl/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRC
         src/test_frequency.c
         src/test_gain.c
         src/test_loopback.c
+        src/test_rx_mux.c
         src/test_sampling.c
         src/test_lpf_mode.c
         src/test_samplerate.c

--- a/host/libraries/libbladeRF_test/test_ctrl/src/main.c
+++ b/host/libraries/libbladeRF_test/test_ctrl/src/main.c
@@ -43,6 +43,7 @@ static const struct test_case *tests[] = {
     &test_case_lpf_mode,
     &test_case_enable_module,
     &test_case_loopback,
+    &test_case_rx_mux,
     &test_case_xb200,
     &test_case_correction,
     &test_case_samplerate,

--- a/host/libraries/libbladeRF_test/test_ctrl/src/test_ctrl.h
+++ b/host/libraries/libbladeRF_test/test_ctrl/src/test_ctrl.h
@@ -74,6 +74,7 @@ DECLARE_TEST(enable_module);
 DECLARE_TEST(gain);
 DECLARE_TEST(frequency);
 DECLARE_TEST(loopback);
+DECLARE_TEST(rx_mux);
 DECLARE_TEST(lpf_mode);
 DECLARE_TEST(samplerate);
 DECLARE_TEST(sampling);

--- a/host/libraries/libbladeRF_test/test_ctrl/src/test_rx_mux.c
+++ b/host/libraries/libbladeRF_test/test_ctrl/src/test_rx_mux.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (C) 2014 Nuand LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "test_ctrl.h"
+
+DECLARE_TEST_CASE(rx_mux);
+
+static int set_and_check(struct bladerf *dev, bladerf_rx_mux mux)
+{
+    int status, status_disable_lb;
+    bladerf_rx_mux readback;
+
+    status = bladerf_set_rx_mux(dev, mux);
+    if (status != 0) {
+        PR_ERROR("Failed to set rx mux: %s\n",
+                 bladerf_strerror(status));
+
+        /* Try to ensure we don't leave the device in loopback */
+        status_disable_lb = bladerf_set_rx_mux(dev, BLADERF_RX_MUX_NORMAL);
+        if (status_disable_lb) {
+            PR_ERROR("Failed to restore rx mux to 'normal': %s\n",
+                     bladerf_strerror(status_disable_lb));
+        }
+        return status;
+    }
+
+    status = bladerf_get_rx_mux(dev, &readback);
+    if (status != 0) {
+        PR_ERROR("Failed to get rx mux setting: %s\n",
+                 bladerf_strerror(status));
+        return status;
+    }
+
+    if (mux != readback) {
+        PR_ERROR("Unexpected rx mux readback=%d, expected=%d\n",
+                 readback, mux);
+        return -1;
+    }
+
+    return 0;
+}
+
+unsigned int test_rx_mux(struct bladerf *dev,
+                           struct app_params *p, bool quiet)
+{
+    int status;
+    size_t i;
+    unsigned int failures = 0;
+    const bladerf_rx_mux muxes[] = {
+        BLADERF_RX_MUX_NORMAL,
+        BLADERF_RX_MUX_12BIT_COUNTER,
+        BLADERF_RX_MUX_32BIT_COUNTER,
+        BLADERF_RX_MUX_ENTROPY,
+        BLADERF_RX_MUX_DIGITAL_LOOPBACK,
+        BLADERF_RX_MUX_NORMAL    /* Ensure we don't leave the device in loopback */
+    };
+
+    PRINT("%s: Setting and checking rx muxes...\n", __FUNCTION__);
+
+    for (i = 0; i < ARRAY_SIZE(muxes); i++) {
+        status = set_and_check(dev, muxes[i]);
+        if (status != 0) {
+            failures++;
+        }
+    }
+
+    return failures;
+}
+

--- a/host/libraries/libbladeRF_test/test_ctrl/src/test_rx_mux.c
+++ b/host/libraries/libbladeRF_test/test_ctrl/src/test_rx_mux.c
@@ -71,7 +71,6 @@ unsigned int test_rx_mux(struct bladerf *dev,
         BLADERF_RX_MUX_NORMAL,
         BLADERF_RX_MUX_12BIT_COUNTER,
         BLADERF_RX_MUX_32BIT_COUNTER,
-        BLADERF_RX_MUX_ENTROPY,
         BLADERF_RX_MUX_DIGITAL_LOOPBACK,
         BLADERF_RX_MUX_NORMAL    /* Ensure we don't leave the device in loopback */
     };


### PR DESCRIPTION
As it took some effort to find how to set this value coming from VHDL to the library, I made a small helper so that it's easier to write test code for custom FPGA changes.

The test code was heavily inspired from the loopback test so that we do not leave the rx_mux into an abnormal mode after running the suite.