### PR TITLE
libbladeRF: use c99 snprintf/vsnprintf for vc14

### DIFF
--- a/host/common/include/host_config.h.in
+++ b/host/common/include/host_config.h.in
@@ -193,8 +193,12 @@
 #if _MSC_VER
 #   define strtok_r    strtok_s
 #   define strtoull    _strtoui64
+#if _MSC_VER < 1900
 #   define snprintf    _snprintf
 #   define vsnprintf   _vsnprintf
+#else
+#define STDC99
+#endif
 #   define strcasecmp  _stricmp
 #   define strncasecmp _strnicmp
 #   define fileno      _fileno


### PR DESCRIPTION
These functions come with MSVC 2015 (vc14) as part of the c99 support.
The compatibility definitions in host_config.h.in were causing
a compilation error. This fix disables the compatibility definitions
when the more recent vc14 compiler is detected.