### PR TITLE
debian: firmware to v1.8.1, fpga to v0.4.1

### DIFF
--- a/debian/bladerf-firmware-fx3.postinst
+++ b/debian/bladerf-firmware-fx3.postinst
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-UPSTREAM='https://nuand.com/fx3/bladeRF_fw_v1.8.0.img'
-CHECKSUM='374011a23258b9245ec9ed78bdfba4c1'
+UPSTREAM='https://www.nuand.com/fx3/bladeRF_fw_v1.8.1.img'
+CHECKSUM='81cb33ced14bcd2942c8236fb6b533f5'
 IMGFILE=/usr/share/Nuand/bladeRF/bladeRF_fw.img
 
 checkfile () {

--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-UPSTREAM='https://nuand.com/fpga/v0.3.3/hostedx115.rbf'
-CHECKSUM='0607f024beb4e3ccda5d672b7f75f283'
+UPSTREAM='https://www.nuand.com/fpga/v0.4.1/hostedx115.rbf'
+CHECKSUM='ae639096fa40478c965e765052dd530c'
 RBFFILE=/usr/share/Nuand/bladeRF/hostedx115.rbf
 
 checkfile () {

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-UPSTREAM='https://nuand.com/fpga/v0.3.3/hostedx40.rbf'
-CHECKSUM='f5749c5f211661a3090b0b556eb29cf1'
+UPSTREAM='https://www.nuand.com/fpga/v0.4.1/hostedx40.rbf'
+CHECKSUM='4bdfc5543d7167d7f59fcf7d38b28945'
 RBFFILE=/usr/share/Nuand/bladeRF/hostedx40.rbf
 
 checkfile () {


### PR DESCRIPTION
Update pointers for the auto-downloaders of FPGA and firmware images
