### PR TITLE
libbladeRF: Move the submit_stream_buffer up one layer to usb.c

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/usb.h
+++ b/host/libraries/libbladeRF/src/backend/usb/usb.h
@@ -103,6 +103,12 @@ struct usb_fns {
     void (*close)(void *driver);
 
     int (*get_speed)(void *driver, bladerf_dev_speed *speed);
+    
+    size_t (*get_num_avail)(struct bladerf_stream *stream);
+
+    size_t (*get_num_transfers)(struct bladerf_stream *stream);
+
+    int (*submit_transfer)(struct bladerf_stream *stream, void *buffer);
 
     int (*change_setting)(void *driver, uint8_t setting);
 
@@ -126,10 +132,6 @@ struct usb_fns {
 
     int (*stream)(void *driver, struct bladerf_stream *stream,
                   bladerf_module module);
-
-    int (*submit_stream_buffer)(void *driver, struct bladerf_stream *stream,
-                                void *buffer, unsigned int timeout_ms,
-                                bool nonblock);
 
     int (*deinit_stream)(void *driver, struct bladerf_stream *stream);
 


### PR DESCRIPTION
Removed [lusb|cyapi]_submit_stream_buffer and replaced it with submit_stream_buffer in usb.c, as pointed out in issue #439 . Also added the functions [lusb|cyapi]_get_num_avail and [lusb|cyapi]_get_num_transfers, since usb.c need to know the values of num_avail and num_transfers.
