### PR TITLE
debian: gracefully handle failed wget when downloading FPGA/firmware images (#454)

### DIFF
--- a/debian/bladerf-firmware-fx3.postinst
+++ b/debian/bladerf-firmware-fx3.postinst
@@ -2,26 +2,45 @@
 
 UPSTREAM='https://www.nuand.com/fx3/bladeRF_fw_v1.9.0.img'
 CHECKSUM='9fd35cdced2a33a08a724ee5162ee6b9'
-IMGFILE=/usr/share/Nuand/bladeRF/bladeRF_fw.img
+DATAFILE='/usr/share/Nuand/bladeRF/bladeRF_fw.img'
+DESCRIPT='firmware'
+MYNAMEIS='bladerf-firmware-fx3'
 
 checkfile () {
 	md5sum --check <<- EOMD5SUM
-	$CHECKSUM  $IMGFILE
+	${CHECKSUM}  ${DATAFILE}
 	EOMD5SUM
 }
 
 # Fetch firmware if needed
-if [ ! -s $IMGFILE ] || ! checkfile ; then
-	echo "Downloading firmware from nuand.com..."
-	rm -f $IMGFILE
-	wget -O $IMGFILE $UPSTREAM || cat <<- EOMSG 1>&2
+if [ ! -s ${DATAFILE} ] || ! checkfile ; then
+	echo "Either your ${DESCRIPT} is missing, or it is out-of-date."
+	echo "Downloading ${DESCRIPT} from ${UPSTREAM}..."
 
-		Warning: Failed to download firmware for bladeRF.
-		Please run "dpkg-reconfigure bladerf-firmware-fx3"
-		again when networking is up, or copy the firmware manually
-		to $IMGFILE
+	# Try downloading it
+	NEWFILE=$(mktemp)
+	[ -z "${NEWFILE}" ] && (echo "Unable to create temporary file!"; exit 2)
 
-	EOMSG
+	if wget -O ${NEWFILE} ${UPSTREAM} ; then
+		# We're good!  Copy it to its new home.
+		echo "Download successful, copying to ${DATAFILE}"
+		mv ${NEWFILE} ${DATAFILE}
+	else
+		# It failed!  Print an error and nuke the temporary file.
+		rm -f ${NEWFILE}
+		cat <<- EOMSG 1>&2
+
+		Warning: Failed to download ${DESCRIPT}.
+		Please run "dpkg-reconfigure ${MYNAMEIS}"
+		again when networking is up, or download the file manually:
+
+		    URL:  ${UPSTREAM}
+		    File: ${DATAFILE}
+
+		EOMSG
+
+		exit 1
+	fi
 fi
 
 #DEBHELPER#

--- a/debian/bladerf-firmware-fx3.postinst
+++ b/debian/bladerf-firmware-fx3.postinst
@@ -7,13 +7,14 @@ DESCRIPT='firmware'
 MYNAMEIS='bladerf-firmware-fx3'
 
 checkfile () {
+	[ -z "$1" ] && exit 3
 	md5sum --check <<- EOMD5SUM
-	${CHECKSUM}  ${DATAFILE}
+	${CHECKSUM}  $1
 	EOMD5SUM
 }
 
 # Fetch firmware if needed
-if [ ! -s ${DATAFILE} ] || ! checkfile ; then
+if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 	echo "Either your ${DESCRIPT} is missing, or it is out-of-date."
 	echo "Downloading ${DESCRIPT} from ${UPSTREAM}..."
 
@@ -21,7 +22,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ; then
 	NEWFILE=$(mktemp)
 	[ -z "${NEWFILE}" ] && (echo "Unable to create temporary file!"; exit 2)
 
-	if wget -O ${NEWFILE} ${UPSTREAM} ; then
+	if wget -O ${NEWFILE} ${UPSTREAM} && checkfile ${NEWFILE}; then
 		# We're good!  Copy it to its new home.
 		echo "Download successful, copying to ${DATAFILE}"
 		mv ${NEWFILE} ${DATAFILE}

--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -2,26 +2,45 @@
 
 UPSTREAM='https://www.nuand.com/fpga/v0.5.0/hostedx115.rbf'
 CHECKSUM='8af6607afdcf9b00ddae8fbd2cf2eafa'
-RBFFILE=/usr/share/Nuand/bladeRF/hostedx115.rbf
+DATAFILE='/usr/share/Nuand/bladeRF/hostedx115.rbf'
+DESCRIPT='FPGA bitstream'
+MYNAMEIS='bladerf-fpga-hostedx115'
 
 checkfile () {
 	md5sum --check <<- EOMD5SUM
-	$CHECKSUM  $RBFFILE
+	${CHECKSUM}  ${DATAFILE}
 	EOMD5SUM
 }
 
 # Fetch firmware if needed
-if [ ! -s $RBFFILE ] || ! checkfile ; then
-	echo "Downloading FPGA bitstream from nuand.com..."
-	rm -f $RBFFILE
-	wget -O $RBFFILE $UPSTREAM || cat <<- EOMSG 1>&2
+if [ ! -s ${DATAFILE} ] || ! checkfile ; then
+	echo "Either your ${DESCRIPT} is missing, or it is out-of-date."
+	echo "Downloading ${DESCRIPT} from ${UPSTREAM}..."
 
-		Warning: Failed to download FPGA bitstream for bladeRF.
-		Please run "dpkg-reconfigure bladerf-fpga-hostedx115"
-		again when networking is up, or copy the firmware manually
-		to $RBFFILE
+	# Try downloading it
+	NEWFILE=$(mktemp)
+	[ -z "${NEWFILE}" ] && (echo "Unable to create temporary file!"; exit 2)
 
-	EOMSG
+	if wget -O ${NEWFILE} ${UPSTREAM} ; then
+		# We're good!  Copy it to its new home.
+		echo "Download successful, copying to ${DATAFILE}"
+		mv ${NEWFILE} ${DATAFILE}
+	else
+		# It failed!  Print an error and nuke the temporary file.
+		rm -f ${NEWFILE}
+		cat <<- EOMSG 1>&2
+
+		Warning: Failed to download ${DESCRIPT}.
+		Please run "dpkg-reconfigure ${MYNAMEIS}"
+		again when networking is up, or download the file manually:
+
+		    URL:  ${UPSTREAM}
+		    File: ${DATAFILE}
+
+		EOMSG
+
+		exit 1
+	fi
 fi
 
 #DEBHELPER#

--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -7,13 +7,14 @@ DESCRIPT='FPGA bitstream'
 MYNAMEIS='bladerf-fpga-hostedx115'
 
 checkfile () {
+	[ -z "$1" ] && exit 3
 	md5sum --check <<- EOMD5SUM
-	${CHECKSUM}  ${DATAFILE}
+	${CHECKSUM}  $1
 	EOMD5SUM
 }
 
 # Fetch firmware if needed
-if [ ! -s ${DATAFILE} ] || ! checkfile ; then
+if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 	echo "Either your ${DESCRIPT} is missing, or it is out-of-date."
 	echo "Downloading ${DESCRIPT} from ${UPSTREAM}..."
 
@@ -21,7 +22,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ; then
 	NEWFILE=$(mktemp)
 	[ -z "${NEWFILE}" ] && (echo "Unable to create temporary file!"; exit 2)
 
-	if wget -O ${NEWFILE} ${UPSTREAM} ; then
+	if wget -O ${NEWFILE} ${UPSTREAM} && checkfile ${NEWFILE}; then
 		# We're good!  Copy it to its new home.
 		echo "Download successful, copying to ${DATAFILE}"
 		mv ${NEWFILE} ${DATAFILE}

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -2,26 +2,45 @@
 
 UPSTREAM='https://www.nuand.com/fpga/v0.5.0/hostedx40.rbf'
 CHECKSUM='af8ea27b4f545113db3d9b6d986f6525'
-RBFFILE=/usr/share/Nuand/bladeRF/hostedx40.rbf
+DATAFILE='/usr/share/Nuand/bladeRF/hostedx40.rbf'
+DESCRIPT='FPGA bitstream'
+MYNAMEIS='bladerf-fpga-hostedx40'
 
 checkfile () {
 	md5sum --check <<- EOMD5SUM
-	$CHECKSUM  $RBFFILE
+	${CHECKSUM}  ${DATAFILE}
 	EOMD5SUM
 }
 
 # Fetch firmware if needed
-if [ ! -s $RBFFILE ] || ! checkfile ; then
-	echo "Downloading FPGA bitstream from nuand.com..."
-	rm -f $RBFFILE
-	wget -O $RBFFILE $UPSTREAM || cat <<- EOMSG 1>&2
+if [ ! -s ${DATAFILE} ] || ! checkfile ; then
+	echo "Either your ${DESCRIPT} is missing, or it is out-of-date."
+	echo "Downloading ${DESCRIPT} from ${UPSTREAM}..."
 
-		Warning: Failed to download FPGA bitstream for bladeRF.
-		Please run "dpkg-reconfigure bladerf-fpga-hostedx40"
-		again when networking is up, or copy the firmware manually
-		to $RBFFILE
+	# Try downloading it
+	NEWFILE=$(mktemp)
+	[ -z "${NEWFILE}" ] && (echo "Unable to create temporary file!"; exit 2)
 
-	EOMSG
+	if wget -O ${NEWFILE} ${UPSTREAM} ; then
+		# We're good!  Copy it to its new home.
+		echo "Download successful, copying to ${DATAFILE}"
+		mv ${NEWFILE} ${DATAFILE}
+	else
+		# It failed!  Print an error and nuke the temporary file.
+		rm -f ${NEWFILE}
+		cat <<- EOMSG 1>&2
+
+		Warning: Failed to download ${DESCRIPT}.
+		Please run "dpkg-reconfigure ${MYNAMEIS}"
+		again when networking is up, or download the file manually:
+
+		    URL:  ${UPSTREAM}
+		    File: ${DATAFILE}
+
+		EOMSG
+
+		exit 1
+	fi
 fi
 
 #DEBHELPER#

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -7,13 +7,14 @@ DESCRIPT='FPGA bitstream'
 MYNAMEIS='bladerf-fpga-hostedx40'
 
 checkfile () {
+	[ -z "$1" ] && exit 3
 	md5sum --check <<- EOMD5SUM
-	${CHECKSUM}  ${DATAFILE}
+	${CHECKSUM}  $1
 	EOMD5SUM
 }
 
 # Fetch firmware if needed
-if [ ! -s ${DATAFILE} ] || ! checkfile ; then
+if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 	echo "Either your ${DESCRIPT} is missing, or it is out-of-date."
 	echo "Downloading ${DESCRIPT} from ${UPSTREAM}..."
 
@@ -21,7 +22,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ; then
 	NEWFILE=$(mktemp)
 	[ -z "${NEWFILE}" ] && (echo "Unable to create temporary file!"; exit 2)
 
-	if wget -O ${NEWFILE} ${UPSTREAM} ; then
+	if wget -O ${NEWFILE} ${UPSTREAM} && checkfile ${NEWFILE}; then
 		# We're good!  Copy it to its new home.
 		echo "Download successful, copying to ${DATAFILE}"
 		mv ${NEWFILE} ${DATAFILE}


### PR DESCRIPTION
Revises the postinst scripts to be more careful about leaving broken stuff in /usr/share/Nuand/bladeRF.

Also improve commonality between the scripts...
