### PR TITLE
Fix to xb.c specify new consts as floats

### DIFF
--- a/host/libraries/libbladeRF/src/xb.c
+++ b/host/libraries/libbladeRF/src/xb.c
@@ -790,11 +790,11 @@ int xb300_get_output_power(struct bladerf *dev, float *pwr)
     volt3 = volt2 * volt;
     volt4 = volt3 * volt;
 
-    *pwr =  -503.933  * volt4 +
-            1409.489  * volt3 -
-            1487.84   * volt2 +
-             722.9793 * volt  -
-             114.7529;
+    *pwr =  -503.933f  * volt4 +
+            1409.489f  * volt3 -
+            1487.84f   * volt2 +
+             722.9793f * volt  -
+             114.7529f;
 
     return 0;
 


### PR DESCRIPTION
constants added in recent commit were not specified as floats, so defaulted to doubles, which caused warning on MSVC and the build is set to fail on all warnings.