### PR TITLE
bladeRF-fsk: Added bladeRF-fsk utility

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,9 +31,10 @@ I: engidea
 G: Engidea
 D: si5338 sample rate functionality, misc. bugfixes
 
-N: Cameron Karlsson
-D: NIOS II redesign, refactoring, and clean-up
-G: ckgt
+N: Ian Frasch
+F: ifrasch
+G: ifrasch
+D: bladeRF-FSK modem project
 
 N: Robert Ghilduta
 E: robert.ghilduta@nuand.com
@@ -55,6 +56,10 @@ F: adamgreig
 I: adamgreig
 G: adamgreig
 D: libbladeRF LPF mode routines
+
+N: Cameron Karlsson
+D: NIOS II redesign, refactoring, and clean-up
+G: ckgt
 
 N: Mike Kershaw
 E: dragorn@kismetwireless.net

--- a/host/utilities/CMakeLists.txt
+++ b/host/utilities/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required(VERSION 2.8)
 
 add_subdirectory(bladeRF-cli)
+add_subdirectory(bladeRF-fsk/c)

--- a/host/utilities/README.md
+++ b/host/utilities/README.md
@@ -1,8 +1,10 @@
 # bladeRF Utilities #
 This directory contains applications that utilize libbladeRF.
 
-| Utility                   | Description                                                       |
-| ------------------------- |:----------------------------------------------------------------- |
-| [bladeRF-cli]             | Command line tool for development and debugging                   |
+| Utility                   | Description                                                                |
+| ------------------------- |:-------------------------------------------------------------------------- |
+| [bladeRF-cli]             | Command line tool for development and debugging                            |
+| [bladeRF-fsk]             | BladeRF-to-bladeRF text/file transfer program based on a custom FSK modem  |
 
 [bladeRF-cli]: ./bladeRF-cli (bladeRF-cli)
+[bladeRF-fsk]: ./bladeRF-fsk (bladeRF-fsk)

--- a/host/utilities/bladeRF-fsk/README.md
+++ b/host/utilities/bladeRF-fsk/README.md
@@ -1,0 +1,141 @@
+# bladeRF-FSK #
+
+## Project Overview ##
+
+The bladeRF-fsk project is a simple frequency shift keying (FSK) based software modem  
+impemented entirely on the host PC side in C code. The project uses libbladeRF to  
+transmit/receive samples with a bladeRF device. A USB 3.0 port is not required when using  
+this modem. The project also contains a MATLAB/Octave simulation/implementation of the  
+physical layer (PHY) portion of the modem.  
+
+The top level bladeRF-fsk C program demonstrates the functionality of the modem in a  
+simple bladeRF-to-bladeRF data transfer program. This program can transmit/receive both  
+text (like a chat program) and binary files (like a file transfer program) with a raw  
+link rate of 250 kbps. To properly demonstrate the program, two instances of the program  
+must be run with two separate bladeRF devices (loopback is not supported).  
+
+The modem modulates with continuous-phase frequency shift keying (CPFSK). Baseband I/Q  
+CPFSK samples are sent to the bladeRF device, inside which they converted from digital  
+to analog, mixed with quadrature RF carriers, and transmitted through the air.  
+Received signals are mixed with quadrature RF carriers to downconvert to baseband I/Q,  
+sampled with an ADC, and sent to the host PC program over the USB connection.  
+
+The physical layer code features an FIR low-pass filter, power normalization, preamble  
+correlation for signal detection, CPFSK modulation/demodulation, and scrambling. The  
+link layer code features framing, error detection via CRC32 checksums, and guaranteed  
+delivery of frames via acknowledgements and retransmissions.  
+
+This project is meant to be an experimental example and should not be treated as a  
+rigorous modem.  
+
+## Dependencies ##
+
+- [libbladeRF]
+
+[libbladeRF]: ../../libraries/libbladeRF
+
+## Build Instructions ##
+
+The program builds as part of the bladeRF host side code. Follow the build instructions  
+listed in [bladeRF/host/README.md].
+
+[bladeRF/host/README.md]: ../../README.md
+
+_NOTE_: Release builds are recommended for this program.  
+More info: The receiver thread inside phy.c eats up a lot of CPU resources with DSP.  
+Debug builds do not contain compiler optimization, so running the a debug build may  
+cause RX overruns (i.e. received samples get dropped) which can cause the modem to fail.  
+If you want to check the %CPU that this thread uses, you can run bladeRF-fsk_test_suite  
+which contains a function phy_receive_test() that simply runs the receiver thread for  
+some time. Monitor the CPU usage of the threads using the linux command:  
+```
+top -H -p $(pidof [path to build/output executables]/bladeRF-fsk_test_suite)
+```
+When bladeRF-fsk_test_suite gets to phy_receive_test(), be sure to watch the CPU usage.  
+
+### Build Variables ###
+
+Below is a list of project-specific CMake options.
+
+| Option                                            | Description                                           |
+| ------------------------------------------------- |:------------------------------------------------------|
+| -DBLADERF-FSK_BYPASS_RX_CHANNEL_FILTER=\<ON/OFF\> | Bypass the RX low-pass channel filter. Default: OFF   |
+| -DBLADERF-FSK_BYPASS_RX_PNORM=\<ON/OFF\>          | Bypass RX power normalization. Default: OFF           |
+| -DBLADERF-FSK_BYPASS_PHY_SCRAMBLING=\<ON/OFF\>    | Bypass scrambling in the PHY layer. Default: OFF      |
+| -DBLADERF-FSK_ENABLE_NOTES_LINK=\<ON/OFF\>        | Print noteworthy messages from link.c. Default: OFF   |
+| -DBLADERF-FSK_ENABLE_NOTES_PHY=\<ON/OFF\>         | Print noteworthy messages from phy.c. Default: OFF    |
+| -DBLADERF-FSK_ENABLE_DEBUG_ALL=\<ON/OFF\>         | Print debug messages from all files. Default: OFF     |
+| -DBLADERF-FSK_ENABLE_DEBUG_TEST_SUITE=\<ON/OFF\>  | Print debug messages from test_suite.c. Default: OFF  |
+| -DBLADERF-FSK_ENABLE_DEBUG_LINK=\<ON/OFF\>        | Print debug messages from link.c. Default: OFF        |
+| -DBLADERF-FSK_ENABLE_DEBUG_PHY=\<ON/OFF\>         | Print debug messages from phy.c. Default: OFF         |
+| -DBLADERF-FSK_ENABLE_DEBUG_FSK=\<ON/OFF\>         | Print debug messages from fsk.c. Default: OFF         |
+| -DBLADERF-FSK_ENABLE_DEBUG_BLADERF=\<ON/OFF\>     | Print bladeRF debug messages. Default: OFF            |
+
+Setting -DBLADERF-FSK_ENABLE_NOTES_LINK=ON will show you when a frame is received with  
+CRC errors. Setting -DBLADERF-FSK_ENABLE_NOTES_PHY=ON will show you when RX overruns  
+occur, meaning the PHY receiver thread could not process a set of samples fast enough  
+and samples had to be dropped.
+
+## How to Run ##
+To run the top-level bladeRF-fsk program with defaults, type into a terminal:
+```
+bladeRF-fsk
+```
+To see a list of configuration options and how to set them, type:
+```
+bladeRF-fsk -h
+```
+_NOTE_: On Windows, if you are running two instances of the program on the same PC, you  
+must specify the bladeRF serial number with the '-b' option, due to a bug. Example:  
+```
+bladeRF-fsk -b *:serial=4e
+```
+Failure to do so will result in libusb error messages; data transfer will not work.
+
+By default the program uses the first available bladeRF device, gets TX input from stdin,  
+writes RX output to stdout, and uses a default set of transmit/receive frequencies and  
+gains. Gains may need to be tweaked for a good connection with another bladeRF running  
+bladeRF-fsk. To transfer files, use the '-i' and '-o' options. If using stdin for tx  
+data, the program will transmit data line-by-line.  
+
+The program runs until it gets an EOF in its TX input.
+
+### Example: Transferring Files ###
+1) Be sure two bladeRF devices are plugged into your PC (or two separate PCs) with  
+   TX and RX antennas attached.  
+  
+2) Run bladeRF-fsk on one of the devices (receiver), with the output RX file specified:  
+```
+bladeRF-fsk -r 904M -t 924M -o rx.jpg
+```
+   _NOTE_: On Windows, if both bladeRFs are plugged into the same PC, you must also  
+   specify the device serial number with the '-b' option when calling bladeRF-fsk. See  
+   note in the "How to Run" section.  
+  
+3) Run bladeRF-fsk on the other device (sender), with opposite frequencies and the input  
+   TX file specified:  
+```
+bladeRF-fsk -r 924M -t 904M -i puppy.jpg
+```
+4) The file will begin transferring, and progress will be printed in the terminal for the  
+   sending device.  
+  
+5) Once the transmission is complete, press [CTRL-D] on Linux/OSX or [CTRL-Z then ENTER]  
+   on Windows to stop the program on the receiving end.
+
+If the sending device does not get any response from the receiving device, it will quit  
+the program. Try increasing the gains and run it again.  
+
+## Known Limitations ##
+1) The program does not currently support the use of an XB-200 transverter expansion  
+   board to transmit/receive at frequencies below 300MHz. In order to add XB-200 support,  
+   a new configuration option as well as functions from the "Expansion boards" section  
+   of the libbladeRF API would need to be added to the source code.  
+
+2) The program is currently unable to perform two file transfers in both directions  
+   simultaneously. Reason #1: The program runs until is gets an EOF in its TX input,  
+   meaning whichever side finishes transmitting its file first will quit and stop  
+   receiving. An EOF bit would need to be added to the link layer packet format in order  
+   to stop this behavior. Reason #2: The program doesn't seem to perform well during  
+   these simultaneous file transfers, and usually loses connection. Further investigation  
+   is required to debug this.  

--- a/host/utilities/bladeRF-fsk/c/CMakeLists.txt
+++ b/host/utilities/bladeRF-fsk/c/CMakeLists.txt
@@ -1,0 +1,368 @@
+cmake_minimum_required(VERSION 2.8)
+project(bladeRF-fsk C)
+
+################################################################################
+# Version information
+################################################################################
+
+set(VERSION_INFO_MAJOR  0)
+set(VERSION_INFO_MINOR  1)
+set(VERSION_INFO_PATCH  0)
+
+################################################################################
+# Dependencies
+################################################################################
+
+set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+if(MSVC)
+    find_package(LibPThreadsWin32 REQUIRED)
+else(MSVC)
+	find_package(Threads REQUIRED)
+endif(MSVC)
+
+################################################################################
+# Options
+################################################################################
+option(BLADERF-FSK_ENABLE_DEBUG_ALL "Print debug messages in all files" OFF)
+option(BLADERF-FSK_ENABLE_DEBUG_PHY
+        "Print debug messages in phy.c"
+        ${BLADERF-FSK_ENABLE_DEBUG_ALL}
+)
+option(BLADERF-FSK_ENABLE_DEBUG_LINK
+        "Print debug messages in link.c"
+        ${BLADERF-FSK_ENABLE_DEBUG_ALL}
+)
+option(BLADERF-FSK_ENABLE_DEBUG_FSK
+        "Print debug messages in fsk.c"
+        ${BLADERF-FSK_ENABLE_DEBUG_ALL}
+)
+option(
+        BLADERF-FSK_ENABLE_DEBUG_TEST_SUITE
+        "Print debug messages in test_suite.c"
+        ${BLADERF-FSK_ENABLE_DEBUG_ALL}
+)
+option(BLADERF-FSK_ENABLE_DEBUG_BLADERF
+        "Print libbladeRF debug messages"
+        ${BLADERF-FSK_ENABLE_DEBUG_ALL}
+)
+option(BLADERF-FSK_ENABLE_NOTES_PHY
+        "Print noteworthy messages (e.g. recoverable errors) in phy.c"
+        OFF
+)
+option(BLADERF-FSK_ENABLE_NOTES_LINK
+        "Print noteworthy messages (e.g. recoverable errors) in link.c"
+        OFF
+)
+option(BLADERF-FSK_BYPASS_RX_CHANNEL_FILTER "Bypass the PHY's RX channel filter." OFF)
+option(BLADERF-FSK_BYPASS_PHY_SCRAMBLING "Bypass scrambling in the phy layer" OFF)
+option(BLADERF-FSK_BYPASS_RX_PNORM "Bypass the PHY's RX power normalization" OFF)
+
+if(BLADERF-FSK_ENABLE_DEBUG_PHY)
+    set_property(SOURCE ${SRC_DIR}/phy.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DDEBUG_MODE ")
+endif()
+if(BLADERF-FSK_ENABLE_DEBUG_LINK)
+    set_property(SOURCE ${SRC_DIR}/link.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DDEBUG_MODE ")
+endif()
+if(BLADERF-FSK_ENABLE_DEBUG_FSK)
+    set_property(SOURCE ${SRC_DIR}/fsk.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DDEBUG_MODE ")
+endif()
+if(BLADERF-FSK_ENABLE_DEBUG_BLADERF)
+    set_property(SOURCE ${SRC_DIR}/radio_config.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DDEBUG_MODE ")
+endif()
+if(BLADERF-FSK_ENABLE_DEBUG_TEST_SUITE)
+    set_property(SOURCE ${SRC_DIR}/test_suite.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DDEBUG_MODE ")
+endif()
+
+if(BLADERF-FSK_ENABLE_NOTES_PHY)
+    set_property(SOURCE ${SRC_DIR}/phy.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DENABLE_NOTES ")
+endif()
+
+if(BLADERF-FSK_ENABLE_NOTES_LINK)
+    set_property(SOURCE ${SRC_DIR}/link.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DENABLE_NOTES ")
+endif()
+
+if(BLADERF-FSK_BYPASS_RX_CHANNEL_FILTER)
+    set_property(SOURCE ${SRC_DIR}/phy.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DBYPASS_RX_CHANNEL_FILTER ")
+endif()
+if(BLADERF-FSK_BYPASS_PHY_SCRAMBLING)
+    set_property(SOURCE ${SRC_DIR}/phy.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DBYPASS_PHY_SCRAMBLING ")
+endif()
+if(BLADERF-FSK_BYPASS_RX_PNORM)
+    set_property(SOURCE ${SRC_DIR}/phy.c APPEND_STRING PROPERTY COMPILE_FLAGS "-DBYPASS_RX_PNORM ")
+endif()
+
+################################################################################
+# Include paths
+################################################################################
+set (FSK_INCLUDE_DIRS
+        ${SRC_DIR}
+        ${BLADERF_HOST_COMMON_INCLUDE_DIRS}
+        ${libbladeRF_SOURCE_DIR}/include
+)
+
+if(MSVC)
+    set(FSK_INCLUDE_DIRS ${FSK_INCLUDE_DIRS} ${MSVC_C99_INCLUDES})
+    set(FSK_INCLUDE_DIRS ${FSK_INCLUDE_DIRS}
+        ${BLADERF_HOST_COMMON_INCLUDE_DIRS}/windows
+        ${LIBPTHREADSWIN32_INCLUDE_DIRS}
+    )
+endif()
+
+if(APPLE)
+    set(FSK_INCLUDE_DIRS ${FSK_INCLUDE_DIRS}
+        ${BLADERF_HOST_COMMON_INCLUDE_DIRS}/osx
+    )
+endif()
+
+include_directories(${FSK_INCLUDE_DIRS})
+
+################################################################################
+# Main bladeRF-fsk program
+################################################################################
+
+set(BLADERF_FSK_SRC
+    ${SRC_DIR}/bladeRF-fsk.c
+    ${SRC_DIR}/config.c
+    ${BLADERF_HOST_COMMON_SOURCE_DIR}/conversions.c
+    ${SRC_DIR}/radio_config.c
+    ${SRC_DIR}/fir_filter.c
+    ${SRC_DIR}/fsk.c
+    ${SRC_DIR}/prng.c
+    ${SRC_DIR}/phy.c
+    ${SRC_DIR}/crc32.c
+    ${SRC_DIR}/link.c
+    ${SRC_DIR}/utils.c
+    ${SRC_DIR}/pnorm.c
+    ${SRC_DIR}/correlator.c
+)
+
+if(MSVC)
+    set(BLADERF_FSK_SRC ${BLADERF_FSK_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/getopt_long.c
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
+    )
+endif()
+
+if(APPLE)
+    set(BLADERF_FSK_SRC ${BLADERF_FSK_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
+    )
+endif()
+
+# Set link libraries
+set(BLADERF_FSK_LIBS
+    libbladerf_shared
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+if(NOT MSVC)
+    set(BLADERF_FSK_LIBS ${BLADERF_FSK_LIBS} m)
+endif()
+
+if(LIBPTHREADSWIN32_FOUND)
+    set(BLADERF_FSK_LIBS ${BLADERF_FSK_LIBS} ${LIBPTHREADSWIN32_LIBRARIES})
+endif()
+
+if(LIBC_VERSION)
+    # clock_gettime() was moved from librt -> libc in 2.17
+    if(${LIBC_VERSION} VERSION_LESS "2.17")
+        set(BLADERF_FSK_LIBS ${BLADERF_FSK_LIBS} rt)
+    endif()
+endif()
+
+add_executable(bladeRF-fsk ${BLADERF_FSK_SRC})
+target_link_libraries(bladeRF-fsk ${BLADERF_FSK_LIBS})
+
+################################################################################
+# Installation of bladeRF-fsk program
+################################################################################
+if (NOT DEFINED BIN_INSTALL_DIR)
+    set(BIN_INSTALL_DIR bin)
+endif()
+
+install(TARGETS bladeRF-fsk DESTINATION ${BIN_INSTALL_DIR})
+
+################################################################################
+# Test suite program
+################################################################################
+
+set(TEST_SUITE_SRC
+    ${SRC_DIR}/radio_config.c
+    ${SRC_DIR}/fir_filter.c
+    ${SRC_DIR}/fsk.c
+    ${SRC_DIR}/prng.c
+    ${SRC_DIR}/crc32.c
+    ${SRC_DIR}/phy.c
+    ${SRC_DIR}/link.c
+    ${SRC_DIR}/test_suite.c
+    ${SRC_DIR}/utils.c
+    ${SRC_DIR}/pnorm.c
+    ${SRC_DIR}/correlator.c
+)
+
+if(MSVC)
+    set(TEST_SUITE_SRC ${TEST_SUITE_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
+    )
+endif()
+
+if(APPLE)
+    set(TEST_SUITE_SRC ${TEST_SUITE_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
+    )
+endif()
+
+# Set link libraries
+set(TEST_SUITE_LIBS
+    libbladerf_shared
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+if(NOT MSVC)
+    set(TEST_SUITE_LIBS ${TEST_SUITE_LIBS} m)
+endif()
+
+if(LIBPTHREADSWIN32_FOUND)
+    set(TEST_SUITE_LIBS ${TEST_SUITE_LIBS} ${LIBPTHREADSWIN32_LIBRARIES})
+endif()
+
+if(LIBC_VERSION)
+    # clock_gettime() was moved from librt -> libc in 2.17
+    if(${LIBC_VERSION} VERSION_LESS "2.17")
+        set(TEST_SUITE_LIBS ${TEST_SUITE_LIBS} rt)
+    endif()
+endif()
+
+add_executable(bladeRF-fsk_test_suite ${TEST_SUITE_SRC})
+target_link_libraries(bladeRF-fsk_test_suite ${TEST_SUITE_LIBS})
+
+################################################################################
+# Configuration test
+################################################################################
+
+set(TEST_CONFIG_SRC
+    ${SRC_DIR}/config.c
+    ${BLADERF_HOST_COMMON_SOURCE_DIR}/conversions.c
+)
+
+if(MSVC)
+    set(TEST_CONFIG_SRC ${TEST_CONFIG_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/getopt_long.c
+    )
+endif()
+
+# Set link libraries
+set(TEST_CONFIG_LIBS
+    libbladerf_shared
+)
+
+add_executable(bladeRF-fsk_test_config ${TEST_CONFIG_SRC})
+target_compile_definitions(bladeRF-fsk_test_config PRIVATE "-DCONFIG_TEST")
+target_link_libraries(bladeRF-fsk_test_config ${TEST_CONFIG_LIBS})
+
+################################################################################
+# CRC32 helpers and tools
+################################################################################
+
+set(CRC32_TEST_SRC ${SRC_DIR}/crc32.c)
+add_executable(bladeRF-fsk_test_crc32 ${CRC32_TEST_SRC})
+target_compile_definitions(bladeRF-fsk_test_crc32 PRIVATE "-DCRC32_TEST")
+
+################################################################################
+# PRNG test
+################################################################################
+
+set(PRNG_TEST_SRC ${SRC_DIR}/prng.c)
+add_executable(bladeRF-fsk_test_prng ${PRNG_TEST_SRC})
+target_compile_definitions(bladeRF-fsk_test_prng PRIVATE "-DPRNG_TEST")
+
+################################################################################
+# FIR Filter test
+################################################################################
+
+set(FIR_FILTER_TEST_SRC 
+    ${BLADERF_HOST_COMMON_SOURCE_DIR}/conversions.c
+    ${SRC_DIR}/fir_filter.c
+    ${SRC_DIR}/utils.c
+)
+
+if(MSVC)
+    set(FIR_FILTER_TEST_SRC ${FIR_FILTER_TEST_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
+    )
+endif()
+
+if(APPLE)
+    set(FIR_FILTER_TEST_SRC ${FIR_FILTER_TEST_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
+    )
+endif()
+
+# Set link libraries
+if(NOT MSVC)
+    set(FIR_FILTER_TEST_LIBS ${FIR_FILTER_TEST_LIBS} m)
+endif()
+
+if(LIBC_VERSION)
+    # clock_gettime() was moved from librt -> libc in 2.17
+    if(${LIBC_VERSION} VERSION_LESS "2.17")
+        set(FIR_FILTER_TEST_LIBS ${FIR_FILTER_TEST_LIBS} rt)
+    endif()
+endif()
+
+add_executable(bladeRF-fsk_test_fir_filter ${FIR_FILTER_TEST_SRC})
+target_compile_definitions(bladeRF-fsk_test_fir_filter PRIVATE "-DFIR_FILTER_TEST")
+target_link_libraries(bladeRF-fsk_test_fir_filter ${FIR_FILTER_TEST_LIBS})
+
+################################################################################
+# Correlator test
+################################################################################
+
+set(CORRELATOR_TEST_SRC 
+    ${SRC_DIR}/correlator.c
+    ${SRC_DIR}/utils.c
+    ${SRC_DIR}/fsk.c
+)
+
+if(MSVC)
+    set(CORRELATOR_TEST_SRC ${CORRELATOR_TEST_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
+    )
+endif()
+
+if(APPLE)
+    set(CORRELATOR_TEST_SRC ${CORRELATOR_TEST_SRC}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
+    )
+endif()
+
+# Set link libraries
+if(NOT MSVC)
+    set(CORRELATOR_TEST_LIBS ${CORRELATOR_TEST_LIBS} m)
+endif()
+
+if(LIBC_VERSION)
+    # clock_gettime() was moved from librt -> libc in 2.17
+    if(${LIBC_VERSION} VERSION_LESS "2.17")
+        set(CORRELATOR_TEST_LIBS ${CORRELATOR_TEST_LIBS} rt)
+    endif()
+endif()
+
+add_executable(bladeRF-fsk_test_correlator ${CORRELATOR_TEST_SRC})
+target_compile_definitions(bladeRF-fsk_test_correlator PRIVATE "-DCORRELATOR_TEST")
+target_link_libraries(bladeRF-fsk_test_correlator ${CORRELATOR_TEST_LIBS})
+
+################################################################################
+# Power normalizer test
+################################################################################
+set(PNORM_TEST_SRC ${SRC_DIR}/pnorm.c)
+
+# Set link libraries
+if(NOT MSVC)
+    set(PNORM_TEST_LIBS ${PNORM_TEST_LIBS} m)
+endif()
+
+add_executable(bladeRF-fsk_test_pnorm ${PNORM_TEST_SRC})
+target_compile_definitions(bladeRF-fsk_test_pnorm PRIVATE "-DPNORM_TEST")
+target_link_libraries(bladeRF-fsk_test_pnorm ${PNORM_TEST_LIBS})

--- a/host/utilities/bladeRF-fsk/c/src/README.txt
+++ b/host/utilities/bladeRF-fsk/c/src/README.txt
@@ -1,0 +1,16 @@
+CODE ORGANIZATION
+-----------------
+
+bladeRF-fsk.c                                   other files:
+    |___________                                utils.c - utility functions
+    |           |                               common.h - common definitions
+ link.c     config.c                            rx_ch_filter.h - FIR filter taps
+    |___________                                test_suite.c - tests
+    |           |
+  phy.c       crc32.c
+    |__________________________________________________________________________
+    |              |           |           |          |           |            |
+{libbladeRF}  radio_config.c  fsk.c   fir_filter.c  pnorm.c   correlator.c   prng.c
+    |
+    |
+{bladeRF device}

--- a/host/utilities/bladeRF-fsk/c/src/bladeRF-fsk.c
+++ b/host/utilities/bladeRF-fsk/c/src/bladeRF-fsk.c
@@ -1,0 +1,320 @@
+/**
+ * @file
+ * @brief   Top-level program that enables data transfer between two devices, using
+ *          link.c to send/receive data
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <pthread.h>
+#include <math.h>
+#include <libbladeRF.h>
+#include "host_config.h"
+
+#include "link.h"
+#include "config.h"
+
+//This should be a multiple of PAYLOAD_LENGTH for best throughput
+#define DATA_BUF_SIZE PAYLOAD_LENGTH
+
+struct bladerf_fsk_handle {
+    struct link_handle *link;
+    struct {
+        FILE *in;
+        long int filesize;
+        pthread_t thread;
+        bool stop;
+        bool on;
+    } tx;
+    struct {
+        FILE *out;
+        pthread_t thread;
+        bool stop;
+        bool on;
+    } rx;
+};
+
+void *sender(void *arg);
+void *receiver(void *arg);
+struct bladerf_fsk_handle *start(struct config *config);
+void stop(struct bladerf_fsk_handle *handle);
+
+/**
+ * Thread function which gets bytes from the user via either stdin or a file and sends
+ * them with link_send_data(). Thread will return when it encounters EOF. Setting 
+ * handle->tx.stop to true will not necessarily stop the thread since it may be stuck
+ * on fgets().
+ *
+ * @param[in]   arg     pointer to bladerf_fsk_handle
+ */
+void *sender(void *arg)
+{
+    int status;
+    struct bladerf_fsk_handle *handle = (struct bladerf_fsk_handle *) arg;
+    uint8_t tx_data[PAYLOAD_LENGTH];
+    char *result;
+    size_t num_bytes;
+    size_t bytes_sent;
+
+    bytes_sent = 0;
+    while(!handle->tx.stop){
+        //Get input data
+        if (handle->tx.in == stdin){
+            memset(tx_data, 0, sizeof(tx_data));
+            result = fgets((char *) tx_data, sizeof(tx_data), stdin);
+            if (result == NULL){
+                break;
+            }
+            num_bytes = sizeof(tx_data);
+        }else{
+            //Print progress
+            fprintf(stderr, "\rSent: %d%%   ",
+                    (int)roundf((float)bytes_sent/handle->tx.filesize * 100));
+            //Read next chunk from file
+            num_bytes = fread(tx_data, 1, sizeof(tx_data), handle->tx.in);
+            if (num_bytes == 0){
+                fprintf(stderr, "\n");
+                break;    //EOF
+            }
+
+        }
+        //Transmit the message
+        status = link_send_data(handle->link, tx_data, (unsigned int)num_bytes);
+        if (status == -2){
+            fprintf(stderr, "ERROR: Transmission failed (no connection)\n");
+            break;
+        }else if (status != 0){
+            fprintf(stderr, "ERROR: Transmission failed (unexpected error)\n");
+            break;
+        }
+        bytes_sent += num_bytes;
+    }
+    return NULL;
+}
+
+/**
+ * Thread function which receives bytes with link_receive_data() and writes them
+ * to the output FILE pointer. Thread will return within 0.5 seconds if
+ * handle->rx_stop is true.
+ *
+ * @param[in]   arg     pointer to bladerf_fsk_handle
+ */
+void *receiver(void *arg)
+{
+    struct bladerf_fsk_handle *handle = (struct bladerf_fsk_handle *) arg;
+    uint8_t rx_data[PAYLOAD_LENGTH];
+    int bytes_received;
+    size_t nwritten;
+
+    while(!handle->rx.stop){
+        //Receive data into buffer
+        bytes_received = link_receive_data(handle->link, sizeof(rx_data), 1, rx_data);
+        if (bytes_received == 0){
+            continue;
+        }else if (bytes_received < 0){
+            fprintf(stderr, "ERROR: Receive data failed (unexpected error)\n");
+            continue;
+        }
+        //Write the received bytes
+        if (handle->rx.out == stdout){
+            //Doing this because on windows null characters print as spaces
+            printf("%s", rx_data);
+            fflush(stdout);
+        }else{
+            nwritten = fwrite(rx_data, 1, bytes_received, handle->rx.out);
+            if ((int)nwritten != bytes_received){
+                fprintf(stderr, "ERROR: Couldn't write received data to file: ");
+                perror("");
+            }
+        }
+    }
+    return NULL;
+}
+
+/*
+ * Initializes the link and starts the sender/receiver threads
+ * @param[in]   config      pointer to config struct specifying configuration info
+ *
+ * @return      pointer to bladerf_fsk_handle on success, NULL on failure
+ */
+struct bladerf_fsk_handle *start(struct config *config)
+{
+    int status;
+    struct bladerf_fsk_handle *handle;
+
+    //Check to see if FPGA is loaded
+    status = bladerf_is_fpga_configured(config->bladerf_dev);
+    if (status < 0){
+        fprintf(stderr, "Couldn't query FPGA configuration: %s\n",
+                bladerf_strerror(status));
+        return NULL;
+    }else if (status == 0){
+        fprintf(stderr, "FPGA is not loaded on bladeRF device. "
+                        "Load the FPGA or configure autoloading.\n");
+        return NULL;
+    }
+
+    //Allocate memory for bladerf-fsk handle
+    handle = calloc(1, sizeof(handle[0]));
+    if (handle == NULL){
+        perror("calloc");
+        goto error;
+    }
+
+    //Set input/output files
+    handle->tx.in = config->tx_input;
+    handle->tx.filesize = config->tx_filesize;
+    handle->rx.out = config->rx_output;
+
+    //Init the link
+    handle->link = link_init(config->bladerf_dev, &config->params);
+    if (handle->link == NULL){
+        goto error;
+    }
+
+    //Start the receiver thread
+    status = pthread_create(&(handle->rx.thread), NULL, receiver, handle);
+    if (status != 0){
+        fprintf(stderr, "Couldn't create rx thread: %s\n", strerror(status));
+        goto error;
+    }
+    handle->rx.on = true;
+
+    //Start the sender thread
+    status = pthread_create(&(handle->tx.thread), NULL, sender, handle);
+    if (status != 0){
+        fprintf(stderr, "Couldn't create tx thread: %s\n", strerror(status));
+        goto error;
+    }
+    handle->tx.on = true;
+
+    return handle;
+
+    error:
+        stop(handle);
+        config_deinit(config);
+        return NULL;
+}
+
+/**
+ * Stop tx/rx threads and close/free all resources
+ *
+ * @param[in]   handle      pointer to bladerf_fsk_handle to stop
+ */
+void stop(struct bladerf_fsk_handle *handle)
+{
+    int status;
+    if (handle != NULL){
+        //Stop tx thread if on
+        if (handle->tx.on){
+            handle->tx.stop = true;
+            status = pthread_join(handle->tx.thread, NULL);
+            if (status != 0){
+                fprintf(stderr, "Error joining tx thread: %s\n", strerror(status));
+            }
+        }
+        //Stop rx thread if on
+        if (handle->rx.on){
+            handle->rx.stop = true;
+            status = pthread_join(handle->rx.thread, NULL);
+            if (status != 0){
+                fprintf(stderr, "Error joining rx thread: %s\n", strerror(status));
+            }
+        }
+        //Close the link
+        link_close(handle->link);
+    }
+    free(handle);
+}
+
+/**
+ * Run bladeRF-fsk
+ */
+int main(int argc, char *argv[])
+{
+    struct config *config = NULL;
+    struct bladerf_fsk_handle *handle = NULL;
+    int status;
+
+    //parse arguments
+    status = config_init_from_cmdline(argc, argv, &config);
+    if (status < 0) {
+        return status;
+    } else if (status == 1) {
+        printf( 
+            "Usage: %s <options>\n"
+            "bladeRF-to-bladeRF text/file transfer program based on a custom FSK software modem\n\n"
+            "Options:\n",
+            argv[0]
+        );
+        config_print_options();
+        printf(
+            "\n"
+            "Notes:\n"
+            "  The -d option takes a device specifier string. See the bladerf_open()\n"
+            "  documentation for more information about the format of this string.\n"
+            "\n"
+            "Example: Text chat between two devices at 904MHz/924MHz with TX gain adjusted.\n"
+            "  Device 1> bladeRF-fsk -d *:serial=4a -r 904M -t 924M --tx-vga2 5\n"
+            "  Device 2> bladeRF-fsk -d *:serial=f0 -r 924M -t 904M --tx-vga2 5\n"
+            "Example: File transfer between two devices at 904MHz/924MHz.\n"
+            "  Receiver   > bladeRF-fsk -d *:serial=4a -r 904M -t 924M -o rx.jpg\n"
+            "  Transmitter> bladeRF-fsk -d *:serial=f0 -r 924M -t 904M -i puppy.jpg\n\n"
+        );
+        return 0;
+    } else if (status > 0) {
+        fprintf(stderr, "Unexpected return value: %d\n", status);
+        return status;
+    }
+
+    if (config->quiet == false){
+        printf("=============== bladeRF-fsk ================\n");
+    }
+    //Initialize the bladeRF-fsk handle
+    handle = start(config);
+    if (handle == NULL){
+        fprintf(stderr, "ERROR: Couldn't start bladeRF-fsk\n");
+        return 1;
+    }
+    if (handle->tx.in == stdin && config->quiet == false){
+        #if BLADERF_OS_WINDOWS
+            printf("----  Press CTRL-Z then ENTER to quit   ----\n");
+        #else
+            printf("----        Press CTRL-D to quit        ----\n");
+        #endif
+        printf("\n");
+    }
+
+    //Wait for TX thread function to end - meaning tx file ended
+    status = pthread_join(handle->tx.thread, NULL);
+    if (status != 0){
+        fprintf(stderr, "Error joining tx thread\n");
+    }
+    handle->tx.on = false;
+
+    if (config->quiet == false){
+        printf("\nQuitting...\n");
+    }
+    //Stop/cleanup everything else
+    stop(handle);
+    config_deinit(config);
+}

--- a/host/utilities/bladeRF-fsk/c/src/common.h
+++ b/host/utilities/bladeRF-fsk/c/src/common.h
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * @brief   Common data structures
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <stdint.h>
+#include <libbladeRF.h>
+
+struct complex_sample {
+    int16_t i;
+    int16_t q;
+};
+
+struct radio_params {
+    //TX
+    unsigned int tx_freq;
+    int tx_vga1_gain;    //Range: -35 to -4 dB
+    int tx_vga2_gain;    //Range: 0 to 25 dB
+    //RX
+    unsigned int rx_freq;
+    bladerf_lna_gain rx_lna_gain;    //Range: 0 to 6 dB
+    int rx_vga1_gain;    //Range: 5 to 30 dB
+    int rx_vga2_gain;    //Range: 0 to 30 dB
+};
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/config.c
+++ b/host/utilities/bladeRF-fsk/c/src/config.c
@@ -1,0 +1,448 @@
+/**
+ * @brief   Gets configuration options from command line arguments
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <getopt.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+#include "config.h"
+#include "conversions.h"
+
+#ifdef DEBUG_CONFIG
+#   define pr_dbg(...) fprintf(stderr, "[CONFIG] " __VA_ARGS__)
+#else
+#   define pr_dbg(...) do {} while (0)
+#endif
+
+#define OPTIONS "hd:r:o:t:i:q"
+
+#define OPTION_HELP     'h'
+#define OPTION_DEVICE   'd'
+#define OPTION_QUIET    'q'
+
+#define OPTION_RXFREQ   'r'
+#define OPTION_INPUT    'i'
+#define OPTION_RXLNA    0x80
+#define OPTION_RXVGA1   0x81
+#define OPTION_RXVGA2   0x82
+
+#define OPTION_TXFREQ   't'
+#define OPTION_OUTPUT   'o'
+#define OPTION_TXVGA1   0x90
+#define OPTION_TXVGA2   0x91
+
+#define RX_FREQ_DEFAULT 904000000
+#define RX_LNA_DEFAULT  BLADERF_LNA_GAIN_MAX
+#define RX_VGA1_DEFAULT BLADERF_RXVGA1_GAIN_MAX
+#define RX_VGA2_DEFAULT BLADERF_RXVGA2_GAIN_MIN
+
+#define TX_FREQ_DEFAULT 924000000
+#define TX_VGA1_DEFAULT BLADERF_TXVGA1_GAIN_MAX
+#define TX_VGA2_DEFAULT BLADERF_TXVGA2_GAIN_MIN
+
+static struct option long_options[] = {
+    { "help",     no_argument,        NULL,   OPTION_HELP     },
+    { "device",   required_argument,  NULL,   OPTION_DEVICE   },
+    { "quiet",    no_argument,        NULL,   OPTION_QUIET    },
+
+    { "output",   required_argument,  NULL,   OPTION_OUTPUT   },
+    { "rx-lna",   required_argument,  NULL,   OPTION_RXLNA    },
+    { "rx-vga1",  required_argument,  NULL,   OPTION_RXVGA1   },
+    { "rx-vga2",  required_argument,  NULL,   OPTION_RXVGA2   },
+    { "rx-freq",  required_argument,  NULL,   OPTION_RXFREQ   },
+
+    { "input",    required_argument,  NULL,   OPTION_INPUT    },
+    { "tx-vga1",  required_argument,  NULL,   OPTION_TXVGA1   },
+    { "tx-vga2",  required_argument,  NULL,   OPTION_TXVGA2   },
+    { "tx-freq",  required_argument,  NULL,   OPTION_TXFREQ   },
+
+    { NULL,       0,                  NULL,   0               },
+};
+
+const struct numeric_suffix freq_suffixes[] = {
+    { "k",      1000 },
+    { "KHz",    1000 },
+
+    { "M",      1000 * 1000 },
+    { "MHz",    1000 * 1000 },
+
+    { "G",      1000 * 1000 * 1000 },
+    { "GHz",    1000 * 1000 * 1000 },
+};
+
+static const size_t num_freq_suffixes =
+    sizeof(freq_suffixes) / sizeof(freq_suffixes[0]);
+
+static struct config *alloc_config_with_defaults()
+{
+    struct config *config;
+
+    config = calloc(1, sizeof(*config));
+    if (!config) {
+        perror("calloc");
+        return NULL;
+    }
+
+    /* RX defaults */
+    config->rx_output            = NULL;
+
+    config->params.rx_freq        = RX_FREQ_DEFAULT;
+
+    config->params.rx_lna_gain    = RX_LNA_DEFAULT;
+    config->params.rx_vga1_gain    = RX_VGA1_DEFAULT;
+    config->params.rx_vga2_gain    = RX_VGA2_DEFAULT;
+
+
+    /* TX defaults */
+    config->tx_input            = NULL;
+
+    config->params.tx_freq        = TX_FREQ_DEFAULT;
+
+    config->params.tx_vga1_gain    = TX_VGA1_DEFAULT;
+    config->params.tx_vga2_gain    = TX_VGA2_DEFAULT;
+
+    return config;
+}
+
+/* Initialize configuration items not provided by user */
+static int init_remaining_params(struct config *config)
+{
+    int status;
+
+    if (config->bladerf_dev == NULL) {
+        status = bladerf_open(&config->bladerf_dev, NULL);
+        if (status != 0) {
+            fprintf(stderr, "Failed to open any available bladeRF: %s\n",
+                    bladerf_strerror(status));
+            return status;
+        }
+    }
+
+    if (config->rx_output == NULL) {
+        config->rx_output = stdout;
+    }
+
+    if (config->tx_input == NULL) {
+        config->tx_input = stdin;
+        config->tx_filesize = -1;
+    }
+
+    return 0;
+}
+
+int config_init_from_cmdline(int argc, char * const argv[],
+                             struct config **config_out)
+{
+    int status = 0;
+    struct config *config = NULL;
+    int c, idx;
+    bool valid;
+    struct stat file_info;
+
+    config = alloc_config_with_defaults();
+    if (config == NULL) {
+        pr_dbg("%s: Failed to alloc config.\n", __FUNCTION__);
+        return -2;
+    }
+
+    while ((c = getopt_long(argc, argv, OPTIONS, long_options, &idx)) != -1) {
+        switch (c) {
+            case OPTION_HELP:
+                status = 1;
+                goto out;
+
+            case OPTION_DEVICE:
+                if (config->bladerf_dev == NULL) {
+                    status = bladerf_open(&config->bladerf_dev, optarg);
+                    if (status < 0) {
+                        fprintf(stderr, "Failed to open bladeRF=%s: %s\n",
+                                optarg, bladerf_strerror(status));
+                        goto out;
+                    }
+                }
+                break;
+
+            case OPTION_OUTPUT:
+                if (config->rx_output == NULL) {
+                    if (!strcasecmp(optarg, "stdout")) {
+                        config->rx_output = stdout;
+                    } else {
+                        config->rx_output = fopen(optarg, "wb");
+                        if (config->rx_output == NULL) {
+                            status = -errno;
+                            fprintf(stderr, "Failed to open %s for writing: %s\n",
+                                    optarg, strerror(-status));
+                            goto out;
+                        }
+                    }
+                }
+                break;
+
+            case OPTION_RXLNA:
+                status = str2lnagain(optarg, &config->params.rx_lna_gain);
+                if (status != 0) {
+                    fprintf(stderr, "Invalid RX LNA gain: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+            case OPTION_RXVGA1:
+                config->params.rx_vga1_gain =
+                    str2int(optarg,
+                            BLADERF_RXVGA1_GAIN_MIN,
+                            BLADERF_RXVGA1_GAIN_MAX,
+                            &valid);
+
+                if (!valid) {
+                    status = -1;
+                    fprintf(stderr, "Invalid RX VGA1 gain: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+            case OPTION_RXVGA2:
+                config->params.rx_vga2_gain =
+                    str2int(optarg,
+                            BLADERF_RXVGA2_GAIN_MIN,
+                            BLADERF_RXVGA2_GAIN_MAX,
+                            &valid);
+
+                if (!valid) {
+                    status = -1;
+                    fprintf(stderr, "Invalid RX VGA2 gain: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+            case OPTION_RXFREQ:
+                config->params.rx_freq =
+                    str2uint_suffix(optarg,
+                                    BLADERF_FREQUENCY_MIN,
+                                    BLADERF_FREQUENCY_MAX,
+                                    freq_suffixes, num_freq_suffixes,
+                                    &valid);
+
+                if (!valid) {
+                    status = -1;
+                    fprintf(stderr, "Invalid RX frequency: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+
+            case OPTION_INPUT:
+                if (config->tx_input == NULL) {
+                    if (!strcasecmp(optarg, "stdin")) {
+                        config->tx_input = stdin;
+                        config->tx_filesize = -1;
+                    } else {
+                        config->tx_input = fopen(optarg, "rb");
+                        if (config->tx_input == NULL) {
+                            status = -errno;
+                            fprintf(stderr, "Failed to open %s for reading: %s\n",
+                                    optarg, strerror(-status));
+                            goto out;
+                        }
+                        //Get file size
+                        status = stat(optarg, &file_info);
+                        if (status != 0){
+                            fprintf(stderr, "Couldn't filesize of %s: %s\n",
+                                    optarg, strerror(status));
+                        }
+                        config->tx_filesize = file_info.st_size;
+                    }
+                }
+                break;
+
+            case OPTION_TXVGA1:
+                config->params.tx_vga1_gain =
+                    str2int(optarg,
+                            BLADERF_TXVGA1_GAIN_MIN,
+                            BLADERF_TXVGA2_GAIN_MAX,
+                            &valid);
+
+                if (!valid) {
+                    status = -1;
+                    fprintf(stderr, "Invalid TX VGA1 gain: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+            case OPTION_TXVGA2:
+                config->params.tx_vga2_gain =
+                    str2int(optarg,
+                            BLADERF_TXVGA2_GAIN_MIN,
+                            BLADERF_TXVGA2_GAIN_MAX,
+                            &valid);
+
+                if (!valid) {
+                    status = -1;
+                    fprintf(stderr, "Invalid TX VGA2 gain: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+            case OPTION_TXFREQ:
+                config->params.tx_freq =
+                    str2uint_suffix(optarg,
+                                    BLADERF_FREQUENCY_MIN,
+                                    BLADERF_FREQUENCY_MAX,
+                                    freq_suffixes, num_freq_suffixes,
+                                    &valid);
+                if (!valid) {
+                    status = -1;
+                    fprintf(stderr, "Invalid TX frequency: %s\n", optarg);
+                    goto out;
+                }
+                break;
+
+            case OPTION_QUIET:
+                config->quiet = true;
+                break;
+        }
+    }
+
+    /* Initialize any properties not covered by user input */
+    status = init_remaining_params(config);
+
+out:
+    if (status != 0) {
+        config_deinit(config);
+        *config_out = NULL;
+    } else {
+        *config_out = config;
+    }
+
+    return status;
+}
+
+void config_deinit(struct config *config)
+{
+    if (config == NULL) {
+        pr_dbg("%s: NULL ptr\n", __FUNCTION__);
+        return;
+    }
+
+    pr_dbg("Deinitializing...\n");
+
+    if (config->bladerf_dev != NULL) {
+        pr_dbg("\tClosing bladerf.\n");
+        bladerf_close(config->bladerf_dev);
+        config->bladerf_dev = NULL;
+    }
+if (config->rx_output != NULL) {
+        fclose(config->rx_output);
+        config->rx_output = NULL;
+    }
+
+    if (config->tx_input != NULL) {
+        fclose(config->tx_input);
+        config->tx_input = NULL;
+    }
+
+    free(config);
+}
+
+void config_print_options()
+{
+    printf(
+
+"   -h, --help              Show this help text.\n"
+"   -d, --device <str>      Open the specified bladeRF device.\n"
+"                            Any available device is used if not specified.\n"
+"   -q, --quiet             Suppress printing of banner/exit messages.\n"
+"\n"
+"   -r, --rx-freq <freq>    RX frequency in Hz. Default: %d\n"
+"   -o, --output <file>     RX data output. stdout is used if not specified.\n"
+"   --rx-lna <value>        RX LNA gain. Values: bypass, mid, max (default)\n"
+"   --rx-vga1 <value>       RX VGA1 gain. Range: %d to %d. Default = %d.\n"
+"   --rx-vga2 <value>       RX VGA2 gain. Range: %d to %d. Default = %d.\n"
+"\n"
+"   -t, --tx-freq <freq>    TX frequency. Default: %d\n"
+"   -i, --input <file>      TX data input. stdin is used if not specified.\n"
+"   --tx-vga1 <value>       TX VGA1 gain. Range: %d to %d. Default = %d.\n"
+"   --tx-vga2 <value>       TX VGA2 gain. Range: %d to %d. Default = %d.\n",
+
+    RX_FREQ_DEFAULT,
+    BLADERF_RXVGA1_GAIN_MIN, BLADERF_RXVGA1_GAIN_MAX, RX_VGA1_DEFAULT,
+    BLADERF_RXVGA2_GAIN_MIN, BLADERF_RXVGA2_GAIN_MAX, RX_VGA2_DEFAULT,
+
+    TX_FREQ_DEFAULT,
+    BLADERF_TXVGA1_GAIN_MIN, BLADERF_TXVGA1_GAIN_MAX, TX_VGA1_DEFAULT,
+    BLADERF_TXVGA2_GAIN_MIN, BLADERF_TXVGA2_GAIN_MAX, TX_VGA2_DEFAULT
+
+    );
+}
+
+#ifdef CONFIG_TEST
+void print_test_help(const char *argv0)
+{
+    printf("Config structure test\n");
+    printf("Usage: %s [options]\n\n", argv0);
+    printf("Options:\n");
+    config_print_options();
+    printf("\n");
+}
+
+void print_config(const struct config *config)
+{
+    printf("bladeRF handle:     %p\n", config->bladerf_dev);
+    printf("\n");
+    printf("RX Parameters:\n");
+    printf("    Output handle:  %p\n", config->rx_output);
+    printf("    Frequency (Hz): %u\n", config->params.rx_freq);
+    printf("    LNA gain:       %d\n", config->params.rx_lna_gain);
+    printf("    VGA1 gain:      %d\n", config->params.rx_vga1_gain);
+    printf("    VGA2 gain:      %d\n", config->params.rx_vga2_gain);
+    printf("\n");
+    printf("TX Parameters:\n");
+    printf("    Input handle:   %p\n", config->tx_input);
+    printf("    Frequency (Hz): %u\n", config->params.tx_freq);
+    printf("    VGA1 gain:      %d\n", config->params.tx_vga1_gain);
+    printf("    VGA2 gain:      %d\n", config->params.tx_vga2_gain);
+    printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+    int status;
+    struct config *config = NULL;
+
+    status = config_init_from_cmdline(argc, argv, &config);
+    if (status < 0) {
+        return status;
+    } else if (status == 1) {
+        print_test_help(argv[0]);
+        return 0;
+    } else if (status > 0) {
+        fprintf(stderr, "Unexpected return value: %d\n", status);
+        return status;
+    }
+
+    print_config(config);
+    config_deinit(config);
+    return EXIT_SUCCESS;
+}
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/config.h
+++ b/host/utilities/bladeRF-fsk/c/src/config.h
@@ -1,0 +1,67 @@
+/**
+ * @file
+ * @brief   Gets configuration options from command line arguments
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <libbladeRF.h>
+
+#include "common.h"
+
+/**
+ * Application configuration parameters
+ */
+struct config {
+    struct bladerf *bladerf_dev;    //bladeRF device handle
+    struct radio_params params;     //Radio parameters: gains and frequencies
+    FILE *rx_output;                //File to write received data to
+    FILE *tx_input;                 //File to read transmitted data from
+    long int tx_filesize;           //Size of the tx_input file, if it is not stdin
+    bool quiet;                     //Option to suppress printing of banner message
+};
+
+
+/**
+ * Create and intialize an application configuration from command line arguments
+ *
+ * @param[in]   argc    argc from main()
+ * @param[in]   argv    argv from main()
+ * @param[out]  c       Updated to point to configuration struture on success,
+ *                      or NULL on non-zero return.
+ *
+ * @return 0 on success
+ *         1 on request for help text
+ *        <0 on failure
+ */
+int config_init_from_cmdline(int argc, char * const argv[], struct config **c);
+
+/**
+ * Deinitialize and deallocate a configuration structure and all of its members
+ *
+ * @param   c       Configuration to deinitialize
+ */
+void config_deinit(struct config *c);
+
+/**
+ * Print help text for options parsed by config_init_from_cmdline()
+ */
+void config_print_options();

--- a/host/utilities/bladeRF-fsk/c/src/correlator.c
+++ b/host/utilities/bladeRF-fsk/c/src/correlator.c
@@ -1,0 +1,394 @@
+/**
+ * @brief   Cross correlates the input waveform with the preamble waveform and
+ *          detects peaks
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <limits.h>
+#include <inttypes.h>
+
+#include "correlator.h"
+#include "host_config.h"
+
+#ifdef ENABLE_CORR_DEBUG_MSG
+#   define DBG(...) fprintf(stderr, "[Corr]  " __VA_ARGS__)
+#else
+#   define DBG(...)
+#endif
+
+#define COUNTDOWN_INACTIVE  (UINT_MAX)
+
+#define LOG_FILE_SUFFIX  "_correlator_log.csv"
+
+struct complexf {
+    float real;
+    float imag;
+};
+
+struct correlator {
+    struct complexf *ref;       /* Reference signal to correlate against */
+    size_t len;                 /* Length of reference sig, insamples */
+
+    float threshold_pwr;        /* Correlation power threshold */
+
+    float max;                  /* Max correlation value we've seen so far */
+
+    unsigned int num_counts;    /* Number of samples to observe after a
+                                 * detected correlation and before asserting
+                                 * a match. This is intended to ensure we
+                                 * we report the local maxima.
+                                 */
+
+    unsigned int countdown;     /* Countdown until a value exceeding the
+                                 * max value is reported */
+
+    uint64_t match_timestamp;   /* Timestamp when we found our max
+                                 * correlation value */
+
+    struct complexf *buf;       /* Sample buffer */
+    struct complexf *ins1;      /* Insertion points */
+    struct complexf *ins2;
+    struct complexf *end;       /* Pointer to element past buf */
+
+#   ifdef LOG_CORRELATOR_OUTPUT
+    FILE *out;
+#   endif
+};
+
+#ifdef LOG_CORRELATION_SIGNAL
+static void save_reference_sig(struct complexf *ref, size_t len)
+{
+    size_t i;
+    FILE *out = fopen("corr_sig.csv", "w");
+    if (out == NULL) {
+        perror("fopen");
+        return;
+    }
+
+    for (i = 0; i < len; i++) {
+        fprintf(out, "%f,%f\n", ref[i].real, ref[i].imag);
+    }
+
+    fclose(out);
+}
+#endif
+
+struct correlator *corr_init(uint8_t *syms, size_t n, unsigned int sps)
+{
+    int status = -1;
+    size_t i;
+    struct correlator *ret = NULL;
+    struct fsk_handle *fsk = NULL;
+    struct complex_sample *raw_samples = NULL;
+#ifdef LOG_CORRELATOR_OUTPUT
+    char log_name[] = "correlator_log.csv";
+#endif
+
+    if (n < 8 || (n % 8 != 0)) {
+        fprintf(stderr, "Number of correlation symbols must be a multiple of 8.\n");
+        return NULL;
+    } else if (sps < 1) {
+        fprintf(stderr, "SPS must be >= 1.\n");
+        return NULL;
+    }
+
+    ret = calloc(1, sizeof(ret[0]));
+    if (ret == NULL) {
+        perror("malloc");
+        goto out;
+    }
+
+#   ifdef LOG_CORRELATOR_OUTPUT
+    ret->out = fopen(log_name, "w");
+    if (ret->out == NULL) {
+        perror("fopen");
+        goto out;
+    }
+#   endif
+
+    //Length is the ceiling of (sps*n/DECIMATION_FACTOR)
+    ret->len = 1 + (sps*n-1)/DECIMATION_FACTOR;
+
+    ret->ref = malloc(ret->len * sizeof(ret->ref[0]));
+    if (ret->ref == NULL) {
+        perror("malloc");
+        goto out;
+    }
+
+    /* Buffer is 2x as a means to implement a shift register using
+     * moving insertion points */
+    ret->buf = malloc(2 * ret->len * sizeof(ret->buf[0]));
+    if (ret->buf == NULL) {
+        perror("malloc");
+        goto out;
+    }
+
+    raw_samples = malloc(sps * n * sizeof(raw_samples[0]));
+    if (raw_samples == NULL) {
+        perror("malloc");
+        goto out;
+    }
+
+    //generate preamble waveform
+    fsk = fsk_init();
+    if (fsk == NULL){
+        fprintf(stderr, "Couldn't initialize FSK modulator\n");
+        goto out;
+    }
+    fsk_mod(fsk, syms, (int)n/8, raw_samples);
+    //Convert sc16q11 to complexf and decimate
+       for (i = 0; i < ret->len; i ++){
+        ret->ref[i].real = raw_samples[i*DECIMATION_FACTOR].i/2048.0f;
+        ret->ref[i].imag = raw_samples[i*DECIMATION_FACTOR].q/2048.0f;
+       }
+
+    /* Take the complex conjugate of our modulated reference signal
+     * to avoid needing to do this each time we perform a dot product
+     * operation later */
+    for (i = 0; i < ret->len; i++) {
+        ret->ref[i].imag = -ret->ref[i].imag;
+    }
+
+    ret->end = &ret->buf[2 * ret->len];
+    //Maximum power is ret->len/DECIMATION_FACTOR * ret->len/DECIMATION_FACTOR
+    ret->threshold_pwr = ret->len * ret->len * 0.5625f;
+
+    ret->num_counts = sps/DECIMATION_FACTOR - 1;
+
+    corr_reset(ret);
+
+#   ifdef LOG_CORRELATION_SIGNAL
+    save_reference_sig(ret->ref, ret->len);
+#   endif
+
+    status = 0;
+
+    DBG("Correlator decimation factor = %u\n", DECIMATION_FACTOR);
+    DBG("Correlator length: %zd symbols (%zd samples)\n",
+        n, ret->len);
+
+    DBG("Correlator power threshold: %f\n", ret->threshold_pwr);
+
+
+out:
+    if (status != 0) {
+        corr_deinit(ret);
+        ret = NULL;
+    }
+
+    fsk_close(fsk);
+    free(raw_samples);
+
+    return ret;
+}
+
+void corr_deinit(struct correlator *corr)
+{
+    if (corr) {
+        free(corr->ref);
+        free(corr->buf);
+
+#       ifdef LOG_CORRELATOR_OUTPUT
+        if (corr->out != NULL) {
+            fclose(corr->out);
+        }
+#       endif
+
+        free(corr);
+    }
+}
+
+static inline void reset_insertion_points(struct correlator *corr)
+{
+    corr->ins1 = corr->buf;
+    corr->ins2 = corr->buf + corr->len;
+}
+
+void corr_reset(struct correlator *corr)
+{
+    size_t i;
+
+    if (corr != NULL) {
+        reset_insertion_points(corr);
+        corr->match_timestamp = CORRELATOR_NO_RESULT;
+        corr->max = corr->threshold_pwr;
+        corr->countdown = COUNTDOWN_INACTIVE;
+
+        for (i = 0; i < (2 * corr->len); i++) {
+            corr->buf[i].real = corr->buf[i].imag = 0.0f;
+        }
+    }
+}
+
+uint64_t corr_process(struct correlator *corr,
+                      const struct complex_sample *samples, size_t n,
+                      uint64_t timestamp)
+{
+    size_t i, j;
+
+    uint64_t detected = CORRELATOR_NO_RESULT;
+
+    for (i = 0; i < n; i += DECIMATION_FACTOR) {
+        struct complexf *ref = corr->ref + corr->len - 1;
+        struct complexf *buf = corr->ins2;
+        struct complexf result;
+        float result_pwr;
+
+        /* Insert sample */
+        //Scale by 1/2048
+        corr->ins1->real = corr->ins2->real = samples[i].i/2048.0f;
+        corr->ins1->imag = corr->ins2->imag = samples[i].q/2048.0f;
+
+        result.real = result.imag = 0;
+
+        /* Cross correlate */
+        for (j = 0; j < corr->len; j ++) {
+            result.real += ref->real * buf->real - ref->imag * buf->imag;
+            result.imag += ref->real * buf->imag + ref->imag * buf->real;
+
+            ref--;
+            buf--;
+        }
+
+        result_pwr = result.real * result.real + result.imag * result.imag;
+
+#       ifdef LOG_CORRELATOR_OUTPUT
+        fprintf(corr->out, "%f, %"PRIu64"\n", result_pwr, timestamp);
+#       endif
+
+        if (result_pwr > corr->max) {
+            corr->max = result_pwr;
+            corr->countdown = corr->num_counts;
+            corr->match_timestamp = timestamp;
+
+            DBG("Got a match at %"PRIu64", result_pwr=%f. Resetting countdown.\n",
+                timestamp, result_pwr);
+
+        } else if (corr->countdown != COUNTDOWN_INACTIVE) {
+            //Find the peak
+
+            if (--corr->countdown == 0) {
+                /* We have a result! Exit early with it */
+                detected = corr->match_timestamp;
+
+                DBG("Countdown complete. Acquired at: %"PRIu64"\n", detected);
+
+                corr_reset(corr);
+                return detected;
+            } else {
+                DBG("Countdown @ %u\n", corr->countdown);
+            }
+        }
+
+        /* Update insertion points */
+        corr->ins2++;
+        if (corr->ins2 == corr->end) {
+            reset_insertion_points(corr);
+        } else {
+            corr->ins1++;
+        }
+
+        /* Update record of which timestamp we're on...*/
+        timestamp += 2;
+    }
+
+    return detected;
+}
+
+#ifdef CORRELATOR_TEST
+#include <string.h>
+#include <errno.h>
+#include "utils.h"
+
+static uint8_t code_a[] = { 0x2E, 0x69, 0x2C, 0xF0 };
+
+int main(int argc, char *argv[])
+{
+    FILE *in = NULL;
+    int16_t *raw_samples = NULL;
+    struct complex_sample *samples = NULL;
+    struct correlator *corr = NULL;
+    uint64_t timestamp = 0;
+    uint64_t acquisition = CORRELATOR_NO_RESULT;
+    int sps;
+    int i;
+    int status;
+
+    int num_samples;
+
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <CSV input file> <sps>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    num_samples = load_samples_from_csv_file(argv[1], false, 0, &raw_samples);
+    if (num_samples < 0){
+        fprintf(stderr, "Couldn't load samples from file\n");
+        return 1;
+    }
+    printf("Loaded %d samples\n", num_samples);
+
+    sps = atoi(argv[2]);
+
+    samples = malloc(num_samples * sizeof(samples[0]));
+    if (samples == NULL) {
+        perror("malloc");
+        goto out;
+    }
+
+    corr = corr_init(code_a, 8 * sizeof(code_a), sps);
+    if (corr == NULL) {
+        fprintf(stderr, "Failed to initialize correlator.\n");
+        goto out;
+    }
+
+    //Convert sc16q11 to complex_sample
+    for (i = 0; i < num_samples*2; i += 2){
+    samples[i/2].i = raw_samples[i];
+    samples[i/2].q = raw_samples[i+1];
+    }
+
+    acquisition = corr_process(corr, samples, num_samples, timestamp);
+
+    if (acquisition == CORRELATOR_NO_RESULT) {
+        printf("Correlation symbols not found.\n");
+    } else {
+        printf("Acquired Code. Acquisition = %lu\n", acquisition);
+    }
+
+    status = 0;
+
+out:
+    corr_deinit(corr);
+
+    if (in != NULL) {
+        fclose(in);
+    }
+
+    free(raw_samples);
+    free(samples);
+    return status;
+}
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/correlator.h
+++ b/host/utilities/bladeRF-fsk/c/src/correlator.h
@@ -1,0 +1,76 @@
+/**
+ * @file
+ * @brief   Cross correlates the input waveform with the preamble waveform and
+ *          detects peaks
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef CORRELATOR_H_
+#define CORRELATOR_H_
+
+#include <stdint.h>
+#include "common.h"
+#include "fsk.h"
+
+struct correlator;
+
+#define CORRELATOR_NO_RESULT   (UINT64_MAX)
+//Amount to decimate by. If 1, no decimation will occur. If 2, the correlator will
+//use every other sample. If 3 the correlator will use every third sample. And so on.
+#define DECIMATION_FACTOR 2
+
+/**
+ * Create a correlator. This is currently limited to symbol lengths that are
+ * a multiple of 8 (a byte).
+ *
+ * @param   syms                Symbols to correlate against
+ * @param   n                   Number of symbols in `syms`. Must be a multiple of 8.
+ * @param   sps                 Samples per symbol for modulation.
+ *
+ * @return correlator handle on success, NULL on failure
+ */
+struct correlator *corr_init(uint8_t *syms, size_t n, unsigned int sps);
+
+/**
+ * Deinitialize and deallocate the provided correlator
+ */
+void corr_deinit(struct correlator *corr);
+
+/**
+ * Reset the state of the corrlator. This should be done after a corr_process()
+ * returns a result.
+ */
+void corr_reset(struct correlator *corr);
+
+/**
+ * Process samples and return timestamp of when correlation occurred
+ *
+ * @param   samples     Samples to process
+ * @param   n           Number of provided samples
+ * @param   timestamp   Timestamp of first samples in `samples`
+ *
+ * @return The timestamp at which the correlation was found to occur,
+ *         or CORRELATOR_NO_RESULT if no match was detected.
+ */
+uint64_t corr_process(struct correlator *corr,
+                      const struct complex_sample *samples, size_t n,
+                      uint64_t timestamp);
+
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/crc32.c
+++ b/host/utilities/bladeRF-fsk/c/src/crc32.c
@@ -1,0 +1,179 @@
+/**
+ * @brief   CRC-32 implementation based upon examples provided in Chapter 14 of
+ *          Hacker's Delight (2nd Edition) by Henry S. Warren, Jr.
+ *
+ * http://www.hackersdelight.org
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+
+#include "host_config.h"
+#include "crc32.h"
+
+static uint32_t crc32_lut[256];
+
+uint32_t crc32(void *data, size_t len)
+{
+    size_t i;
+    uint8_t *bytes = (uint8_t *) data;
+    uint32_t crc = 0xffffffff;
+
+    for (i = 0; i < len; i++) {
+        crc = (crc >> 8) ^ crc32_lut[(crc ^ bytes[i]) & 0xff];
+    }
+
+    return ~crc;
+}
+
+#if defined(CRC32_TEST)
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+int main(int argc, char *argv[])
+{
+    FILE *in;
+    uint8_t *buf = NULL;
+    long file_len;
+    ssize_t n_read;
+    int status;
+    uint32_t crc;
+
+    if (argc != 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
+        fprintf(stderr, "%s <filename>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    in = fopen(argv[1], "rb");
+    if (!in) {
+        perror("fopen");
+        return EXIT_FAILURE;
+    }
+
+    status = fseek(in, 0, SEEK_END);
+    if (status != 0) {
+        perror("fseek");
+        goto out;
+    }
+
+    file_len = ftell(in);
+    if (file_len < 0) {
+        perror("ftell");
+        goto out;
+    }
+
+    status = fseek(in, 0, SEEK_SET);
+    if (status != 0) {
+        perror("fseek");
+        goto out;
+    }
+
+    buf = malloc(file_len);
+    if (!buf) {
+        perror("malloc");
+    }
+
+    n_read = fread(buf, 1, file_len, in);
+    if (n_read < 0) {
+        perror("fread");
+    }
+
+    crc = crc32(buf, file_len);
+    printf("%08x\n", crc);
+
+out:
+    free(buf);
+    fclose(in);
+    return status;
+}
+
+#elif defined(CRC32_GEN_TABLE)
+#include <stdio.h>
+int main(int argc, char *argv[])
+{
+    uint32_t crc, mask;
+    unsigned int i, j;
+    printf("staticx uint32_t crc32_lut[256] = {");
+
+    for (i = 0; i < 256; i++) {
+        crc = i;
+        for (j = 0; j < 8; j++) {
+            mask = -(crc & 1);
+            crc = (crc >> 1) ^ (0xedb88320 & mask);
+        }
+
+        /* Keep lines under 80 char */
+        if (i % 6 == 0) {
+            printf("\n   ");
+        }
+        printf(" 0x%08x,", crc);
+    }
+
+    printf("\n};\n");
+
+    return 0;
+}
+#endif
+
+static uint32_t crc32_lut[256] = {
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+    0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+    0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
+    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
+    0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+    0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
+    0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
+    0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
+    0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
+    0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+    0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
+    0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+    0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
+    0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
+    0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+    0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
+    0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+    0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
+    0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
+};

--- a/host/utilities/bladeRF-fsk/c/src/crc32.h
+++ b/host/utilities/bladeRF-fsk/c/src/crc32.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * @brief   CRC-32 implementation based upon examples provided in Chapter 14 of
+ *          Hacker's Delight (2nd Edition) by Henry S. Warren, Jr.
+ *
+ * http://www.hackersdelight.org
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef CRC32_CALC_H_
+#define CRC32_CALC_H_
+
+#include <stdint.h>
+
+/**
+ * Compute return a CRC32 checksum computed over the `len` bytes of `data`.
+ */
+uint32_t crc32(void *data, size_t len);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/fir_filter.c
+++ b/host/utilities/bladeRF-fsk/c/src/fir_filter.c
@@ -1,0 +1,277 @@
+/**
+ * @brief   Filters the input signal with the given FIR filter coefficients
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+
+#include "fir_filter.h"
+
+#ifdef ENABLE_FIR_FILTER_DEBUG_MSG
+#   define DBG(...) fprintf(stderr, "[FIR] " __VA_ARGS__)
+#else
+#   define DBG(...)
+#endif
+
+struct fir_filter {
+
+    float *taps;        /* Filter taps */
+    size_t length;      /* Length of the filter, in taps */
+
+    /* Interpolation or decimation factor */
+    unsigned int factor;
+
+    /* Insertion points into "shift register" implementation that utilizes
+     * two copies of data to achieve a contiguious shifting window. */
+    size_t ins1;
+    size_t ins2;
+
+    /* Filter state buffers */
+    int32_t *i;
+    int32_t *q;
+};
+
+static void fir_reset(struct fir_filter *filt)
+{
+    size_t n;
+
+    for (n = 0; n < (2 * filt->length); n++) {
+        filt->i[n] = 0;
+        filt->q[n] = 0;
+    }
+
+    /* Remember, state is 2 copies: array len is 2 * filt->length elts */
+    filt->ins1  = 0;
+    filt->ins2  = filt->length;
+}
+
+void fir_deinit(struct fir_filter *filt)
+{
+    if (filt) {
+        free(filt->q);
+        free(filt->i);
+        free(filt->taps);
+        free(filt);
+    }
+}
+
+struct fir_filter * fir_init(const float *taps, size_t length)
+{
+    struct fir_filter *filt;
+
+    filt = calloc(1, sizeof(filt[0]));
+    if (!filt) {
+        perror("calloc");
+        return NULL;
+    }
+
+    /* Filter state is a sliding window implemented with 2 copies of data */
+    filt->i = calloc(2 * length, sizeof(filt->i[0]));
+    if (!filt->i) {
+        perror("calloc");
+        fir_deinit(filt);
+        return NULL;
+    }
+
+    filt->q = calloc(2 * length, sizeof(filt->q[0]));
+    if (!filt->i) {
+        perror("calloc");
+        fir_deinit(filt);
+        return NULL;
+    }
+
+    filt->taps = calloc(length, sizeof(filt->taps[0]));
+    if (!filt->taps) {
+        perror("calloc");
+        fir_deinit(filt);
+        return NULL;
+    }
+
+    memcpy(filt->taps, taps, length * sizeof(filt->taps[0]));
+    filt->length = length;
+
+    fir_reset(filt);
+    return filt;
+}
+
+void fir_process(struct fir_filter *f, int16_t *input,
+                    struct complex_sample *output, size_t count)
+{
+    /* Index into input/output buffers */
+    size_t inout_idx;
+
+    /* Index into f->taps array */
+    size_t t;
+
+    /* Index into f->i and f->q state arrays */
+    size_t s;
+
+    for (inout_idx = 0; inout_idx < (2*count); inout_idx += 2) {
+        int32_t i = input[inout_idx];
+        int32_t q = input[inout_idx+1];
+        float result_i = 0;
+        float result_q = 0;
+
+        /* Insert samples */
+        f->i[f->ins1] = f->i[f->ins2] = i;
+        f->q[f->ins1] = f->q[f->ins2] = q;
+
+        /* Convolve */
+        for (t = 0, s = f->ins2; t < f->length; t++, s--) {
+            float tmp_i, tmp_q;
+
+            tmp_i = f->taps[t] * f->i[s];
+            tmp_q = f->taps[t] * f->q[s];
+
+            result_i += tmp_i;
+            result_q += tmp_q;
+        }
+
+        /* Update output sample */
+        output[inout_idx/2].i = (int16_t) roundf(result_i);
+        output[inout_idx/2].q = (int16_t) roundf(result_q);
+
+        /* Advance insertion points */
+        f->ins2++;
+        if (f->ins2 == (2 * f->length)) {
+            f->ins1 = 0;
+            f->ins2 = f->length;
+        } else {
+            f->ins1++;
+        }
+    }
+}
+
+#ifdef FIR_FILTER_TEST
+#include <stdbool.h>
+#include "conversions.h"
+#include "rx_ch_filter.h"
+#include "utils.h"
+
+int main(int argc, char *argv[])
+{
+    int status              = EXIT_FAILURE;
+    FILE *infile            = NULL;
+    FILE *outfile           = NULL;
+
+    int16_t *inbuf = NULL, *tempbuf = NULL;
+    struct complex_sample *outbuf = NULL;
+
+    struct fir_filter *filt = NULL;
+
+    static const unsigned int max_chunk_size = 1024 * 1024 * 1024;
+
+    unsigned int chunk_size = 4096;
+    size_t n_read, n_written;
+    bool done = false;
+
+    if (argc < 3 || argc > 4) {
+        fprintf(stderr,
+                "Filter sc16q11 samples from <infile> and write"
+                "them to <outfile>.\n\n");
+
+        fprintf(stderr,
+                "Usage: %s <infile> <outfile> [# chunk size(samples)]\n",
+                argv[0]);
+
+        return EXIT_FAILURE;
+    }
+
+    if (argc == 4) {
+        bool valid;
+        chunk_size = str2uint(argv[3], 1, max_chunk_size, &valid);
+        if (!valid) {
+            fprintf(stderr, "Invalid chunk size: %s samples\n", argv[3]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    filt = fir_init(rx_ch_filter, rx_ch_filter_len);
+    if (!filt) {
+        fprintf(stderr, "Failed to allocate filter.\n");
+        return EXIT_FAILURE;
+    }
+
+    inbuf = calloc(2*sizeof(int16_t), chunk_size);
+    if (!inbuf) {
+        perror("calloc");
+        goto out;
+    }
+    tempbuf = calloc(2*sizeof(int16_t), chunk_size);
+    if (!tempbuf) {
+        perror("calloc");
+        goto out;
+    }
+
+    outbuf = calloc(sizeof(struct complex_sample), chunk_size);
+    if (!outbuf) {
+        perror("calloc");
+        goto out;
+    }
+
+    infile = fopen(argv[1], "rb");
+    if (!infile) {
+        perror("Failed to open input file");
+        goto out;
+    }
+
+    outfile = fopen(argv[2], "wb");
+    if (!outfile) {
+        perror("Failed to open output file");
+        goto out;
+    }
+
+    while (!done) {
+        n_read = fread(inbuf, 2*sizeof(int16_t), chunk_size, infile);
+        done = n_read != chunk_size;
+
+        fir_process(filt, inbuf, outbuf, n_read);
+        //convert
+        conv_struct_to_samples(outbuf, (unsigned int) n_read, tempbuf);
+
+        n_written = fwrite(tempbuf, 2*sizeof(int16_t), n_read, outfile);
+        if (n_written != n_read) {
+            fprintf(stderr, "Short write encountered. Exiting.\n");
+            status = -1;
+            goto out;
+        }
+    }
+
+    status = 0;
+
+out:
+    if (infile) {
+        fclose(infile);
+    }
+
+    if (outfile) {
+        fclose(outfile);
+    }
+    free(tempbuf);
+    free(inbuf);
+    free(outbuf);
+    fir_deinit(filt);
+
+    return status;
+}
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/fir_filter.h
+++ b/host/utilities/bladeRF-fsk/c/src/fir_filter.h
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * @brief   Filters the input signal with the given FIR filter coefficients
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef FIR_FILTER_H_
+#define FIR_FILTER_H_
+
+#include "common.h"
+
+struct fir_filter;
+
+/**
+ * Construct a FIR filter with provided taps and decimation factor
+ *
+ * @param[in]   taps        Filter taps.
+ *
+ * @param[in]   num_tamps   Number of taps contained within `taps`
+ *
+ * @return      `fir_filter` handle on success,
+ *              or NULL on failure or invalid parameter
+ */
+struct fir_filter * fir_init(const float *taps, size_t num_taps);
+
+/**
+ * Deinitialize and deallocate the provided filter
+ *
+ * @param   filt        Filter to deinitialize
+ */
+void fir_deinit(struct fir_filter *filt);
+
+/**
+ * Perform filter operation over the provided samples
+ *
+ * @parm[in]    filt        Filter to use
+ *
+ * @param[in]   input       Input SC16Q11 samples
+ * @param[in]   output      Output SC16Q11 samples
+ * @param[in]   count       Number samples to process
+ *
+ */
+void fir_process(struct fir_filter *filt, int16_t *input,
+                    struct complex_sample *output, size_t count);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/fsk.c
+++ b/host/utilities/bladeRF-fsk/c/src/fsk.c
@@ -1,0 +1,304 @@
+/**
+ * @brief   FSK modulator/demodulator
+ *
+ * This file handles raw modulation and demodulation of bits using continuous-phase
+ * frequency shift keying (CPFSK). fsk_mod() takes in an array of bytes and produces
+ * a CPFSK signal in the form of baseband IQ samples. fsk_demod() takes in an array of
+ * CPFSK IQ samples and produces an array of bytes.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "fsk.h"
+
+#ifdef DEBUG_MODE
+    #define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
+#else
+    #define DEBUG_MSG(...)
+#endif
+
+//internal structs
+struct fsk_handle {
+    struct complex_sample *sample_table;
+    int points_per_rev;
+    int samp_per_symb;
+    //These variables keep track of the demodulator's state when a call to fsk_demod()
+    //did not fully demodulate the last byte, meaning it needs to be called again with
+    //more samples to finish demodulating that last byte
+    bool last_byte_demod_complete;  //False if the last byte was partially demodulated
+                                    //in a call to fsk_demod()
+    uint8_t last_byte;
+    double last_phase;
+    double curr_dphase_tot;
+    int curr_samp_index;            //Current samples index (0 - SAMP_PER_SYMB-1)
+    int curr_bit_index;
+};
+
+//internal functions
+static struct complex_sample *fsk_gen_samples_table(int points_per_rev);
+static double angle(int i, int q);
+static void angle_unwrap(double angle_prev, double *angle);
+
+/**
+ * Generate 16bit two's complement IQ samples (SC16 Q11 format) corresponding to angles
+ * from 0 to 2*pi on the unit circle. Range = [-2048, 2047]. Store in 'sample_table'.
+ * 0th index is at 1+j0 (2047 + j0). Next indices will rotate counter-clockwise around 
+ * the circle.
+ * Example: points_per_rev = 12 -> would produce:
+ *
+ *           |Q
+ *         . ' .
+ *       .   |   .
+ *    --.----+----.--I
+ *       .   |   .
+ *         . | .
+ *           '
+ *           |
+ *
+ * @param[in]   points_per_rev      number of points desired in one revolution (0-2*pi)
+ *                                  of the complex unit circle
+ *
+ * @return      pointer to array of complex samples
+ */
+static struct complex_sample *fsk_gen_samples_table(int points_per_rev)
+{
+    int i;
+    struct complex_sample *sample_table;
+
+    sample_table = malloc(points_per_rev*sizeof(struct complex_sample));
+    if (sample_table == NULL){
+        perror("malloc");
+        return NULL;
+    }
+
+    for (i = 0; i < points_per_rev; i++){
+        //Calculate cosine/sine samples. Round to nearest integer.
+        sample_table[i].i = (int16_t) round(2048.0*cos(i * 2.0 * M_PI / points_per_rev));
+        sample_table[i].q = (int16_t) round(2048.0*sin(i * 2.0 * M_PI / points_per_rev));
+        //Clamp values to [-2048, 2047]
+        if (sample_table[i].i > 2047){
+            sample_table[i].i = 2047;
+        }
+        if (sample_table[i].i < -2048){
+            sample_table[i].i = -2048;
+        }
+        if (sample_table[i].q > 2047){
+            sample_table[i].q = 2047;
+        }
+        if (sample_table[i].q < -2048){
+            sample_table[i].q = -2048;
+        }
+    }
+    return sample_table;
+}
+
+unsigned int fsk_mod(struct fsk_handle *fsk, uint8_t *data_buf, int num_bytes,
+                        struct complex_sample *samples)
+{
+
+    int samp_table_pos;        //current position in samples table
+    int byte;                //current byte (0-(num_bytes-1))
+    int bit;                //current bit (0-7) in byte
+    int samp;                //current sample in symbol period (0-(samps_per_symb-1))
+    int i;                    //index in samples buffer
+
+    //Set initial position to 0 (1 + 0j)
+    samp_table_pos = 0;
+    i = 0;
+    for (byte = 0; byte < num_bytes; byte++){
+        for (bit = 0; bit < 8; bit++){
+            //Check for 1
+            if ( ((data_buf[byte] >> bit) & 0x01) == 0x01 ){
+                //This bit is a 1. Rotate phase CCW
+                for (samp = 0; samp < fsk->samp_per_symb; samp++){
+                    if (samp_table_pos == fsk->points_per_rev - 1){
+                        samp_table_pos = 0;
+                    }else{
+                        samp_table_pos += 1;    //Increment phase
+                    }
+                    samples[i].i = fsk->sample_table[samp_table_pos].i;
+                    samples[i].q = fsk->sample_table[samp_table_pos].q;
+                    i++;
+                }
+            }else{
+                //This bit is a 0. Rotate phase CW
+                for (samp = 0; samp < fsk->samp_per_symb; samp++){
+                    if (samp_table_pos == 0){
+                        samp_table_pos = fsk->points_per_rev - 1;
+                    }else{
+                        samp_table_pos -= 1;    //Decrement phase
+                    }
+                    samples[i].i = fsk->sample_table[samp_table_pos].i;
+                    samples[i].q = fsk->sample_table[samp_table_pos].q;
+                    i++;
+                }
+            }
+        }
+    }
+    return i;
+}
+
+/**
+ * Unwrap a single angle so it is not wrapped to [-pi, pi]. Example: If angle_prev is 0.9*pi,
+ * and (*angle) is -0.9*pi, then (*angle) will be changed to 1.1*pi, so the large
+ * (discontinuous) phase jump is not seen.
+ *
+ * @param[in]       angle_prev      pointer to initial angle in radians
+ * @param[inout]    angle           pointer to final angle. If an angle jump greater than pi
+ *                                  or less than pi is found, this angle will be modified.
+ */
+static void angle_unwrap(double angle_prev, double *angle)
+{
+    double diff = *angle - angle_prev;
+    if (diff > M_PI){
+        //Subtract a multiple of 2*pi from the angle
+        *angle -= 2*M_PI * (int)( (diff+M_PI)/(2*M_PI) );
+    }else if (diff < -M_PI){
+        //Add a multiple of 2*pi to the angle
+        *angle += 2*M_PI * (int)( (diff-M_PI)/(-2*M_PI) );
+    }
+}
+
+/**
+ * Returns the angle of I+jQ, using the interval (-pi, pi)
+ */
+static double angle(int i, int q)
+{
+    double ratio = (double)q / (double)i;
+    if (i == 0 && q == 0){
+        return 0;    //Angle is undefined here. Just return 0.
+    }else if (i >= 0 && q >= 0){
+        return atan(ratio);
+    }else if (i < 0 && q >= 0){
+        return atan(ratio) + M_PI;
+    }else if (i < 0 && q < 0){
+        return atan(ratio) - M_PI;
+    }else{    //if (i >= 0 && q < 0)
+        return atan(ratio);
+    }
+}
+
+unsigned int fsk_demod(struct fsk_handle *fsk, struct complex_sample *samples,
+                    int num_samples, bool new_signal, int num_bytes, uint8_t *data_buf)
+{
+    int i;        //Current samples index (0 to num_samples-1)
+    int byte = 0;
+    int bit;
+    int samp;
+    double phase, phase_prev, dphase_tot;
+
+    i = 0;
+    if (new_signal){
+        //Reset everything, calculate initial phase
+        fsk->curr_samp_index = 0;
+        fsk->curr_dphase_tot = 0;
+        fsk->curr_bit_index = 0;
+        fsk->last_phase = angle(samples[0].i, samples[0].q);
+        i++;
+    }
+    phase = fsk->last_phase;
+    //Initialize byte appropriately if last demod was not fully completed
+    //(i.e. last byte was partially demodulated)
+    if (!fsk->last_byte_demod_complete){
+        data_buf[0] = fsk->last_byte;
+    }
+    //Loop through each byte
+    for (byte = 0; byte != num_bytes && i < num_samples; byte++){
+        //Loop through each bit in the byte
+        for (bit = fsk->curr_bit_index; bit < 8; bit++){
+            //Loop through SAMP_PER_SYMB samples and their corresponding changes in phase
+            //Stop if we reach the end of the samples buffer
+            dphase_tot = fsk->curr_dphase_tot;
+            for (samp = fsk->curr_samp_index; (samp < fsk->samp_per_symb) && i < num_samples;
+                    samp++){
+                phase_prev = phase;
+                phase = angle(samples[i].i, samples[i].q);
+                //Unwrap angle
+                angle_unwrap(phase_prev, &phase);
+                //Add this angle change to the total angle change
+                dphase_tot += phase - phase_prev;
+                i++;
+            }
+            //Check to see if we broke out of the loop before demodulating the full bit
+            if (samp != fsk->samp_per_symb){
+                //Set demod state information
+                fsk->last_byte_demod_complete = false;
+                fsk->last_byte = data_buf[byte];
+                fsk->last_phase = phase;
+                fsk->curr_dphase_tot = dphase_tot;
+                fsk->curr_samp_index = samp;
+                fsk->curr_bit_index = bit;
+                goto out;
+            }
+            if (dphase_tot > 0){
+                //Received a 1. Set bit to 1.
+                data_buf[byte] |= 0x01 << bit;
+            }else{
+                //Received a 0. Set bit to 0.
+                data_buf[byte] &= ~(0x01 << bit);
+            }
+            //Reset index variables
+            fsk->curr_samp_index = 0;
+            fsk->curr_dphase_tot = 0;
+        }
+        fsk->last_phase = phase;
+        fsk->curr_bit_index = 0;
+        fsk->last_byte_demod_complete = true;
+    }
+
+    out:
+        return byte;
+}
+
+struct fsk_handle *fsk_init(void)
+{
+    struct fsk_handle *fsk;
+
+    //Allocate memory for handle
+    fsk = malloc(sizeof(struct fsk_handle));
+    if (fsk == NULL){
+        perror("malloc");
+        return NULL;
+    }
+    //Set modulation/demodulation parameters
+    fsk->samp_per_symb = SAMP_PER_SYMB;
+    fsk->points_per_rev = POINTS_PER_REV;
+    //Generate the samples table
+    fsk->sample_table = fsk_gen_samples_table(POINTS_PER_REV);
+    if (fsk->sample_table == NULL){
+        fprintf(stderr, "Couldn't generate samples table\n");
+        free(fsk);
+        return NULL;
+    }
+    //Initialize demod state variables
+    fsk->last_byte_demod_complete = true;
+    fsk->last_byte = 0x00;
+    fsk->curr_dphase_tot = 0;
+    fsk->last_phase = 0;
+    fsk->curr_samp_index = 0;
+    fsk->curr_bit_index = 0;
+    return fsk;
+}
+
+void fsk_close(struct fsk_handle *fsk)
+{
+    if (fsk != NULL){
+        free(fsk->sample_table);
+    }
+    free(fsk);
+}

--- a/host/utilities/bladeRF-fsk/c/src/fsk.h
+++ b/host/utilities/bladeRF-fsk/c/src/fsk.h
@@ -1,0 +1,106 @@
+/**
+ * @file
+ * @brief   FSK modulator/demodulator
+ *
+ * This file handles raw modulation and demodulation of bits using continuous-phase
+ * frequency shift keying (CPFSK). fsk_mod() takes in an array of bytes and produces
+ * a CPFSK signal in the form of baseband IQ samples. fsk_demod() takes in an array of
+ * CPFSK IQ samples and produces an array of bytes.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef FSK_H
+#define FSK_H
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "common.h"
+
+/* 32 points per revolution and 8 samples per symbol means one quarter turn per
+   symbol = phase modulation index of pi/2 */
+
+//Sample points per one revolution of the complex IQ unit circle
+#define POINTS_PER_REV 32
+//Sample points per symbol
+#define SAMP_PER_SYMB 8
+//NOTE: If you change these^ two macros, you'll need to change the FIR channel
+//filter as well if you want the modem to work
+
+struct fsk_handle;
+
+/**
+ * Initialize an allocate memory for an fsk handle
+ *
+ * @return    pointer to allocated/initiailized fsk_handle on success, NULL on failure
+ */
+struct fsk_handle *fsk_init(void);
+
+/**
+ * Deinitialize / deallocate memory for an fsk handle
+ *
+ * @param   pointer to fsk handle to close
+ */
+void fsk_close(struct fsk_handle *fsk);
+
+/**
+ * Convert an array of bytes to an array of CPFSK modulated IQ samples
+ * Bit order: LSb transmitted first, MSb last
+ * This function assumes an initial phase of 0 (1 + 0j)
+ *
+ * @param[in]   fsk             pointer to fsk handle
+ * @param[in]   data_buf        bytes to transmit
+ * @param[in]   num_bytes       number of bytes to transmit from data_buf
+ * @param[out]  samples         buffer to place modulated IQ samples in
+ *
+ * @return      number of IQ samples modulated
+ */
+unsigned int fsk_mod(struct fsk_handle *fsk, uint8_t *data_buf, int num_bytes,
+                        struct complex_sample *samples);
+
+/**
+ * Convert an array of modulated CPFSK IQ samples into an array of bytes.
+ * Expected bit order: LSb arrives first, MSb arrives last.
+ * This function will still work when the number of samples line up in a way that the
+ * last byte is only partially demodulated (e.g. 3 of 8 bits demodulated, 6 of 8 samples
+ * processed from the 4th bit). It saves off its state to the fsk_handle struct, so in 
+ * the next call to fsk_demod(), it will resume and finish demodulating that byte.
+ *
+ * @param[in]   fsk             fsk_handle struct
+ * @param[in]   samples         Array of baseband IQ samples to demodulate
+ * @param[in]   num_samples     Number of samples in samples array
+ * @param[in]   new_signal      Is this a new FSK signal or a continuation of a previous one?
+ *                              If true, the first sample will define the initial phase. Otherwise,
+ *                              the previous phase (from last call to fsk_demod()) will define the
+ *                              initial phase.
+ * @param[in]   num_bytes       number of bytes to attempt to demodulate. If -1, the function will
+ *                              demod as many bytes as 'num_samples' will allow.
+ * @param[out]  data_buf        buffer to place demodulated bytes in
+ *
+ * @return      number of bytes demodulated. This number will be less than the 'num_bytes' parameter
+ *              if there weren't enough samples to demod 'num_bytes' bytes
+ */
+unsigned int fsk_demod(struct fsk_handle *fsk, struct complex_sample *samples,
+                    int num_samples, bool new_signal, int num_bytes, uint8_t *data_buf);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/link.c
+++ b/host/utilities/bladeRF-fsk/c/src/link.c
@@ -1,0 +1,1208 @@
+/**
+ * @brief   Link layer code for modem
+ *
+ * This file interfaces with phy.c through its transmit_data_frames() and
+ * receive_frames() functions.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "link.h"
+#include "phy.h"
+#include "crc32.h"
+#include "utils.h"
+
+#ifdef DEBUG_MODE
+    #define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
+    #ifndef ENABLE_NOTES
+        #define ENABLE_NOTES
+    #endif
+#else
+    #define DEBUG_MSG(...)
+#endif
+
+#ifdef ENABLE_NOTES
+    #define NOTE(...) fprintf(stderr, __VA_ARGS__)
+#else
+    #define NOTE(...)
+#endif
+
+/********************************************
+ *                                          *
+ *  PRIVATE FUNCTIONS AND DATA STRUCTURES   *
+ *                                          *
+ ********************************************/
+
+struct data_frame {
+    //Total frame length = 1009 bytes (8072 bits)
+    uint8_t type;               //0x00 = data frame, 0xFF = ack frame
+    uint16_t seq_num;           //Sequence number
+    uint16_t payload_length;    //Length of used payload data in bytes
+    uint8_t payload[PAYLOAD_LENGTH];    //payload data
+    uint32_t crc32;             //32-bit CRC
+};
+
+struct ack_frame {
+    //Total frame length = 7 bytes (56 bits)
+    uint8_t type;               //0x00 = data frame, 0xFF = ack frame
+    uint16_t ack_num;           //Acknowledgement number
+    uint32_t crc32;             //32-bit CRC
+};
+
+struct tx {
+    struct data_frame data_frame_buf;   //Input data frame buffer
+    struct ack_frame ack_frame_buf;     //Input ack frame buffer
+    bool stop;                          //Signal to stop tx thread
+    bool data_buf_filled;               //Is the data frame buffer filled
+    pthread_t thread;                   //Transmitter thread
+    pthread_cond_t data_buf_filled_cond;    //pthread condition corresponding to
+                                            //data_buf_filled
+    pthread_mutex_t data_buf_status_lock;   //Mutex for data_buf_filled_cond
+    bool link_on;   //Is the transmitter on
+    bool done;      //Has the transmitter finished a transmission
+    bool success;   //Was the transmitter transmission successful
+};
+
+struct rx {
+    struct data_frame data_frame_buf;   //Output data frame buffer
+    struct ack_frame ack_frame_buf;     //Output ack frame buffer
+    //Leftover bytes received but not returned to the user after a call to
+    //link_receive_data()
+    uint8_t extra_bytes[PAYLOAD_LENGTH];
+    unsigned int num_extra_bytes;       //Number of bytes in 'extra_bytes' buffer
+    pthread_t thread;                   //Receiver thread
+    bool stop;                          //Signal to stop rx thread
+    bool data_buf_filled;               //Is the data frame buffer filled
+    pthread_cond_t data_buf_filled_cond;    //pthread condition for data_buf_filled
+    pthread_mutex_t data_buf_status_lock;   //mutex for data_buf_filled_cond
+    bool ack_buf_filled;                    //Is the ack frame buffer filled
+    pthread_cond_t ack_buf_filled_cond;     //pthread condition for ack_buf_filled
+    pthread_mutex_t ack_buf_status_lock;    //mutex for ack_buf_filled_cond
+    bool link_on;                           //Is the receiver on
+};
+
+struct link_handle {
+    struct phy_handle *phy;
+    struct tx *tx;
+    struct rx *rx;
+    bool phy_tx_on;     //Is the phy transmitter on
+    bool phy_rx_on;     //Is the phy receiver on
+};
+
+//internal functions
+//tx:
+static int start_transmitter(struct link_handle *link);
+static int stop_transmitter(struct link_handle *link);
+void *transmit_data_frames(void *arg);
+static int send_payload(struct link_handle *link, uint8_t *payload,
+                        uint16_t used_payload_length);
+//rx:
+static int start_receiver(struct link_handle *link);
+static int stop_receiver(struct link_handle *link);
+void *receive_frames(void *arg);
+static int receive_ack(struct link_handle *link, uint16_t ack_num,
+                        unsigned int timeout_ms);
+static int receive_payload(struct link_handle *link, uint8_t *payload,
+                            unsigned int timeout_ms);
+//utility:
+static void convert_data_frame_struct_to_buf(struct data_frame *frame, uint8_t *buf);
+static void convert_ack_frame_struct_to_buf(struct ack_frame *frame, uint8_t *buf);
+static void convert_buf_to_data_frame_struct(uint8_t *buf, struct data_frame *frame);
+static void convert_buf_to_ack_frame_struct(uint8_t *buf, struct ack_frame *frame);
+
+/****************************************
+ *                                      *
+ *  INIT/DEINIT AND UTILITY FUNCTIONS   *
+ *                                      *
+ ****************************************/
+
+struct link_handle *link_init(struct bladerf *dev, struct radio_params *params)
+{
+    int status;
+    struct link_handle *link;
+
+    DEBUG_MSG("[LINK] Initializing\n");
+    //-------------Allocate memory for link handle struct--------------
+    //Calloc so all pointers are initialized to NULL, and all bools are
+    //initialized to false
+    link = calloc(1, sizeof(struct link_handle));
+    if (link == NULL){
+        perror("malloc");
+        return NULL;
+    }
+
+    //---------------Open/Initialize phy handle--------------------------
+    link->phy = phy_init(dev, params);
+    if (link->phy == NULL){
+        fprintf(stderr, "[LINK] Couldn't initialize phy handle\n");
+        goto error;
+    }
+    //Start phy receiver
+    status = phy_start_receiver(link->phy);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Couldn't start phy recevier\n");
+        goto error;
+    }
+    link->phy_rx_on = true;
+    //Start phy transmitter
+    status = phy_start_transmitter(link->phy);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Couldn't start phy transmitter\n");
+        goto error;
+    }
+    link->phy_tx_on = true;
+
+    //------------------Allocate memory for tx struct and initialize-----
+    link->tx = malloc(sizeof(struct tx));
+    if (link->tx == NULL){
+        perror("malloc");
+        goto error;
+    }
+    //Initialize control/state variables
+    link->tx->stop = false;
+    link->tx->data_buf_filled = false;
+    link->tx->done = false;
+    link->tx->success = false;
+    link->tx->link_on = false;
+    //Initialize pthread condition variable
+    status = pthread_cond_init(&(link->tx->data_buf_filled_cond), NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error initializing pthread_cond: %s\n",
+                    strerror(status));
+        goto error;
+    }
+    //Initialize pthread mutex variable
+    status = pthread_mutex_init(&(link->tx->data_buf_status_lock), NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error initializing pthread_mutex: %s\n",
+                    strerror(status));
+        goto error;
+    }
+    //------------------Allocate memory for rx struct and initialize-----
+    link->rx = malloc(sizeof(struct rx));
+    if (link->rx == NULL){
+        perror("malloc");
+        goto error;
+    }
+    //Initialize pthread condition variable for data
+    status = pthread_cond_init(&(link->rx->data_buf_filled_cond), NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error initializing pthread_cond: %s\n",
+                    strerror(status));
+        goto error;
+    }
+    //Initialize pthread mutex variable for data
+    status = pthread_mutex_init(&(link->rx->data_buf_status_lock), NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error initializing pthread_mutex: %s\n",
+                    strerror(status));
+        goto error;
+    }
+    //Initialize pthread condition variable for ack
+    status = pthread_cond_init(&(link->rx->ack_buf_filled_cond), NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error initializing pthread_cond: %s\n",
+                    strerror(status));
+        goto error;
+    }
+    //Initialize pthread mutex variable for ack
+    status = pthread_mutex_init(&(link->rx->ack_buf_status_lock), NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error initializing pthread_mutex: %s\n",
+                    strerror(status));
+        goto error;
+    }
+    //Initialize control/state variables
+    link->rx->stop = false;
+    link->rx->data_buf_filled = false;
+    link->rx->ack_buf_filled = false;
+    link->rx->num_extra_bytes = 0;
+    link->rx->link_on = false;
+
+    //---------------------Start the link receiver--------------------------
+    status = start_receiver(link);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Couldn't start receiver\n");
+        goto error;
+    }
+    link->rx->link_on = true;
+    //-------------------Start the link transmitter-------------------------
+    status = start_transmitter(link);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Couldn't start receiver\n");
+        goto error;
+    }
+    link->tx->link_on = true;
+
+    DEBUG_MSG("[LINK] Initialization done\n");
+    return link;
+
+    error:
+        link_close(link);
+        return NULL;
+}
+
+void link_close(struct link_handle *link)
+{
+    int status;
+
+    DEBUG_MSG("[LINK] Closing\n");
+
+    //Cleanup all internal resources
+    if (link != NULL){
+        //Cleanup tx struct
+        if (link->tx != NULL){
+            //Stop the link transmitter if it is on
+            if (link->tx->link_on){
+                status = stop_transmitter(link);
+                if (status != 0){
+                    fprintf(stderr, "[LINK] Error stopping link transmitter\n");
+                }
+            }
+            status = pthread_mutex_destroy(&(link->tx->data_buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Error destroying pthread_mutex\n");
+            }
+            status = pthread_cond_destroy(&(link->tx->data_buf_filled_cond));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Error destroying pthread_cond\n");
+            }
+        }
+        free(link->tx);
+        //Cleanup rx struct
+        if (link->rx != NULL){
+            //Stop the link receiver if it is on
+            if (link->rx->link_on){
+                status = stop_receiver(link);
+                if (status != 0){
+                    fprintf(stderr, "[LINK] Error stopping link receiver\n");
+                }
+            }
+            status = pthread_mutex_destroy(&(link->rx->data_buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Error destroying pthread_mutex\n");
+            }
+            status = pthread_cond_destroy(&(link->rx->data_buf_filled_cond));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Error destroying pthread_cond\n");
+            }
+            status = pthread_mutex_destroy(&(link->rx->ack_buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Error destroying pthread_mutex\n");
+            }
+            status = pthread_cond_destroy(&(link->rx->ack_buf_filled_cond));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Error destroying pthread_cond\n");
+            }
+        }
+        free(link->rx);
+        //Close the phy
+        if (link->phy != NULL){
+            //Stop phy transmitter/receiver if they are on
+            if (link->phy_tx_on){
+                status = phy_stop_transmitter(link->phy);
+                if (status != 0){
+                    fprintf(stderr, "[LINK] Error stopping phy transmitter\n");
+                }
+            }
+            if (link->phy_rx_on){
+                status = phy_stop_receiver(link->phy);
+                if (status != 0){
+                    fprintf(stderr, "[LINK] Error stopping phy receiver\n");
+                }
+            }
+        }
+        //Close phy handle
+        phy_close(link->phy);
+    }
+    free(link);
+    link = NULL;
+}
+
+/**
+ * Convert data frame struct to a buffer of uint8_t
+ * @param[in]   frame   pointer to data_frame structure to convert
+ * @param[out]  buf     pointer to buffer to place the frame in
+ */
+static void convert_data_frame_struct_to_buf(struct data_frame *frame, uint8_t *buf)
+{
+    int i = 0;
+
+    //Frame type
+    memcpy(&buf[i], &(frame->type), sizeof(frame->type));
+    i += sizeof(frame->type);
+    //Seq num
+    memcpy(&buf[i], &(frame->seq_num), sizeof(frame->seq_num));
+    i += sizeof(frame->seq_num);
+    //payload length
+    memcpy(&buf[i], &(frame->payload_length), sizeof(frame->payload_length));
+    i += sizeof(frame->payload_length);
+    //payload
+    memcpy(&buf[i], frame->payload, PAYLOAD_LENGTH);
+    i += PAYLOAD_LENGTH;
+    //crc
+    memcpy(&buf[i], &(frame->crc32), sizeof(frame->crc32));
+    i += sizeof(frame->crc32);
+
+    if (i != DATA_FRAME_LENGTH){
+        fprintf(stderr, "[LINK] %s: ERROR: Link layer is using a different data frame "
+                        "length (%d) than the phy layer (%d). Update the DATA_FRAME_LENGTH"
+                        " macro in phy.h and recompile or there will be unexpected results\n",
+                        __FUNCTION__, i, DATA_FRAME_LENGTH);
+    }
+}
+
+/**
+ * Convert ack frame struct to a buffer of uint8_t
+ * @param[in]   frame   pointer to ack_frame structure to convert
+ * @param[out]  buf     pointer to buffer to place the frame in
+ */
+static void convert_ack_frame_struct_to_buf(struct ack_frame *frame, uint8_t *buf)
+{
+    int i = 0;
+
+    //Frame type
+    memcpy(&buf[i], &(frame->type), sizeof(frame->type));
+    i += sizeof(frame->type);
+    //ack num
+    memcpy(&buf[i], &(frame->ack_num), sizeof(frame->ack_num));
+    i += sizeof(frame->ack_num);
+    //crc
+    memcpy(&buf[i], &(frame->crc32), sizeof(frame->crc32));
+    i += sizeof(frame->crc32);
+
+    if (i != ACK_FRAME_LENGTH){
+        fprintf(stderr, "[LINK] %s: ERROR: Link layer is using a different ack frame "
+                        "length (%d) than the phy layer (%d). Update the ACK_FRAME_LENGTH"
+                        " macro in phy.h and recompile or there will be unexpected results\n",
+                        __FUNCTION__, i, ACK_FRAME_LENGTH);
+    }
+}
+
+/**
+ * Convert uint8_t buffer to data frame struct
+ *
+ * @param[in]   buf     pointer to buffer holding a data frame
+ * @param[out]  frame   pointer to data_frame struct to place frame in
+ */
+static void convert_buf_to_data_frame_struct(uint8_t *buf, struct data_frame *frame)
+{
+    int i = 0;
+
+    //Frame type
+    memcpy(&(frame->type), &buf[i], sizeof(frame->type));
+    i += sizeof(frame->type);
+    //Seq num
+    memcpy(&(frame->seq_num), &buf[i], sizeof(frame->seq_num));
+    i += sizeof(frame->seq_num);
+    //payload length
+    memcpy(&(frame->payload_length), &buf[i], sizeof(frame->payload_length));
+    i += sizeof(frame->payload_length);
+    //payload
+    memcpy(frame->payload, &buf[i], PAYLOAD_LENGTH);
+    i += PAYLOAD_LENGTH;
+    //crc
+    memcpy(&(frame->crc32), &buf[i], sizeof(frame->crc32));
+    i += sizeof(frame->crc32);
+
+    if (i != DATA_FRAME_LENGTH){
+        fprintf(stderr, "[LINK] %s: ERROR: Link layer is using a different data frame "
+                        "length (%d) than the phy layer (%d). Update the DATA_FRAME_LENGTH"
+                        " macro in phy.h and recompile or there will be unexpected results\n",
+                        __FUNCTION__, i, DATA_FRAME_LENGTH);
+    }
+}
+
+/**
+ * Convert uint8_t buffer to ack frame struct
+ *
+ * @param[in]   buf     pointer to buffer holding a ack frame
+ * @param[out]  frame   pointer to ack_frame struct to place frame in
+ */
+static void convert_buf_to_ack_frame_struct(uint8_t *buf, struct ack_frame *frame)
+{
+    int i = 0;
+
+    //Frame type
+    memcpy(&(frame->type), &buf[i], sizeof(frame->type));
+    i += sizeof(frame->type);
+    //ack num
+    memcpy(&(frame->ack_num), &buf[i], sizeof(frame->ack_num));
+    i += sizeof(frame->ack_num);
+    //crc
+    memcpy(&(frame->crc32), &buf[i], sizeof(frame->crc32));
+    i += sizeof(frame->crc32);
+
+    if (i != ACK_FRAME_LENGTH){
+        fprintf(stderr, "[LINK] %s: ERROR: Link layer is using a different ack frame "
+                        "length (%d) than the phy layer (%d). Update the ACK_FRAME_LENGTH"
+                        " macro in phy.h and recompile or there will be unexpected results\n",
+                        __FUNCTION__, i, ACK_FRAME_LENGTH);
+    }
+}
+
+/****************************************
+ *                                      *
+ *          TRANSMITTER FUNCTIONS       *
+ *                                      *
+ ****************************************/
+
+/**
+ * Start the transmitter thread
+ *
+ * @param[in]   link    pointer to link handle
+ *
+ * @return  0 on success, -1 on failure
+ */
+static int start_transmitter(struct link_handle *link)
+{
+    int status;
+
+    link->tx->done = false;
+    link->tx->success = false;
+    //be sure stop signal is off
+    link->tx->stop = false;
+    //Kick off transmitter thread
+    status = pthread_create(&(link->tx->thread), NULL, transmit_data_frames, link);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error creating tx thread: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * Stop the transmitter thread
+ *
+ * @param[in]   link    pointer to link handle
+ *
+ * @return  0 on success, -1 on failure
+ */
+static int stop_transmitter(struct link_handle *link)
+{
+    int status;
+
+    DEBUG_MSG("[LINK] TX: Stopping transmitter...\n");
+    //signal stop
+    link->tx->stop = true;
+    //Signal the buffer filled condition so the thread will stop waiting
+    //for a filled buffer
+    status = pthread_mutex_lock(&(link->tx->data_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error locking pthread_mutex\n");
+    }
+    status = pthread_cond_signal(&(link->tx->data_buf_filled_cond));
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error signaling pthread_cond\n");
+    }
+    status = pthread_mutex_unlock(&(link->tx->data_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error unlocking pthread_mutex\n");
+    }
+    //Wait for tx thread to finish
+    status = pthread_join(link->tx->thread, NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error joining tx thread: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    DEBUG_MSG("[LINK] TX: Transmitter stopped\n");
+    return 0;
+}
+
+int link_send_data(struct link_handle *link, uint8_t *data, unsigned int data_length)
+{
+    unsigned int num_full_payloads;
+    unsigned int i;
+    unsigned int last_payload_length;
+    int status;
+
+    num_full_payloads = data_length/PAYLOAD_LENGTH;
+
+    //Loop through each full payload
+    for(i = 0; i < num_full_payloads; i++){
+        //Send the frame
+        status = send_payload(link, &data[i*PAYLOAD_LENGTH], PAYLOAD_LENGTH);
+        if (status != 0){
+            if (status == -2){
+                DEBUG_MSG("[LINK] TX: Send data failed: "
+                            "No response for payload #%d\n", i+1);
+            }else{
+                fprintf(stderr, "[LINK] TX: Send data failed: "
+                            "Unexpected error sending payload #%d\n", i+1);
+            }
+            return status;
+        }
+    }
+
+    //Send the last payload for the remaining bytes
+    last_payload_length = data_length % PAYLOAD_LENGTH;
+    if (last_payload_length != 0){
+        status = send_payload(link, &data[i*PAYLOAD_LENGTH],
+                                (uint16_t) last_payload_length);
+        if (status != 0){
+            if (status == -2){
+                DEBUG_MSG("[LINK] TX: Send data failed: "
+                            "No response for payload #%d\n", i+1);
+            }else{
+                fprintf(stderr, "[LINK] TX: Send data failed: "
+                            "Unexpected error sending payload #%d\n", i+1);
+            }
+            return status;
+        }
+    }
+    return 0;
+}
+
+/**
+ * Sends a payload. Blocks until either the transmission was successful (with an
+ * acknowledgement) or there was no response (exceeded max number of retransmissions)
+ *
+ * @param[in]   link                    pointer to link handle
+ * @param[in]   payload                 buffer of bytes to send
+ * @param[in]   used_payload_length     number of bytes to send in 'payload'. If less
+ *                                      than PAYLOAD_LENGTH, zeros will be padded.
+ * @return      0 on success, -1 on error, -2 on timeout/no response
+ */
+static int send_payload(struct link_handle *link, uint8_t *payload,
+                    uint16_t used_payload_length)
+{
+    int status;
+
+    if (used_payload_length > PAYLOAD_LENGTH){
+        fprintf(stderr, "[LINK] %s: Invalid payload length of %hu\n", __FUNCTION__,
+                used_payload_length);
+        return -1;
+    }
+
+    //Wait for tx buf to be empty
+    while(link->tx->data_buf_filled){
+        usleep(50);
+    }
+    //Copy payload data into frame buffer
+    memcpy(link->tx->data_frame_buf.payload, payload, used_payload_length);
+    //Pad zeros to unused portion of the payload
+    memset(&(link->tx->data_frame_buf.payload[used_payload_length]), 0,
+            PAYLOAD_LENGTH - used_payload_length);
+    //Set payload length
+    link->tx->data_frame_buf.payload_length = used_payload_length;
+    //Mark tx not done
+    link->tx->done = false;
+    //Mark buffer filled
+    link->tx->data_buf_filled = true;
+    //Signal the buffer filled condition
+    status = pthread_mutex_lock(&(link->tx->data_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error locking pthread_mutex: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    status = pthread_cond_signal(&(link->tx->data_buf_filled_cond));
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error signaling pthread_cond: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    status = pthread_mutex_unlock(&(link->tx->data_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error unlocking pthread_mutex: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    //Wait for the transmission to complete
+    //TODO: Change this to a pthread condition signal
+    while (!link->tx->done){
+        usleep(100);
+    }
+    //Check the status of the transmission
+    if (!link->tx->success){
+        return -2;
+    }
+
+    return 0;
+}
+
+/**
+ * Thread function that transmits data frames and waits for acks.
+ * Does not directly receive acks - the receive_frames() function does this.
+ * Does not transmit acks - the receive_frames function does this.
+ *
+ * @param[in]   arg     pointer to link handle
+ */
+void *transmit_data_frames(void *arg)
+{
+    int status;
+    uint16_t seq_num;
+    uint32_t crc_32;
+    unsigned int tries;
+    uint8_t data_send_buf[DATA_FRAME_LENGTH];
+    bool failed;
+
+    //cast arg
+    struct link_handle *link = (struct link_handle *) arg;
+    //Set initial sequence number to random value
+    srand((unsigned int)time(NULL));
+    seq_num = rand() % 65536;
+    DEBUG_MSG("[LINK] TX: Initial seq num = %hu\n", seq_num);
+    tries = 1;
+
+    while (!link->tx->stop){
+        if (tries > LINK_MAX_TRIES){
+            DEBUG_MSG("[LINK] TX: Exceeded max tries (%u) without an ACK."
+                            " Skipping frame\n", tries-1);
+            link->tx->success = false;
+            link->tx->done = true;
+            tries = 1;
+        }
+        if (tries == 1){
+            //---------Wait for data buffer to be filled-----------
+            //Lock mutex
+            status = pthread_mutex_lock(&(link->tx->data_buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[LINK] Mutex lock failed: %s\n",
+                        strerror(status));
+                goto out;
+            }
+            //Wait for condition signal - meaning buffer is full
+            failed = false;
+            while (!link->tx->data_buf_filled && !link->tx->stop){
+                DEBUG_MSG("[LINK] TX: Waiting for buffer to be filled\n");
+                status = pthread_cond_wait(&(link->tx->data_buf_filled_cond),
+                                            &(link->tx->data_buf_status_lock));
+                if (status != 0){
+                    fprintf(stderr, "[LINK] transmit_frames(): "
+                            "Condition wait failed: %s\n", strerror(status));
+                    failed = true;
+                    break;
+                }
+            }
+            //Unlock mutex
+            status = pthread_mutex_unlock(&(link->tx->data_buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[LINK] transmit_frames(): Mutex unlock failed: %s\n",
+                        strerror(status));
+                failed = true;
+            }
+            //Stop thread if stop variable is true, or something with pthreads went wrong
+            if (link->tx->stop || failed){
+                link->tx->data_buf_filled = false;
+                goto out;
+            }
+            DEBUG_MSG("[LINK] TX: Frame buffer filled. Sending...\n");
+            //Set frame type
+            link->tx->data_frame_buf.type = DATA_FRAME_CODE;
+            //Set sequence number
+            link->tx->data_frame_buf.seq_num = seq_num;
+            //Copy frame into send buf
+            convert_data_frame_struct_to_buf(&(link->tx->data_frame_buf), data_send_buf);
+            //Calculate the CRC
+            crc_32 = crc32(data_send_buf, DATA_FRAME_LENGTH - sizeof(crc_32));
+            //Copy this CRC to the send buf
+            memcpy(&data_send_buf[DATA_FRAME_LENGTH - sizeof(crc_32)],
+                    &crc_32, sizeof(crc_32));
+            //Mark tx data buffer empty
+            link->tx->data_buf_filled = false;
+        }
+        //Transmit the frame
+        status = phy_fill_tx_buf(link->phy, data_send_buf, DATA_FRAME_LENGTH);
+        if (status != 0){
+            fprintf(stderr, "[LINK] Couldn't fill phy tx buffer\n");
+            goto out;
+        }
+        DEBUG_MSG("[LINK] TX: Frame sent to PHY. Waiting for ACK...\n");
+        //Wait for an ack
+        status = receive_ack(link, seq_num, ACK_TIMEOUT_MS);
+        if (status == -2){
+            DEBUG_MSG("[LINK] TX: Didn't get an ACK (timed out). Resending\n");
+            tries++;
+            continue;
+        }else if (status == -3){
+            DEBUG_MSG("[LINK] TX: Received wrong ACK number. Resending\n");
+            tries++;
+            continue;
+        }else if (status < 0){
+            fprintf(stderr, "[LINK] TX: Error receiving ACK. "
+                            "Stopping transmitter\n");
+            goto out;
+        }
+        //Success!
+        DEBUG_MSG("[LINK] TX: Got an ACK\n");
+        link->tx->success = true;
+        link->tx->done = true;
+        tries = 1;
+        seq_num++;
+    }
+
+    out:
+        link->tx->done = true;
+        return NULL;
+}
+
+/****************************************
+ *                                      *
+ *          RECEIVER FUNCTIONS          *
+ *                                      *
+ ****************************************/
+
+/**
+ * Start the receiver thread
+ *
+ * @param[in]   link    pointer to link handle
+ *
+ * @return  0 on success, -1 on failure
+ */
+static int start_receiver(struct link_handle *link)
+{
+    int status;
+
+    //be sure stop signal is off
+    link->rx->stop = false;
+    //Kick off receiver thread
+    status = pthread_create(&(link->rx->thread), NULL, receive_frames, link);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error creating rx thread: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * Stop the receiver thread
+ *
+ * @param[in]   link    pointer to link handle
+ *
+ * @return  0 on success, -1 on failure
+ */
+static int stop_receiver(struct link_handle *link)
+{
+    int status;
+
+    DEBUG_MSG("[LINK] RX: Stopping receiver...\n");
+    //signal stop
+    link->rx->stop = true;
+    //Wait for rx thread to finish
+    status = pthread_join(link->rx->thread, NULL);
+    if (status != 0){
+        fprintf(stderr, "[LINK] Error joining rx thread: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    DEBUG_MSG("[LINK] RX: Receiver stopped\n");
+    return 0;
+}
+
+int link_receive_data(struct link_handle *link, int size, int max_timeouts,
+                        uint8_t *data_buf)
+{
+    int bytes_received;
+    int bytes_remaining;
+    uint8_t temp_buf[PAYLOAD_LENGTH];
+    int i;
+    int timeouts;
+
+    //Check for invalid input
+    if (size < 0 || max_timeouts < 0){
+        fprintf(stderr, "[LINK] RX: link_receive_data(): parameter is negative\n");
+        return -1;
+    }
+
+    timeouts = 0;
+    //Read any extra bytes left over from the last call to this function
+    if (size < (int)(link->rx->num_extra_bytes)){
+        //Special case: More extra bytes than the request size.
+        memcpy(data_buf, link->rx->extra_bytes, size);
+        //Move over the remaining extra_bytes
+        memmove(link->rx->extra_bytes, &(link->rx->extra_bytes[size]),
+                link->rx->num_extra_bytes - size);
+        i = size;
+        return i;
+    }else{
+        memcpy(data_buf, link->rx->extra_bytes, link->rx->num_extra_bytes);
+        i = link->rx->num_extra_bytes;
+    }
+
+    while(i < size && timeouts < max_timeouts){
+        bytes_remaining = size - i;
+        //Make sure to not write more than 'size' bytes. For the last payload(s),
+        //Use a temp buffer first
+        if (bytes_remaining < PAYLOAD_LENGTH){
+            bytes_received = receive_payload(link, temp_buf, 500);
+            //Check for timeout
+            if (bytes_received == -2){
+                timeouts++;
+                continue;
+            }else if (bytes_received < 0){
+                fprintf(stderr, "[LINK] RX: Error receiving payload\n");
+                return -1;
+            }
+            //Copy bytes from temp buf to data_buf
+            if (bytes_received < bytes_remaining){
+                memcpy(&data_buf[i], temp_buf, bytes_received);
+                i += bytes_received;
+            }else{    //bytes_received >= bytes_remaining
+                memcpy(&data_buf[i], temp_buf, bytes_remaining);
+                i += bytes_remaining;
+                //Copy extra bytes to extra_bytes buffer
+                link->rx->num_extra_bytes = bytes_received - bytes_remaining;
+                memcpy(link->rx->extra_bytes, &temp_buf[bytes_remaining],
+                        link->rx->num_extra_bytes);
+            }
+        //For all other payloads
+        }else{
+            bytes_received = receive_payload(link, &data_buf[i], 500);
+            //Check for timeout
+            if (bytes_received == -2){
+                timeouts++;
+                continue;
+            }
+            if (bytes_received < 0){
+                fprintf(stderr, "[LINK] RX: Error receiving payload\n");
+                return -1;
+            }
+            i += bytes_received;
+        }
+    }
+
+    return i;
+}
+
+/**
+ * Receives a payload and copies it into the given buffer
+ * @param[in]   link            pointer to link handle
+ * @param[in]   timeout_ms      Amount of time to wait for a received payload
+ * @param[out]  payload         pointer to buffer to place payload in
+ *
+ * @return      number of bytes received (0 - PAYLOAD_LENGTH), -1 on error,
+ *              -2 on timeout
+ */
+static int receive_payload(struct link_handle *link, uint8_t *payload, unsigned int timeout_ms)
+{
+    int payload_length = 10;    //must be initialized above 0
+    struct timespec timeout_abs;
+    int status;
+
+    //Create absolute time format timeout
+    status = create_timeout_abs(timeout_ms, &timeout_abs);
+    if (status != 0){
+        fprintf(stderr, "[LINK] RX: receive_payload(): Error creating timeout\n");
+        return -1;
+    }
+
+    //Prepare to wait with pthread_cond_timedwait()
+    status = pthread_mutex_lock(&(link->rx->data_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] RX: receive_payload(): Error locking mutex: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    //Wait for condition signal - meaning rx data buffer is full
+    while (!link->rx->data_buf_filled){
+        status = pthread_cond_timedwait(&(link->rx->data_buf_filled_cond),
+                                    &(link->rx->data_buf_status_lock), &timeout_abs);
+        if (status != 0){
+            if (status == ETIMEDOUT){
+                payload_length = -2;
+            }else{
+                fprintf(stderr, "[LINK] RX: receive_payload(): "
+                        "Condition wait failed: %s\n", strerror(status));
+                payload_length = -1;
+            }
+            break;
+        }
+    }
+    //Waiting is done. Unlock mutex.
+    status = pthread_mutex_unlock(&(link->rx->data_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] RX: receive_payload(): Mutex unlock failed: %s\n",
+                strerror(status));
+        payload_length = -1;
+    }
+    //Did we error or timeout? Return
+    if (payload_length < 0){
+        return payload_length;
+    }
+
+    //Get the length of the used portion of the payload
+    payload_length = link->rx->data_frame_buf.payload_length;
+    //Copy the used portion of the payload
+    memcpy(payload, link->rx->data_frame_buf.payload, payload_length);
+    //Mark the rx data buffer empty
+    link->rx->data_buf_filled = false;
+
+    return payload_length;
+}
+
+/**
+ * Attempts to receive an ACK with the given ACK number
+ * Waits until it either receives an ack or times out.
+ *
+ * @param[in]   link        pointer to link handle
+ * @param[in]   ack_num     acknowledgement number to look for
+ * @param[in]   timeout_ms  amount of time to wait for an ACK, in milliseconds
+ *
+ * @return      0 if successfully received ack, -1 if pthread error or wrong ack number,
+ *              -2 if timed out, -3 if wrong ack number
+ */
+static int receive_ack(struct link_handle *link, uint16_t ack_num, unsigned int timeout_ms)
+{
+    struct timespec timeout_abs;
+    int status, ret = 0;
+
+    //Create absolute time format timeout
+    status = create_timeout_abs(timeout_ms, &timeout_abs);
+    if (status != 0){
+        fprintf(stderr, "[LINK] RX: receive_ack(): Error creating timeout\n");
+        return -1;
+    }
+
+    //Prepare to wait with pthread_cond_timedwait()
+    status = pthread_mutex_lock(&(link->rx->ack_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] RX: receive_ack(): Error locking mutex: %s\n",
+                    strerror(status));
+        return -1;
+    }
+    //Wait for condition signal - meaning buffer is full
+    while (!link->rx->ack_buf_filled){
+        status = pthread_cond_timedwait(&(link->rx->ack_buf_filled_cond),
+                                    &(link->rx->ack_buf_status_lock), &timeout_abs);
+        if (status != 0){
+            if (status == ETIMEDOUT){
+                ret = -2;
+            }else{
+                fprintf(stderr, "[LINK] RX: receive_ack(): Condition wait failed: %s\n",
+                    strerror(status));
+                ret = -1;
+            }
+            break;
+        }
+    }
+    //Waiting is done. Unlock mutex.
+    status = pthread_mutex_unlock(&(link->rx->ack_buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[LINK] RX: receive_ack(): Mutex unlock failed: %s\n",
+                strerror(status));
+        ret = -1;
+    }
+    //Check the sequence number if nothing failed
+    if (ret == 0 && link->rx->ack_frame_buf.ack_num != ack_num){
+        fprintf(stderr, "[LINK] RX: receive_ack(): Incorrect ack number %hu "
+                    "(expected %hu)\n", link->rx->ack_frame_buf.ack_num, ack_num);
+        ret = -3;
+    }
+    //mark the rx ack buffer empty
+    link->rx->ack_buf_filled = false;
+
+    return ret;
+}
+
+/**
+ * Thread function which receives data and ACK frames from the PHY, and transmits ACKs.
+ * Checks CRC on all received frames before copying them to a buffer which other
+ * functions can use. If the CRC is incorrect, it disregards the frame and does not
+ * copy it. If a data frame is received, it checks sequence number for duplicate.
+ * If not a duplicate, it copies the frame to rx data_frame_buf and marks the buffer
+ * full. An acknowledgement is always sent, regardless of whether or not the received
+ * data frame is a duplicate. This is the only function that sends acks.
+ *
+ * @param[in]   arg     pointer to link handle
+ */
+void *receive_frames(void *arg)
+{
+    uint8_t *rx_buf;
+    unsigned int frame_length;
+    uint32_t crc_32, crc_32_rx;
+    bool is_data_frame;
+    int status;
+    uint8_t ack_send_buf[ACK_FRAME_LENGTH];
+    uint16_t seq_num = 0;
+    bool first_frame = true;
+    bool duplicate;
+
+    //cast arg
+    struct link_handle *link = (struct link_handle *) arg;
+    //declare states
+    enum states {WAIT, CHECK_CRC, COPY, SEND_ACK};
+    //current state variable
+    enum states state = WAIT;
+
+    while(!link->rx->stop){
+        switch(state){
+            case WAIT:
+                //--Wait for PHY to receive a frame
+                //DEBUG_MSG("[LINK] RX: State = WAIT\n");
+                rx_buf = phy_request_rx_buf(link->phy, 500);
+                if (rx_buf == NULL){
+                    //timed out (or error). Continue waiting.
+                    state = WAIT;
+                }else{
+                    state = CHECK_CRC;
+                }
+                break;
+            case CHECK_CRC:
+                //--We received a frame from the PHY. Check the CRC
+                DEBUG_MSG("[LINK] RX: State = CHECK_CRC\n");
+                //First check if it's an ack or data frame to determine length
+                if (rx_buf[0] == DATA_FRAME_CODE){
+                    DEBUG_MSG("[LINK] RX: Received a data frame\n");
+                    is_data_frame = true;
+                    frame_length = DATA_FRAME_LENGTH;
+                }else{
+                    DEBUG_MSG("[LINK] RX: Received a ack frame\n");
+                    is_data_frame = false;
+                    frame_length = ACK_FRAME_LENGTH;
+                }
+                //Copy the received CRC
+                memcpy(&crc_32_rx, &rx_buf[frame_length - sizeof(crc_32)],
+                        sizeof(crc_32));
+                //Compute expected CRC
+                crc_32 = crc32(rx_buf, frame_length - sizeof(crc_32));
+                //Compare received CRC vs expected CRC
+                if (crc_32_rx != crc_32){
+                    //Drop the frame since there was an error
+                    //First release the buffer for the PHY
+                    phy_release_rx_buf(link->phy);
+                    NOTE("[LINK] RX: Frame received with errors. Dropping.\n");
+                    state = WAIT;
+                }else{
+                    DEBUG_MSG("[LINK] RX: Frame received with no errors\n");
+                    state = COPY;
+                }
+                break;
+            case COPY:
+                //--CRC passed. Now copy the frame to link layer buffer
+                //--if it is not a duplicate frame
+                DEBUG_MSG("[LINK] RX: State = COPY\n");
+                if (is_data_frame){
+                    //Is the previous data frame still being worked with?
+                    if (link->rx->data_buf_filled){
+                        //Instead of causing a disruption, drop the current frame
+                        fprintf(stderr, "[LINK] RX: Data frame dropped!\n");
+                        phy_release_rx_buf(link->phy);
+                        break;
+                    }
+                    //Copy/convert to data frame struct
+                    convert_buf_to_data_frame_struct(rx_buf,
+                                                &(link->rx->data_frame_buf));
+                    //Release buffer from the phy
+                    phy_release_rx_buf(link->phy);
+                    //Is this frame a duplicate of the last frame?
+                    if (link->rx->data_frame_buf.seq_num == seq_num && !first_frame){
+                        DEBUG_MSG("[LINK] RX: Received a duplicate frame.\n");
+                        duplicate = true;
+                    }else{
+                        duplicate = false;
+                    }
+                    seq_num = link->rx->data_frame_buf.seq_num;
+                    first_frame = false;
+                    //Mark buffer filled if not a duplicate data frame
+                    if (!duplicate){
+                        //Signal that the link data buffer is filled
+                        link->rx->data_buf_filled = true;
+                        status = pthread_mutex_lock(&(link->rx->data_buf_status_lock));
+                        if (status != 0){
+                            fprintf(stderr, "[LINK] RX: receive_frames(): "
+                                            "Error locking pthread_mutex\n");
+                            return NULL;
+                        }
+                        status = pthread_cond_signal(&(link->rx->data_buf_filled_cond));
+                        if (status != 0){
+                            fprintf(stderr, "[LINK] RX: receive_frames(): "
+                                            "Error signaling pthread_cond\n");
+                            return NULL;
+                        }
+                        status = pthread_mutex_unlock(&(link->rx->data_buf_status_lock));
+                        if (status != 0){
+                            fprintf(stderr, "[LINK] RX: receive_frames(): "
+                                            "Error unlocking pthread_mutex\n");
+                            return NULL;
+                        }
+                    }
+                    //Transition to send acknowledgement
+                    state = SEND_ACK;
+                }else{
+                    //Is the previous ack frame still being worked with?
+                    if (link->rx->ack_buf_filled){
+                        //Instead of causing a disruption, drop the current frame
+                        fprintf(stderr, "[LINK] RX: ACK frame dropped!\n");
+                        phy_release_rx_buf(link->phy);
+                        break;
+                    }
+                    //Copy/convert to ack frame struct and mark ack buffer filled
+                    convert_buf_to_ack_frame_struct(rx_buf, &(link->rx->ack_frame_buf));
+                    //Release buffer from the phy
+                    phy_release_rx_buf(link->phy);
+                    //Signal that the link ack buffer is filled
+                    link->rx->ack_buf_filled = true;
+                    status = pthread_mutex_lock(&(link->rx->ack_buf_status_lock));
+                    if (status != 0){
+                        fprintf(stderr, "[LINK] RX: receive_frames(): "
+                                        "Error locking pthread_mutex\n");
+                        return NULL;
+                    }
+                    status = pthread_cond_signal(&(link->rx->ack_buf_filled_cond));
+                    if (status != 0){
+                        fprintf(stderr, "[LINK] RX: receive_frames(): "
+                                        "Error signaling pthread_cond\n");
+                        return NULL;
+                    }
+                    status = pthread_mutex_unlock(&(link->rx->ack_buf_status_lock));
+                    if (status != 0){
+                        fprintf(stderr, "[LINK] RX: receive_frames(): "
+                                        "Error unlocking pthread_mutex\n");
+                        return NULL;
+                    }
+                    //Done with the frame. Go back to WAIT state
+                    state = WAIT;
+                }
+                break;
+            case SEND_ACK:
+                //--We received a data frame, now it's time to send the ack
+                DEBUG_MSG("[LINK] RX: State = SEND_ACK (ack# = %hu)\n", seq_num);
+
+                link->tx->ack_frame_buf.type = 0xFF;
+                link->tx->ack_frame_buf.ack_num = seq_num;
+
+                //Copy frame into send buf
+                convert_ack_frame_struct_to_buf(&(link->tx->ack_frame_buf),
+                                                ack_send_buf);
+                //Calculate the CRC
+                crc_32 = crc32(ack_send_buf, ACK_FRAME_LENGTH - sizeof(crc_32));
+                //Copy this CRC to the send buf
+                memcpy(&ack_send_buf[ACK_FRAME_LENGTH - sizeof(crc_32)], &crc_32,
+                        sizeof(crc_32));
+                //Transmit with phy
+                status = phy_fill_tx_buf(link->phy, ack_send_buf, ACK_FRAME_LENGTH);
+                if (status != 0){
+                    fprintf(stderr, "[LINK] Couldn't fill phy tx buffer\n");
+                    goto out;
+                }
+                //Done; go back to the WAIT state
+                state = WAIT;
+                break;
+            default:
+                fprintf(stderr, "[LINK] receive_frames(): invalid state\n");
+                return NULL;
+        }
+    }
+    out:
+        return NULL;
+}

--- a/host/utilities/bladeRF-fsk/c/src/link.h
+++ b/host/utilities/bladeRF-fsk/c/src/link.h
@@ -1,0 +1,99 @@
+/**
+ * @file
+ * @brief   Link layer code for modem
+ *
+ * This file handles framing, error detection, and guaranteed delivery of frames.
+ * On the sender side, this file formats payload data into packets to transmit
+ * using phy.c, and waits for acknowledgements. A retransmission is automatically
+ * sent if no acknowledgement is received within the timeout period. On the receiver
+ * side, this file extracts payload data from a packet received using phy.c, and sends
+ * acknowledgements.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2013 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef LINK_H
+#define LINK_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <time.h>
+#include <errno.h>
+#include <libbladeRF.h>
+#include "host_config.h"
+
+#include "common.h"
+
+#define PAYLOAD_LENGTH 1000     //If you change this, DATA_FRAME_LENGTH
+                                //ACK_FRAME_LENGTH must also be changed in phy.h
+#define ACK_TIMEOUT_MS 500      //Timeout to wait for an acknowledgement
+#define LINK_MAX_TRIES 3        //Maximum number of frame retransmissions before the
+                                //transmitter gives up
+
+/** Opaque handle to link data structure */
+struct link_handle;
+
+/**
+ * Send data of arbitrary length. Breaks data up into packets (if needed) and sends each
+ * packet one-by-one.
+ *
+ * @param[in]   link            pointer to link handle
+ * @param[in]   data            Data to send
+ * @param[in]   data_length     Length of data in bytes
+ *
+ * @return      0 on success, -1 on error, -2 on no connection
+ */
+int link_send_data(struct link_handle *link, uint8_t *data, unsigned int data_length);
+
+/**
+ * Attempts to receive the number of bytes specified by size and places them into
+ * data_buf.
+ *
+ * @param[in]   link            pointer to link handle
+ * @param[in]   size            number of bytes to attempt to receive
+ * @param[in]   max_timeouts    max number of 0.5 second timeouts before the function
+ *                              returns
+ * @param[out]  data_buf        buffer to place received bytes in
+ *
+ * @return      number of bytes received on success, -1 on error. In the case of a
+ *              timeout (i.e. when 'max_timeouts' have occured), this return value
+ *              will be less than 'size'
+ */
+int link_receive_data(struct link_handle *link, int size, int max_timeouts,
+                        uint8_t *data_buf);
+
+/**
+ * Initializes/allocates a link handle data structure and starts all threads
+ *
+ * @param[in]   dev         pointer to opened bladeRF device handle
+ * @param[in]   params      radio parameters to use when configuring bladeRF device
+ *
+ * @return      pointer to allocated link_handle struct on success, NULL on error
+ */
+struct link_handle *link_init(struct bladerf *dev, struct radio_params *params);
+
+/**
+ * Deinitializes/closes/frees a link_handle struct. Does nothing if link is NULL
+ *
+ * @param[in]   link        pointer to link handle
+ */
+void link_close(struct link_handle *link);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/phy.c
+++ b/host/utilities/bladeRF-fsk/c/src/phy.c
@@ -1,0 +1,944 @@
+/**
+ * @brief   Physical layer code for modem
+ *
+ * This file handles transmission/reception of data frames over the air. It uses fsk.c to
+ * perform baseband IQ modulation and demodulation, and libbladeRF to transmit/receive
+ * samples using the bladeRF device. A different modulator could be used by swapping
+ * fsk.c with a file that implements a different modulator. On the receive side the file
+ * uses fir_filter.c to low-pass filter the received signal, pnorm.c to power normalize
+ * the input signal, and correlator.c to correlate the received signal with a preamble.
+ * waveform.
+ *
+ * The structure of a physical layer transmission is as follows:
+ * / ramp up | training sequence | preamble | link layer frame | ramp down \
+ *
+ * The ramps at the beginning/end are SAMP_PER_SYMB samples long
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "phy.h"
+#include "fir_filter.h"
+#include "rx_ch_filter.h"
+#include "pnorm.h"
+#include "prng.h"
+#include "correlator.h"
+#include "fsk.h"            //modulator/demodulator
+#include "radio_config.h"    //bladeRF configuration
+
+#ifdef DEBUG_MODE
+    #define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
+    #ifndef ENABLE_NOTES
+        #define ENABLE_NOTES
+    #endif
+#else
+    #define DEBUG_MSG(...)
+#endif
+
+#ifdef ENABLE_NOTES
+    #define NOTE(...) fprintf(stderr, __VA_ARGS__)
+#else
+    #define NOTE(...)
+#endif
+
+//Internal structs
+struct rx {
+    int16_t *in_samples;        //Raw input samples from device
+    struct fir_filter *ch_filt;             //Channel filter
+    struct pnorm_state_t *pnorm;            //Power normalizer
+    struct correlator *corr;                //Correlator
+    struct complex_sample *filt_samples;    //Filtered input samples
+    struct complex_sample *pnorm_samples;    //power normalized samples
+    uint8_t *data_buf;            //received data output buffer (no training seq/preamble)
+    bool buf_filled;            //is the rx data buffer filled
+    bool stop;                    //control variable to stop the receiver
+    pthread_t thread;            //pthread for the receiver
+    pthread_cond_t buf_filled_cond;        //condition variable for buf_filled
+    pthread_mutex_t buf_status_lock;    //mutex variable for accessing buf_filled
+};
+struct tx {
+    uint8_t *data_buf;            //input data to transmit (including training seq/preamble)
+    unsigned int data_length;    //length of data to transmit (not including preamble)
+    bool buf_filled;
+    bool stop;
+    pthread_t thread;
+    pthread_cond_t buf_filled_cond;
+    pthread_mutex_t buf_status_lock;
+    unsigned int max_num_samples;        //Maximum number of tx samples to transmit
+    struct complex_sample *samples;        //output samples to transmit
+};
+
+struct phy_handle {
+    struct bladerf *dev;        //bladeRF device handle
+    struct fsk_handle *fsk;        //fsk handle
+    struct tx *tx;                //tx data structure
+    struct rx *rx;                //rx data structure
+    uint8_t *scrambling_sequence;
+};
+
+//Internal functions
+void *phy_receive_frames(void *arg);
+void *phy_transmit_frames(void *arg);
+static void scramble_frame(uint8_t *frame, int frame_length, uint8_t *scrambling_sequence);
+static void unscramble_frame(uint8_t *frame, int frame_length, uint8_t *scrambling_sequence);
+static void create_ramps(unsigned int ramp_length, struct complex_sample ramp_down_init,
+                    struct complex_sample *ramp_up, struct complex_sample *ramp_down);
+
+/****************************************
+ *                                      *
+ *        INIT/DEINIT  FUNCTIONS        *
+ *                                      *
+ ****************************************/
+
+struct phy_handle *phy_init(struct bladerf *dev, struct radio_params *params)
+{
+    int status;
+    struct phy_handle *phy;
+    uint64_t prng_seed;
+    uint8_t preamble[PREAMBLE_LENGTH] = PREAMBLE;
+
+    //------------Allocate memory for phy handle struct--------------
+    //Calloc so all pointers are initialized to NULL
+    phy = calloc(1, sizeof(struct phy_handle));
+    if (phy == NULL){
+        perror("malloc");
+        return NULL;
+    }
+
+    DEBUG_MSG("[PHY] Initializing...\n");
+
+    if (dev == NULL){
+        fprintf(stderr, "[PHY] %s: BladeRF device uninitialized", __FUNCTION__);
+    }
+    phy->dev = dev;
+
+    //--------Initialize and configure bladeRF device-------------
+    status = radio_init_and_configure(phy->dev, params);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Couldn't configure bladeRF\n", __FUNCTION__);
+        goto error;
+    }
+    DEBUG_MSG("[PHY] BladeRF initialized and configured successfully\n");
+
+    //-------------------Open fsk handle------------------------
+    phy->fsk = fsk_init();
+    if(phy->fsk == NULL){
+        fprintf(stderr, "[PHY] %s: Couldn't open fsk handle\n", __FUNCTION__);
+        goto error;
+    }
+    DEBUG_MSG("[PHY] FSK Initialized\n");
+
+    //------------------Initialize TX struct--------------------
+    phy->tx = calloc(1, sizeof(struct tx));
+    if (phy->tx == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+    //Allocate memory for tx data buffer
+    phy->tx->data_buf = malloc(TRAINING_SEQ_LENGTH + PREAMBLE_LENGTH +
+                                MAX_LINK_FRAME_SIZE);
+    if (phy->tx->data_buf == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+    //Allocate memory for tx samples buffer
+    //2*RAMP_LENGTH for the ramp up/ramp down
+    phy->tx->max_num_samples = 2*RAMP_LENGTH + (TRAINING_SEQ_LENGTH + PREAMBLE_LENGTH +
+                    MAX_LINK_FRAME_SIZE) * 8 * SAMP_PER_SYMB;
+    phy->tx->samples = malloc(phy->tx->max_num_samples * sizeof(struct complex_sample));
+    if (phy->tx->samples == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+    //Initialize control variables
+    phy->tx->data_length = 0;
+    phy->tx->buf_filled = false;
+    phy->tx->stop = false;
+    //Initialize pthread condition variable for buf_filled
+    status = pthread_cond_init(&(phy->tx->buf_filled_cond), NULL);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error initializing pthread_cond\n", __FUNCTION__);
+        goto error;
+    }
+    //Initialize pthread mutex variable for buf_filled
+    status = pthread_mutex_init(&(phy->tx->buf_status_lock), NULL);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error initializing pthread_mutex\n", __FUNCTION__);
+        goto error;
+    }
+
+    //------------------Initialize RX struct------------------
+    phy->rx = calloc(1, sizeof(struct rx));
+    if (phy->rx == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+    //Allocate memory for rx data buffer
+    phy->rx->data_buf = malloc(MAX_LINK_FRAME_SIZE);
+    if (phy->rx->data_buf == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+    //Allocate memory for rx samples buffer
+    phy->rx->in_samples = malloc(NUM_SAMPLES_RX * 2 * sizeof(phy->rx->in_samples[0]));
+    if (phy->rx->in_samples == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+
+    // Allocate memory for filtered RX samples
+    phy->rx->filt_samples = malloc(NUM_SAMPLES_RX * sizeof(struct complex_sample));
+    if (phy->rx->filt_samples == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+
+    //Allocate memory for power normalized samples
+    phy->rx->pnorm_samples = malloc(NUM_SAMPLES_RX * sizeof(struct complex_sample));
+    if (phy->rx->pnorm_samples == NULL){
+        perror("[PHY] malloc");
+        goto error;
+    }
+
+    // Create RX Channel Filter
+    phy->rx->ch_filt = fir_init(rx_ch_filter, rx_ch_filter_len);
+    if (phy->rx->ch_filt == NULL) {
+        fprintf(stderr, "[PHY] %s: Failed to create channel filter.\n", __FUNCTION__);
+        goto error;
+    }
+
+    // Create power normalizer
+    phy->rx->pnorm = pnorm_init(0.95f, 0.1f, 20.0f);
+    if (phy->rx->pnorm == NULL){
+        fprintf(stderr, "[PHY] %s: Couldn't initialize power normalizer\n",
+                __FUNCTION__);
+        goto error;
+    }
+
+    //Create RX correlator
+    phy->rx->corr = corr_init(preamble, 8*PREAMBLE_LENGTH, SAMP_PER_SYMB);
+    if (phy->rx->corr == NULL){
+        fprintf(stderr, "[PHY] %s: Couldn't initialize correlator\n", __FUNCTION__);
+        goto error;
+    }
+
+    //Initialize control variables
+    phy->rx->buf_filled = false;
+    phy->rx->stop = false;
+    //Initialize pthread condition variable for buf_filled
+    status = pthread_cond_init(&(phy->rx->buf_filled_cond), NULL);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error initializing pthread_cond\n", __FUNCTION__);
+        goto error;
+    }
+    //Initialize pthread mutex variable for buf_filled
+    status = pthread_mutex_init(&(phy->rx->buf_status_lock), NULL);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error initializing pthread_mutex\n", __FUNCTION__);
+        goto error;
+    }
+
+    //-----------------Load scrambling sequence--------------------
+    prng_seed = PRNG_SEED;
+    phy->scrambling_sequence = prng_fill(&prng_seed, MAX_LINK_FRAME_SIZE);
+    if (phy->scrambling_sequence == NULL){
+        fprintf(stderr, "[PHY] %s: Couldn't load scrambling sequence\n", __FUNCTION__);
+        goto error;
+    }
+
+    #ifdef BYPASS_RX_CHANNEL_FILTER
+        DEBUG_MSG("[PHY] Info: Bypassing rx channel filter\n");
+    #endif
+    #ifdef BYPASS_RX_PNORM
+        DEBUG_MSG("[PHY] Info: Bypassing rx power normalization\n");
+    #endif
+    #ifdef BYPASS_PHY_SCRAMBLING
+        DEBUG_MSG("[PHY] Info: Bypassing scrambling\n");
+    #endif
+
+    DEBUG_MSG("[PHY] Initialization done\n");
+
+    return phy;
+
+    error:
+        phy_close(phy);
+        return NULL;
+}
+
+void phy_close(struct phy_handle *phy)
+{
+    int status;
+
+    DEBUG_MSG("[PHY] Closing\n");
+    if (phy != NULL){
+        //close fsk handle
+        fsk_close(phy->fsk);
+        //Stop bladeRF (handle closed elsewhere)
+        radio_stop(phy->dev);
+        //free scrambling sequence buffer
+        free(phy->scrambling_sequence);
+        //free TX struct and its buffers
+        if (phy->tx != NULL){
+            free(phy->tx->data_buf);
+            free(phy->tx->samples);
+            status = pthread_mutex_destroy(&(phy->tx->buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[PHY] %s: Error destroying pthread_mutex\n",
+                        __FUNCTION__);
+            }
+            status = pthread_cond_destroy(&(phy->tx->buf_filled_cond));
+            if (status != 0){
+                fprintf(stderr, "[PHY] %s: Error destroying pthread_cond\n",
+                        __FUNCTION__);
+            }
+        }
+        free(phy->tx);
+        //free RX struct and its buffers
+        if (phy->rx != NULL){
+            free(phy->rx->data_buf);
+            fir_deinit(phy->rx->ch_filt);
+            corr_deinit(phy->rx->corr);
+            pnorm_deinit(phy->rx->pnorm);
+            free(phy->rx->in_samples);
+            free(phy->rx->filt_samples);
+            free(phy->rx->pnorm_samples);
+            status = pthread_mutex_destroy(&(phy->rx->buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[PHY] %s: Error destroying pthread_mutex\n",
+                        __FUNCTION__);
+            }
+            status = pthread_cond_destroy(&(phy->rx->buf_filled_cond));
+            if (status != 0){
+                fprintf(stderr, "[PHY] %s: Error destroying pthread_cond\n",
+                        __FUNCTION__);
+            }
+        }
+        free(phy->rx);
+    }
+    //free phy struct
+    free(phy);
+    phy = NULL;
+}
+
+/****************************************
+ *                                      *
+ *          TRANSMITTER FUNCTIONS       *
+ *                                      *
+ ****************************************/
+
+int phy_start_transmitter(struct phy_handle *phy)
+{
+    int status;
+
+    //turn off stop signal
+    phy->tx->stop = false;
+    //Kick off frame transmitter thread
+    status = pthread_create(&(phy->tx->thread), NULL, phy_transmit_frames, phy);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error creating tx thread: %s\n", __FUNCTION__,
+                strerror(status));
+        return -1;
+    }
+    return 0;
+}
+
+int phy_stop_transmitter(struct phy_handle *phy)
+{
+    int status;
+
+    DEBUG_MSG("[PHY] TX: Stopping transmitter...\n");
+    //signal stop
+    phy->tx->stop = true;
+    //Signal the buffer filled condition so that the thread will stop
+    //waiting for a filled buffer
+    status = pthread_mutex_lock(&(phy->tx->buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error locking pthread_mutex\n", __FUNCTION__);
+    }
+    status = pthread_cond_signal(&(phy->tx->buf_filled_cond));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error signaling pthread_cond\n", __FUNCTION__);
+    }
+    status = pthread_mutex_unlock(&(phy->tx->buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error unlocking pthread_mutex\n", __FUNCTION__);
+    }
+    //Wait for tx thread to finish
+    status = pthread_join(phy->tx->thread, NULL);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error joining tx thread: %s\n", __FUNCTION__,
+                strerror(status));
+        return -1;
+    }
+    DEBUG_MSG("[PHY] TX: Transmitter stopped\n");
+    return 0;
+}
+
+int phy_fill_tx_buf(struct phy_handle *phy, uint8_t *data_buf, unsigned int length)
+{
+    int status;
+
+    //Check for null
+    if (data_buf == NULL){
+        fprintf(stderr, "[PHY] %s: The supplied data buf is null\n", __FUNCTION__);
+        return -1;
+    }
+    //Check for length outside of bounds
+    if (length > MAX_LINK_FRAME_SIZE){
+        fprintf(stderr, "[PHY] %s: Data length of %u is greater than the maximum "
+                        "allowed length (%u)\n", __FUNCTION__, length,
+                        MAX_LINK_FRAME_SIZE);
+        return -1;
+    }
+    //Wait for the buffer to be empty (and therefore ready for the next frame)
+    //Not doing a pthread_cond_wait() because this shouldn't take long
+    while(phy->tx->buf_filled){
+        usleep(50);
+    }
+
+    //Copy the tx data into the phy's tx data buf, just after where the preamble goes
+    memcpy(&(phy->tx->data_buf[TRAINING_SEQ_LENGTH+PREAMBLE_LENGTH]), data_buf, length);
+    //Set the data length
+    phy->tx->data_length = length;
+    //Mark the buffer filled
+    phy->tx->buf_filled = true;
+    //Signal the buffer filled condition
+    status = pthread_mutex_lock(&(phy->tx->buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error locking pthread_mutex\n", __FUNCTION__);
+        return -1;
+    }
+    status = pthread_cond_signal(&(phy->tx->buf_filled_cond));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error signaling pthread_cond\n", __FUNCTION__);
+        return -1;
+    }
+    status = pthread_mutex_unlock(&(phy->tx->buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error unlocking pthread_mutex\n", __FUNCTION__);
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * Thread function which transmits data frames
+ * 
+ * @param[in]   arg     pointer to phy handle struct
+ */
+void *phy_transmit_frames(void *arg)
+{
+    int status;
+    //Cast arg
+    struct phy_handle *phy = (struct phy_handle *) arg;
+    uint8_t preamble[PREAMBLE_LENGTH] = PREAMBLE;
+    uint8_t training_seq[TRAINING_SEQ_LENGTH] = TRAINING_SEQ;
+    int ramp_down_index;
+    int num_mod_samples, num_samples;
+    bool failed = false;
+    struct bladerf_metadata metadata;
+    int16_t *out_samples_raw = NULL;
+
+    out_samples_raw = malloc(phy->tx->max_num_samples * 2 * sizeof(int16_t));
+    if (out_samples_raw == NULL){
+        perror("[PHY] malloc");
+        return NULL;
+    }
+
+    //Set field(s) in bladerf metadata struct
+    memset(&metadata, 0, sizeof(metadata));
+    metadata.flags =     BLADERF_META_FLAG_TX_BURST_START |
+                        BLADERF_META_FLAG_TX_NOW |
+                        BLADERF_META_FLAG_TX_BURST_END;
+
+    while (!phy->tx->stop){
+        //--------Wait for buffer to be filled---------
+        //Lock mutex
+        status = pthread_mutex_lock(&(phy->tx->buf_status_lock));
+        if (status != 0){
+            fprintf(stderr, "[PHY] %s: Mutex lock failed: %s\n", __FUNCTION__,
+                    strerror(status));
+            return NULL;
+        }
+        //Wait for condition signal - meaning buffer is full
+        while (!phy->tx->buf_filled && !phy->tx->stop){
+            DEBUG_MSG("[PHY] TX: Waiting for buffer to be filled\n");
+            status = pthread_cond_wait(&(phy->tx->buf_filled_cond), &(phy->tx->buf_status_lock));
+            if (status != 0){
+                fprintf(stderr, "[PHY] %s: Condition wait failed: %s\n", __FUNCTION__,
+                        strerror(status));
+                failed = true;
+                break;
+            }
+        }
+        //Unlock mutex
+        status = pthread_mutex_unlock(&(phy->tx->buf_status_lock));
+        if (status != 0){
+            fprintf(stderr, "[PHY] %s: Mutex unlock failed: %s\n", __FUNCTION__,
+                    strerror(status));
+            failed = true;
+        }
+        //Stop thread if stop variable is true, or something with pthreads went wrong
+        if (phy->tx->stop || failed){
+            phy->tx->buf_filled = false;
+            return NULL;
+        }
+        //------------Transmit the frame-------------
+        DEBUG_MSG("[PHY] TX: Buffer filled. Transmitting.\n");
+        //Calculate the number of samples to transmit.
+        num_samples = 2*RAMP_LENGTH + (TRAINING_SEQ_LENGTH + PREAMBLE_LENGTH +
+                    phy->tx->data_length) * 8 * SAMP_PER_SYMB;
+        //Add training sequence to tx data buffer
+        memcpy(phy->tx->data_buf, &training_seq, TRAINING_SEQ_LENGTH);
+        //Add preamble to tx data buffer
+        memcpy(&(phy->tx->data_buf[TRAINING_SEQ_LENGTH]), &preamble, PREAMBLE_LENGTH);
+        #ifndef BYPASS_PHY_SCRAMBLING
+            //Scramble the frame data (not including the training sequence or preamble)
+            scramble_frame(&(phy->tx->data_buf[TRAINING_SEQ_LENGTH + PREAMBLE_LENGTH]),
+                            phy->tx->data_length, phy->scrambling_sequence);
+        #endif
+        //zero the tx samples buffer
+        memset(phy->tx->samples, 0, sizeof(int16_t) * 2 * num_samples);
+        //modulate samples - leave space for ramp up/ramp down in the samples buffer
+        num_mod_samples = fsk_mod(phy->fsk, phy->tx->data_buf,
+                            TRAINING_SEQ_LENGTH + PREAMBLE_LENGTH + phy->tx->data_length,
+                            &(phy->tx->samples[RAMP_LENGTH]));
+        //Mark the buffer empty
+        phy->tx->buf_filled = false;
+
+        //Add the ramp up/ ramp down of samples
+        ramp_down_index = RAMP_LENGTH+num_mod_samples;
+        create_ramps(RAMP_LENGTH, phy->tx->samples[ramp_down_index-1], phy->tx->samples,
+                        &(phy->tx->samples[ramp_down_index]));
+        //Convert samples
+        conv_struct_to_samples(phy->tx->samples, num_samples, out_samples_raw);
+
+        //transmit all samples. TX_NOW
+        status = bladerf_sync_tx(phy->dev, out_samples_raw, num_samples,
+                                &metadata, 5000);
+        if (status != 0){
+            fprintf(stderr, "[PHY] %s: Couldn't transmit samples with bladeRF: %s\n",
+                    __FUNCTION__, bladerf_strerror(status));
+            return NULL;
+        }
+    }
+
+    free(out_samples_raw);
+    return NULL;
+}
+
+/**
+ * Creates a ramp up and ramp down of samples in the following format: Ramp up will use
+ * 'ramp_length' samples to ramp up the I samples from 0 to 2048, and set the Q samples to 0.
+ * Ramp down will use 'ramp_length' samples to ramp down  the I samples from
+ * ramp_down_init.i to 0, and ramp down the Q samples from ramp_down_init.q to 0.
+ *
+ * Ex: If ramp_length is 4, ramp_down_i_init is -2048, and ramp_down_q_init is 0,
+ * ramp_up buffer will be:
+ * [.25+0j  .5+0j  .75+0j  1+0j] scaled by 2048
+ * and ramp_down will be
+ * [-.75+0j  -.5+0j  -.25+0j  0+0j] scaled by 2048
+ */
+static void create_ramps(unsigned int ramp_length, struct complex_sample ramp_down_init,
+                    struct complex_sample *ramp_up, struct complex_sample *ramp_down)
+{
+    unsigned int samp;
+    double ramp_up_step = 2048.0/ramp_length;
+    double ramp_down_step_i;
+    double ramp_down_step_q;
+
+    //Determine ramp down steps
+    if (ramp_down_init.i == 0){
+        ramp_down_step_i = 0;
+    }else{
+        ramp_down_step_i = (double)ramp_down_init.i/(double)ramp_length;
+    }
+    if (ramp_down_init.q == 0){
+        ramp_down_step_q = 0;
+    }else{
+        ramp_down_step_q = (double)ramp_down_init.q/(double)ramp_length;
+    }
+    //Create the ramps
+    for (samp = 0; samp < ramp_length-1; samp++){
+        //ramp up
+        ramp_up[samp].i = (int16_t) rint(ramp_up_step*(samp+1));    //I
+        ramp_up[samp].q = 0;                            //Q
+
+        //ramp down
+		ramp_down[samp].i = (int16_t) rint(ramp_down_init.i - ramp_down_step_i*(samp + 1));
+		ramp_down[samp].q = (int16_t) rint(ramp_down_init.q - ramp_down_step_q*(samp + 1));
+    }
+
+    //Set last ramp up/ ramp down sample (will always be the same)
+    ramp_up[ramp_length-1].i = 2047;    //I
+    ramp_up[ramp_length-1].q = 0;        //Q
+
+    ramp_down[ramp_length-1].i = 0;        //I
+    ramp_down[ramp_length-1].q = 0;        //Q
+}
+
+/**
+ * Scrambles the given data with the given scrambling sequence. The size of the
+ * scrambling sequence array must be at least as large as the frame.
+ */
+static void scramble_frame(uint8_t *frame, int frame_length,
+                            uint8_t *scrambling_sequence)
+{
+    int i;
+    for (i = 0; i < frame_length; i++){
+        //XOR byte with byte from scrambling sequence
+        frame[i] ^= scrambling_sequence[i];
+    }
+}
+
+/****************************************
+ *                                      *
+ *          RECEIVER FUNCTIONS          *
+ *                                      *
+ ****************************************/
+
+int phy_start_receiver(struct phy_handle *phy)
+{
+    int status;
+
+    //turn off stop signal
+    phy->rx->stop = false;
+    //Kick off frame receiver thread
+    status = pthread_create(&(phy->rx->thread), NULL, phy_receive_frames, phy);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error creating rx thread: %s\n", __FUNCTION__,
+                strerror(status));
+        return -1;
+    }
+    return 0;
+}
+
+int phy_stop_receiver(struct phy_handle *phy)
+{
+    int status;
+
+    DEBUG_MSG("[PHY] RX: Stopping receiver...\n");
+    //signal stop
+    phy->rx->stop = true;
+    //Wait for rx thread to finish
+    status = pthread_join(phy->rx->thread, NULL);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error joining rx thread: %s\n", __FUNCTION__,
+                strerror(status));
+        return -1;
+    }
+    DEBUG_MSG("[PHY] RX: Receiver stopped\n");
+    return 0;
+}
+
+uint8_t *phy_request_rx_buf(struct phy_handle *phy, unsigned int timeout_ms)
+{
+    int status;
+    struct timespec timeout_abs;
+    bool failed = false;
+
+    //Create absolute time format timeout
+    status = create_timeout_abs(timeout_ms, &timeout_abs);
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error creating timeout\n", __FUNCTION__);
+        return NULL;
+    }
+
+    //Lock mutex
+    status = pthread_mutex_lock(&(phy->rx->buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Error locking mutex: %s\n", __FUNCTION__,
+                    strerror(status));
+        return NULL;
+    }
+    //Wait for condition signal - meaning buffer is full
+    while (!phy->rx->buf_filled){
+        status = pthread_cond_timedwait(&(phy->rx->buf_filled_cond), &(phy->rx->buf_status_lock),
+                                        &timeout_abs);
+        if (status != 0){
+            if (status == ETIMEDOUT){
+                //DEBUG_MSG("[PHY] phy_request_rx_buf(): Condition wait timed out\n");
+            }else{
+                fprintf(stderr, "[PHY] %s: Condition wait failed: %s\n", __FUNCTION__,
+                            strerror(status));
+            }
+            failed = true;
+            break;
+        }
+    }
+    //Unlock mutex
+    status = pthread_mutex_unlock(&(phy->rx->buf_status_lock));
+    if (status != 0){
+        fprintf(stderr, "[PHY] %s: Mutex unlock failed: %s\n", __FUNCTION__,
+                strerror(status));
+        failed = true;
+    }
+
+    if (failed){
+        return NULL;
+    }
+    return phy->rx->data_buf;
+}
+
+void phy_release_rx_buf(struct phy_handle *phy)
+{
+    phy->rx->buf_filled = false;
+}
+
+/**
+ * Thread function which listens for and receives frames. The steps are:
+ * 1) Receive samples with libbladeRF
+ * 2) Low pass filter the samples
+ * 3) Power normalize the samples
+ * 4) Correlate the samples with the preamble waveform
+ * 5) If a match is found, demodulate the samples into data bytes
+ * 6) Unscramble the data
+ * 7) Copy the frame to a buffer which can be acquired with phy_request_rx_buf(), or
+ *    drop the frame if the buffer is still in use
+ *
+ * @param    arg        pointer to phy_handle struct
+ */
+void *phy_receive_frames(void *arg)
+{
+    struct phy_handle *phy = (struct phy_handle *) arg;
+    int status;
+    unsigned int num_bytes_rx;
+    unsigned int data_index;        //Current index of rx_buffer to receive new bytes on
+                                    //doubles as the current received frame length
+    uint64_t samples_index;            //Current index of samples buffer to correlate/demod
+                                    //samples from
+    bool preamble_detected;
+    bool new_frame;
+    int frame_length = 0;            //link layer frame length
+    uint8_t *rx_buffer = NULL;    //local rx data buffer
+    uint8_t frame_type;
+    struct bladerf_metadata metadata;            //bladerf metadata for sync_rx()
+    unsigned int num_bytes_to_demod;
+    uint64_t timestamp = UINT64_MAX;
+
+    enum states {RECEIVE, PREAMBLE_CORRELATE, DEMOD,
+                    CHECK_FRAME_TYPE, DECODE, COPY};
+    enum states state;                //current state variable
+
+    //Allocate memory for buffer
+    rx_buffer = malloc(MAX_LINK_FRAME_SIZE);
+    if (rx_buffer == NULL){
+        perror("[PHY] malloc");
+        goto out;
+    }
+
+    //Set bladeRF metadata
+    memset(&metadata, 0, sizeof(metadata));
+    metadata.flags = BLADERF_META_FLAG_RX_NOW;
+
+    preamble_detected = false;
+    data_index = 0;
+    state = RECEIVE;
+    //Loop until stop signal detected
+    while(!phy->rx->stop){
+        switch(state){
+            case RECEIVE:
+                //--Receive samples, filter, and power normalize
+                //DEBUG_MSG("[PHY] RX: State = RECEIVE\n");
+                samples_index = 0;
+                status = bladerf_sync_rx(phy->dev, phy->rx->in_samples, NUM_SAMPLES_RX,
+                                            &metadata, 5000);
+                if (status != 0){
+                    fprintf(stderr, "[PHY] %s: Couldn't receive samples from bladeRF\n",
+                            __FUNCTION__);
+                    goto out;
+                }
+                //Check metadata
+                if (metadata.status & BLADERF_META_STATUS_OVERRUN){
+                    NOTE("[PHY] %s: Got an overrun. Expected count = %u;"
+                                " actual count = %u. Skipping these samples.\n",
+                                __FUNCTION__, NUM_SAMPLES_RX, metadata.actual_count);
+                    break;
+                }
+                if (timestamp != UINT64_MAX && metadata.timestamp != timestamp+NUM_SAMPLES_RX){
+                    NOTE("[PHY] %s: Unexpected timestamp. Expected %lu, got %lu.\n",
+                            __FUNCTION__, timestamp+NUM_SAMPLES_RX, metadata.timestamp);
+                }
+                timestamp = metadata.timestamp;
+
+                #ifndef BYPASS_RX_CHANNEL_FILTER
+                    // Apply channel filter
+                    fir_process(phy->rx->ch_filt, phy->rx->in_samples,
+                                phy->rx->filt_samples, NUM_SAMPLES_RX);
+                #else
+                    conv_samples_to_struct(phy->rx->in_samples, NUM_SAMPLES_RX,
+                                            phy->rx->filt_samples);
+                #endif
+                //Power normalize
+                #ifndef BYPASS_RX_PNORM
+                    pnorm(phy->rx->pnorm, NUM_SAMPLES_RX, phy->rx->filt_samples,
+                            phy->rx->pnorm_samples, NULL, NULL);
+                #else
+                    memcpy(phy->rx->pnorm_samples, phy->rx->filt_samples,
+                            NUM_SAMPLES_RX * sizeof(struct complex_sample));
+                #endif
+                if (preamble_detected){
+                    state = DEMOD;
+                }else{
+                    state = PREAMBLE_CORRELATE;
+                }
+                break;
+            case PREAMBLE_CORRELATE:
+                //--Cross correlate received samples with preamble to find start
+                //--of the data frame
+                //DEBUG_MSG("[PHY] RX: State = PREAMBLE_CORRELATE\n");
+                samples_index = corr_process(phy->rx->corr,
+                                            &(phy->rx->pnorm_samples[samples_index]),
+                                            NUM_SAMPLES_RX-samples_index, 0);
+                if (samples_index != CORRELATOR_NO_RESULT){
+                    DEBUG_MSG("[PHY] RX: Preamble matched @ index %lu\n", samples_index);
+                    preamble_detected = true;
+                    new_frame = true;
+                    //First we only demod the first byte to determine frame type
+                    num_bytes_to_demod = 1;
+                    data_index = 0;
+                    state = DEMOD;
+                }else{
+                    //No preamble match. Receive more samples
+                    state = RECEIVE;
+                }
+                break;
+            case DEMOD:
+                //--Demod samples
+                DEBUG_MSG("[PHY] RX: State = DEMOD\n");
+                num_bytes_rx = fsk_demod(phy->fsk, &(phy->rx->pnorm_samples[samples_index]),
+                                        NUM_SAMPLES_RX-(int)samples_index, new_frame,
+                                        num_bytes_to_demod, &rx_buffer[data_index]);
+                if (num_bytes_rx < num_bytes_to_demod){
+                    //Receive more samples
+                    num_bytes_to_demod -= num_bytes_rx;
+                    state = RECEIVE;
+                }else{
+                    if (new_frame){
+                        state = CHECK_FRAME_TYPE;
+                        //Account for extra sample which defines initial phase
+                        samples_index++;
+                    }else{
+                        //We demoded all samples in the frame
+                        state = DECODE;
+                    }
+                }
+                data_index += num_bytes_rx;
+                samples_index += num_bytes_rx*8*SAMP_PER_SYMB;
+                new_frame = false;
+                break;
+            case CHECK_FRAME_TYPE:
+                //--Check the frame type byte
+                DEBUG_MSG("[PHY] RX: State = CHECK_FRAME_TYPE\n");
+                #ifndef BYPASS_PHY_SCRAMBLING
+                    frame_type = rx_buffer[0] ^ phy->scrambling_sequence[0];
+                #else
+                    frame_type = rx_buffer[0];
+                #endif
+                //Set frame length according to what type of frame it is
+                if (frame_type == ACK_FRAME_CODE){
+                    DEBUG_MSG("[PHY] RX: Getting an ACK frame...\n");
+                    frame_length = ACK_FRAME_LENGTH;
+                }else if(frame_type == DATA_FRAME_CODE){
+                    DEBUG_MSG("[PHY] RX: Getting a data frame...\n");
+                    frame_length = DATA_FRAME_LENGTH;
+                }else{
+                    NOTE("[PHY] %s: rx'ed unknown frame type 0x%.2X\n",
+                            __FUNCTION__, frame_type);
+                    data_index = 0;
+                    preamble_detected = false;
+                    state = RECEIVE;
+                    break;
+                }
+                //Demod the rest of the bytes
+                num_bytes_to_demod = frame_length-1;
+                state = DEMOD;
+                break;
+            case DECODE:
+                //--Remove any phy encoding on the received frame
+                DEBUG_MSG("[PHY] RX: State = DECODE\n");
+                #ifndef BYPASS_PHY_SCRAMBLING
+                    //Unscramble the frame
+                    unscramble_frame(rx_buffer, frame_length, phy->scrambling_sequence);
+                #endif
+                state = COPY;
+                break;
+            case COPY:
+                //--Copy frame into buffer which can be accessed by the link layer
+                DEBUG_MSG("[PHY] RX: State = COPY\n");
+                //Is the link layer still working with the previous frame?
+                if (phy->rx->buf_filled){
+                    //Instead of disrupting the link layer, drop this frame
+                    NOTE("[PHY] RX: Frame dropped!\n");
+                }else{
+                    //Copy frame into rx_data_buf
+                    memcpy(phy->rx->data_buf, rx_buffer,
+                            frame_length);
+                    phy->rx->buf_filled = true;
+                    //Signal that the buffer is filled
+                    status = pthread_mutex_lock(&(phy->rx->buf_status_lock));
+                    if (status != 0){
+                        fprintf(stderr, "[PHY] %s: Error locking pthread_mutex\n",
+                                __FUNCTION__);
+                        goto out;
+                    }
+                    status = pthread_cond_signal(&(phy->rx->buf_filled_cond));
+                    if (status != 0){
+                        fprintf(stderr, "[PHY] %s: Error signaling pthread_cond\n",
+                                __FUNCTION__);
+                        goto out;
+                    }
+                    status = pthread_mutex_unlock(&(phy->rx->buf_status_lock));
+                    if (status != 0){
+                        fprintf(stderr, "[PHY] %s: Error unlocking pthread_mutex\n",
+                                __FUNCTION__);
+                        goto out;
+                    }
+                    DEBUG_MSG("[PHY] RX: Frame ready\n");
+                }
+                preamble_detected = false;
+
+                if (samples_index == NUM_SAMPLES_RX){
+                    state = RECEIVE;
+                }else{
+                    state = PREAMBLE_CORRELATE;
+                }
+                break;
+            default:
+                fprintf(stderr, "[PHY] %s: Invalid state\n", __FUNCTION__);
+                goto out;
+        }
+    }
+    out:
+        free(rx_buffer);
+        return NULL;
+}
+
+/**
+ * Unscrambles the given data with the given scrambling sequence. The size of the
+ * scrambling sequence array must be at least as large as the frame.
+ */
+static void unscramble_frame(uint8_t *frame, int frame_length,
+                                uint8_t *scrambling_sequence)
+{
+    int i;
+    for (i = 0; i < frame_length; i++){
+        //XOR byte with byte from scrambling sequence
+        frame[i] ^= scrambling_sequence[i];
+    }
+}

--- a/host/utilities/bladeRF-fsk/c/src/phy.h
+++ b/host/utilities/bladeRF-fsk/c/src/phy.h
@@ -1,0 +1,167 @@
+/**
+ * @file
+ * @brief   Physical layer code for modem
+ *
+ * This file handles transmission/reception of data frames over the air. It uses fsk.c to
+ * perform baseband IQ modulation and demodulation, and libbladeRF to transmit/receive
+ * samples using the bladeRF device. A different modulator could be used by swapping
+ * fsk.c with a file that implements a different modulator. On the receive side the file
+ * uses fir_filter.c to low-pass filter the received signal, pnorm.c to power normalize
+ * the input signal, and correlator.c to correlate the received signal with a preamble.
+ * waveform.
+ *
+ * The structure of a physical layer transmission is as follows:
+ * ```
+ *    / ramp up | training sequence | preamble | link layer frame | ramp down \
+ * ```
+ * The ramps at the beginning/end are SAMP_PER_SYMB samples long
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef PHY_H
+#define PHY_H
+
+#include <stdbool.h>
+#include <libbladeRF.h>
+#include <string.h>
+#include <pthread.h>
+#include <errno.h>
+#include <math.h>
+
+#include "host_config.h"
+#include "common.h"
+#include "utils.h"
+
+//Training sequence which goes at the start of every frame
+//Note: In order for the preamble waveform not to be messed up, the last
+//sample of the modulated training sequence MUST be 1 + 0j (2047 + 0j)
+#define TRAINING_SEQ {0xAA, 0xAA, 0xAA, 0xAA}
+//Length of training sequence in bytes
+#define TRAINING_SEQ_LENGTH 4
+//preamble which goes after the training sequence
+#define PREAMBLE {0x2E, 0x69, 0x2C, 0xF0}
+//Length of preamble in bytes
+#define PREAMBLE_LENGTH 4
+//Byte codes for data/ack frame
+#define DATA_FRAME_CODE 0x00
+#define ACK_FRAME_CODE 0xFF
+//Frame lengths
+#define DATA_FRAME_LENGTH 1009
+#define ACK_FRAME_LENGTH 7
+//Maximum frame size in bytes
+#define MAX_LINK_FRAME_SIZE DATA_FRAME_LENGTH
+//Seed for pseudorandom number sequence generator
+#define PRNG_SEED 0x0109BBA53CFFD081
+//Length (in samples) of ramp up/ramp down
+#define RAMP_LENGTH SAMP_PER_SYMB
+//Number of samples to receive at a time from bladeRF
+#define NUM_SAMPLES_RX SYNC_BUFFER_SIZE
+//Correlator countdown size
+#define CORR_COUNTDOWN SAMP_PER_SYMB
+
+struct phy_handle;
+
+//----------------------Transmitter functions---------------------------
+/**
+ * Start the PHY transmitter thread
+ * 
+ * @param[in]   phy     pointer to phy_handle struct
+ *
+ * @return      0 on success, -1 on failure
+ */
+int phy_start_transmitter(struct phy_handle *phy);
+
+/**
+ * Stop the PHY transmitter thread
+ * 
+ * @param[in]   phy     pointer to phy_handle struct
+ *
+ * @return      0 on success, -1 on failure
+ */
+int phy_stop_transmitter(struct phy_handle *phy);
+
+/**
+ * Fill the tx buffer so its data will be transmitted using phy_transmit_frames()
+ *
+ * @param[in]   phy         pointer to phy handle structure
+ * @param[in]   data_buf    bytes to transmit
+ * @param[in]   length      length of data buf
+ *
+ * @return      0 on success, -1 on failure
+ */
+int phy_fill_tx_buf(struct phy_handle *phy, uint8_t *data_buf, unsigned int length);
+
+//------------------------Receiver functions---------------------------
+/**
+ * Start the PHY receiver  thread
+ * 
+ * @param[in]   phy     pointer to phy_handle struct
+ *
+ * @return      0 on success, -1 on failure
+ */
+int phy_start_receiver(struct phy_handle *phy);
+
+/**
+ * Stop the PHY receiver thread
+ * 
+ * @param[in]   phy     pointer to phy_handle struct
+ *
+ * @return      0 on success, -1 on failure
+ */
+int phy_stop_receiver(struct phy_handle *phy);
+
+/**
+ * Request a received frame from phy_receive_frames(). Caller should call
+ * phy_release_rx_buf() when done with the received frame so that 
+ * phy_receive_frames() does not drop any frames.
+ *
+ * @param[in]   phy             pointer to phy_handle struct
+ * @param[in]   timeout_ms      amount of time to wait for a buffer from the PHY
+ *
+ * @return      pointer to filled buffer with received frame inside
+ */
+uint8_t *phy_request_rx_buf(struct phy_handle *phy, unsigned int timeout_ms);
+
+/**
+ * Release RX buffer so that phy_receive_frames() can copy new frames into the buffer
+ *
+ * @param[in]   phy     pointer to phy_handle struct
+ */
+void phy_release_rx_buf(struct phy_handle *phy);
+
+//-----------------------Init/Deinit functions-------------------------
+/**
+ * Open/Initialize a phy_handle
+ * 
+ * @param[in]   dev     pointer to opened bladeRF device handle
+ * @param[in]   params  pointer to radio parameters struct
+ *
+ * @return      allocated phy_handle on success, NULL on failure
+ */
+struct phy_handle *phy_init(struct bladerf *dev, struct radio_params *params);
+
+/**
+ * Close a phy handle. Does nothing if handle is NULL
+ *
+ * @param[in]   phy_handle to close
+ */
+void phy_close(struct phy_handle *phy);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/pnorm.c
+++ b/host/utilities/bladeRF-fsk/c/src/pnorm.c
@@ -1,0 +1,205 @@
+/**
+ * @brief   Normalizes the input IQ signal [-1.0, 1.0] to a power of 1.0
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <stdio.h>
+#include <math.h>
+
+#include "pnorm.h"
+
+struct pnorm_state_t {
+    float est ;            //Estimate of signal power (essentially a running average)
+    bool hold ;            //Hold the current gain?
+    float alpha ;
+    float invalpha ;
+    float min_gain ;
+    float max_gain ;
+} ;
+
+struct pnorm_state_t *pnorm_init(float alpha, float min_gain, float max_gain) {
+    struct pnorm_state_t *state ;
+    state = malloc(sizeof(state[0])) ;
+    if( state == NULL ) {
+        perror("malloc") ;
+        return NULL ;
+    }
+    state->est = 1.0f ;
+    state->hold = false ;
+    state->alpha = alpha ;
+    state->invalpha = (1.0f - alpha) ;
+
+    assert(min_gain < max_gain) ;
+    state->min_gain = min_gain ;
+    state->max_gain = max_gain ;
+
+    return state ;
+}
+
+void pnorm_reset(struct pnorm_state_t *state) {
+    state->est = 1.0f ;
+    state->hold = false ;
+}
+
+void pnorm_deinit(struct pnorm_state_t *state) {
+    free(state) ;
+    return ;
+}
+
+void pnorm_hold(struct pnorm_state_t *state, bool val) {
+    state->hold = val ;
+    return ;
+}
+
+void pnorm(struct pnorm_state_t *state, uint16_t length, struct complex_sample *in,
+            struct complex_sample *out, float *ests, float *gains) {
+    int i ;
+    float power;
+    int32_t temp;
+    float gain, est;
+
+    for( i = 0 ; i < length ; i++ ) {
+        /* Power IIR filter */
+        if( state->hold == false ) {
+            //New estimate of power (normalized)
+            est = state->est = state->alpha*state->est +
+                state->invalpha*(in[i].i*in[i].i + in[i].q*in[i].q)/(SAMP_MAX_ABS*SAMP_MAX_ABS);
+        } else {
+            est = state->est ;
+        }
+
+        /* Ideal power is 1.0, so to get x to 1.0, we need to multiply by 1/est */
+        gain = 1.0f/sqrtf(state->est) ;
+
+        /* Check below min gain */
+        if( gain < state->min_gain ) {
+            gain = state->min_gain ;
+        }
+
+        /* Check above max gain */
+        if( gain > state->max_gain ) {
+            gain = state->max_gain ;
+        }
+
+        /* Apply gain */
+        //Use temp int32_t in case this number goes outside 16bit range
+        temp = (int32_t) round(in[i].i * gain);
+        //Clamp
+        if (temp > CLAMP_VAL_ABS){
+            temp = CLAMP_VAL_ABS;
+        }else if (temp < -CLAMP_VAL_ABS){
+            temp = -CLAMP_VAL_ABS;
+        }
+        out[i].i = (int16_t) temp;
+
+        temp = (int32_t) round(in[i].q * gain);
+        //Clamp
+        if (temp > CLAMP_VAL_ABS){
+            temp = CLAMP_VAL_ABS;
+        }else if (temp < -CLAMP_VAL_ABS){
+            temp = -CLAMP_VAL_ABS;
+        }
+        out[i].q = (int16_t) temp;
+
+        /* Blank impulse power */
+        power = (out[i].i * out[i].i + out[i].q * out[i].q)/(float)(SAMP_MAX_ABS*SAMP_MAX_ABS);
+        if (power >= 10.0f) {
+            out[i].i = out[i].q = 0;
+        }
+
+        //Write to debug buffers
+        if (ests != NULL){
+            ests[i] = est;
+        }
+        if (gains != NULL){
+            gains[i] = gain;
+        }
+    }
+    return ;
+}
+
+#ifdef PNORM_TEST
+
+#define NUM_SAMPLES 4000
+
+struct complex_sample input[NUM_SAMPLES] ;
+struct complex_sample output[NUM_SAMPLES] ;
+float est[NUM_SAMPLES] ;
+float gain[NUM_SAMPLES] ;
+
+int main(int argc, char *argv[]) {
+    FILE *fin, *fout ;
+    struct pnorm_state_t *state ;
+    float alpha, min_gain, max_gain ;
+    unsigned int count, i ;
+    int result;
+
+    if( argc < 6 ) {
+        fprintf(stderr, "Usage: %s <alpha> <min gain> <max gain> <input csv> <output csv>\n", argv[0]) ;
+        return 1 ;
+    }
+
+    fin = fopen( argv[4], "r" ) ;
+    if( fin == NULL ) {
+        fprintf( stderr, "Couldn't open %s\n for input csv",argv[2] ) ;
+        return 1 ;
+    }
+
+    fout = fopen( argv[5], "w" ) ;
+    if( fout == NULL ) {
+        fprintf( stderr, "Couldn't open %s for output csv", argv[3] ) ;
+    }
+
+    alpha = (float) atof(argv[1]) ;
+    min_gain = (float) atof(argv[2]) ;
+    max_gain = (float) atof(argv[3]) ;
+
+    state = pnorm_init(alpha, min_gain, max_gain) ;
+    while (!feof(fin)) {
+        count = 0 ;
+        while( count < sizeof(input) && !feof(fin) ) {
+            result = fscanf( fin, "%hi,%hi\n", &input[count].i, &input[count].q ) ;
+            if (result == EOF){
+                break;
+            }
+            count++ ;
+        }
+        pnorm( state, count, input, output, est, gain ) ;
+        for( i = 0 ; i < count ; i++ ) {
+            fprintf( fout, "%hi,%hi,%15.9f,%15.9f\n", output[i].i,
+                    output[i].q, est[i], gain[i] ) ;
+        }
+    }
+
+    pnorm_deinit(state) ;
+
+    fclose( fin ) ;
+    fclose( fout ) ;
+
+    return 0 ;
+}
+
+#endif
+

--- a/host/utilities/bladeRF-fsk/c/src/pnorm.h
+++ b/host/utilities/bladeRF-fsk/c/src/pnorm.h
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * @brief   Normalizes the input IQ signal [-1.0, 1.0] to a power of 1.0
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef PNORM_H_
+#define PNORM_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "common.h"    //For struct complex_sample
+
+#define SAMP_MAX_ABS 2048
+#define CLAMP_VAL_ABS 3072
+
+struct pnorm_state_t ;
+
+struct pnorm_state_t *pnorm_init(float alpha, float min_gain, float max_gain) ;
+void pnorm_reset(struct pnorm_state_t *state) ;
+void pnorm_deinit(struct pnorm_state_t *state) ;
+void pnorm_hold(struct pnorm_state_t *state, bool val) ;
+
+/**
+ * Power normalize a set of samples.
+ * The 'ests' and 'gains' output buffers are for extra debug information. If they are NULL,
+ * the function will not attempt to place values in them.
+ */
+void pnorm(struct pnorm_state_t *state, uint16_t length, struct complex_sample *in,
+            struct complex_sample *out, float *est, float *gain);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/prng.c
+++ b/host/utilities/bladeRF-fsk/c/src/prng.c
@@ -1,0 +1,129 @@
+/**
+ * @brief   XORshift Pseudorandom number generator
+ *
+ * https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "prng.h"
+
+uint8_t * prng_fill(uint64_t *state_inout, size_t len)
+{
+    size_t i;
+    size_t to_fill;
+    uint8_t *ret, *curr;
+    uint64_t state = *state_inout;
+
+    assert(state != 0);
+
+    ret = malloc(len);
+    if (!ret) {
+        return NULL;
+    }
+
+    curr = ret;
+
+    /* Fill 64-bit words first */
+    to_fill = (len / 8) * 8;
+
+    for (i = 0; i < to_fill; i += 8, curr += 8) {
+        state = prng_update(state);
+        curr[0] = (state >> 0)  & 0xff;
+        curr[1] = (state >> 8)  & 0xff;
+        curr[2] = (state >> 16) & 0xff;
+        curr[3] = (state >> 24) & 0xff;
+        curr[4] = (state >> 32) & 0xff;
+        curr[5] = (state >> 40) & 0xff;
+        curr[6] = (state >> 48) & 0xff;
+        curr[7] = (state >> 56) & 0xff;
+    }
+
+    /* Fill remaining partial words */
+    to_fill = len - to_fill;
+    if (to_fill != 0) {
+        state = prng_update(state);
+        for (i = 0; i < to_fill; i++) {
+            *curr = state & 0xff;
+            state >>= 8;
+            curr++;
+        }
+    }
+
+    return ret;
+}
+
+#ifdef PRNG_TEST
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+int main(int argc, char *argv[])
+{
+    int len;
+    uint64_t seed;
+    uint8_t *buf;
+    FILE *out;
+    ssize_t n_written;
+    int status = 0;
+
+    if (argc < 4 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
+        fprintf(stderr, "Usage: %s <seed> <length> <output file>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    seed = atoll(argv[1]);
+    if (seed == 0) {
+        fprintf(stderr, "Seed must be non-zero.\n");
+        return EXIT_FAILURE;
+    }
+
+    len = atoi(argv[2]);
+    if (len <= 0) {
+        fprintf(stderr, "Length must be >= 1.\n");
+        return EXIT_FAILURE;
+    }
+
+    buf = prng_fill(&seed, len);
+    if (!buf) {
+        fprintf(stderr, "Failed to create PRNG data buffer.\n");
+        return EXIT_FAILURE;
+    }
+
+    out = fopen(argv[3], "wb");
+    if (!out) {
+        fprintf(stderr, "Failed to open %s for writing: %s\n",
+                argv[3], strerror(errno));
+        goto out;
+    }
+
+    n_written = fwrite(buf, 1, len, out);
+    if (n_written != len) {
+        fprintf(stderr, "Failed to write PRNG data.\n");
+        status = EXIT_FAILURE;
+    }
+
+    fclose(out);
+
+out:
+    free(buf);
+    return status;
+}
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/prng.h
+++ b/host/utilities/bladeRF-fsk/c/src/prng.h
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * @brief   XORshift Pseudorandom number generator
+ *
+ * https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "host_config.h"
+
+/**
+ * Update the PRNG value
+ *
+ * @param   state_in    Input PRNG state. Must be non-zero.
+ *
+ * @return next PRNG value in the sequence
+ */
+static inline uint64_t prng_update(uint64_t state_in)
+{
+    uint64_t state = state_in;
+    assert(state != 0);
+
+    state ^= state >> 12;
+    state ^= state << 25;
+    state ^= state >> 27;
+    state *= 0x2545f4914f6cdd1d;
+
+    return state;
+}
+
+/**
+ * Allocate and fill a byte array with PRNG values. The caller is responsible
+ * for freeing the returned buffer.
+ *
+ * @param[inout]  state    PRNG state or seed. Updated with new state.
+ * @param[in]     len      Desired buffer length, in bytes. Recommended
+ *                         to be a multiple of 8.
+ *
+ * @return Heap-allocated buffer filled with PRNG output on success,
+ *         NULL on failure.
+ */
+uint8_t * prng_fill(uint64_t *state, size_t len);

--- a/host/utilities/bladeRF-fsk/c/src/radio_config.c
+++ b/host/utilities/bladeRF-fsk/c/src/radio_config.c
@@ -1,0 +1,236 @@
+/**
+ * @brief   BladeRF radio configuration - setting of frequencies, gains, etc.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "radio_config.h"
+
+#ifdef DEBUG_MODE
+    #define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
+#else
+    #define DEBUG_MSG(...)
+#endif
+
+//private structs
+struct module_config{
+    bladerf_module module;
+    unsigned int frequency;
+    unsigned int bandwidth;
+    unsigned int samplerate;
+    /* Gains */
+    bladerf_lna_gain rx_lna;
+    int vga1;
+    int vga2;
+};
+//internal functinos
+static int radio_configure_module(struct bladerf *dev, struct module_config *c);
+static int radio_init_sync(struct bladerf *dev);
+
+/**
+ * Configure RX/TX module
+ */
+static int radio_configure_module(struct bladerf *dev, struct module_config *c)
+{
+    int status;
+    status = bladerf_set_frequency(dev, c->module, c->frequency);
+    if (status != 0) {
+        fprintf(stderr, "Failed to set frequency = %u: %s\n",
+                c->frequency, bladerf_strerror(status));
+        return status;
+    }
+    status = bladerf_set_sample_rate(dev, c->module, c->samplerate, NULL);
+    if (status != 0) {
+        fprintf(stderr, "Failed to set samplerate = %u: %s\n",
+                c->samplerate, bladerf_strerror(status));
+        return status;
+    }
+    status = bladerf_set_bandwidth(dev, c->module, c->bandwidth, NULL);
+    if (status != 0) {
+        fprintf(stderr, "Failed to set bandwidth = %u: %s\n",
+                c->bandwidth, bladerf_strerror(status));
+        return status;
+    }
+    switch (c->module) {
+        case BLADERF_MODULE_RX:
+            /* Configure the gains of the RX LNA, RX VGA1, and RX VGA2  */
+            status = bladerf_set_lna_gain(dev, c->rx_lna);
+            if (status != 0) {
+                fprintf(stderr, "Failed to set RX LNA gain: %s\n",
+                        bladerf_strerror(status));
+                return status;
+            }
+            status = bladerf_set_rxvga1(dev, c->vga1);
+            if (status != 0) {
+                fprintf(stderr, "Failed to set RX VGA1 gain: %s\n",
+                        bladerf_strerror(status));
+                return status;
+            }
+            status = bladerf_set_rxvga2(dev, c->vga2);
+            if (status != 0) {
+                fprintf(stderr, "Failed to set RX VGA2 gain: %s\n",
+                        bladerf_strerror(status));
+                return status;
+            }
+            break;
+        case BLADERF_MODULE_TX:
+            /* Configure the TX VGA1 and TX VGA2 gains */
+            status = bladerf_set_txvga1(dev, c->vga1);
+            if (status != 0) {
+                fprintf(stderr, "Failed to set TX VGA1 gain: %s\n",
+                        bladerf_strerror(status));
+                return status;
+            }
+            status = bladerf_set_txvga2(dev, c->vga2);
+            if (status != 0) {
+                fprintf(stderr, "Failed to set TX VGA2 gain: %s\n",
+                        bladerf_strerror(status));
+                return status;
+            }
+            break;
+        default:
+            status = BLADERF_ERR_INVAL;
+            fprintf(stderr, "%s: Invalid module specified (%d)\n",
+                    __FUNCTION__, c->module);
+    }
+    return status;
+}
+
+/** 
+ * Initialize synchronous interface
+ */
+static int radio_init_sync(struct bladerf *dev)
+{
+    int status;
+    const unsigned int num_buffers   = 64;
+    const unsigned int buffer_size   = SYNC_BUFFER_SIZE;  /* Must be a multiple of 1024 */
+    const unsigned int num_transfers = 16;
+    const unsigned int timeout_ms    = 3500;
+    /* Configure both the device's RX and TX modules for use with the synchronous
+     * interface. SC16 Q11 samples with metadata are used. */
+    status = bladerf_sync_config(dev,
+                                 BLADERF_MODULE_RX,
+                                 BLADERF_FORMAT_SC16_Q11_META,
+                                 num_buffers,
+                                 buffer_size,
+                                 num_transfers,
+                                 timeout_ms);
+    if (status != 0) {
+        fprintf(stderr, "Failed to configure RX sync interface: %s\n",
+                bladerf_strerror(status));
+        return status;
+    }
+    status = bladerf_sync_config(dev,
+                                 BLADERF_MODULE_TX,
+                                 BLADERF_FORMAT_SC16_Q11_META,
+                                 num_buffers,
+                                 buffer_size,
+                                 num_transfers,
+                                 timeout_ms);
+    if (status != 0) {
+        fprintf(stderr, "Failed to configure TX sync interface: %s\n",
+                bladerf_strerror(status));
+    }
+    return status;
+}
+
+int radio_init_and_configure(struct bladerf *dev, struct radio_params *params)
+{
+    struct module_config config;
+    int status;
+
+    #ifdef DEBUG_MODE
+        bladerf_log_set_verbosity(BLADERF_LOG_LEVEL_DEBUG);
+    #endif
+
+    //Configure TX parameters
+    config.module       = BLADERF_MODULE_TX;
+    config.frequency    = params->tx_freq;
+    config.bandwidth    = BLADERF_BANDWIDTH;
+    config.samplerate   = BLADERF_SAMPLE_RATE;
+    config.vga1         = params->tx_vga1_gain;
+    config.vga2         = params->tx_vga2_gain;
+    status = radio_configure_module(dev, &config);
+    if (status != 0){
+        fprintf(stderr, "Couldn't configure TX module: %s\n", bladerf_strerror(status));
+        return status;
+    }
+
+    //Configure RX parameters
+    config.module       = BLADERF_MODULE_RX;
+    config.frequency    = params->rx_freq;
+    config.bandwidth    = BLADERF_BANDWIDTH;
+    config.samplerate   = BLADERF_SAMPLE_RATE;
+    config.rx_lna       = params->rx_lna_gain;
+    config.vga1         = params->rx_vga1_gain;
+    config.vga2         = params->rx_vga2_gain;
+    status = radio_configure_module(dev, &config);
+    if (status != 0){
+        fprintf(stderr, "Couldn't configure RX module: %s\n", bladerf_strerror(status));
+        return status;
+    }
+
+    //Unset loopback
+    status = bladerf_set_loopback(dev, BLADERF_LB_NONE);
+    if (status != 0){
+        fprintf(stderr, "Couldn't set loopback: %s", bladerf_strerror(status));
+        return status;
+    }
+
+    //Initialize synchronous interface
+    status = radio_init_sync(dev);
+    if (status != 0){
+        fprintf(stderr, "Couldn't initialize synchronous interface: %s\n",
+                bladerf_strerror(status));
+        return status;
+    }
+
+    //Enable tx module
+    status = bladerf_enable_module(dev, BLADERF_MODULE_TX, true);
+    if (status != 0){
+        fprintf(stderr, "Couldn't enable TX module: %s\n", bladerf_strerror(status));
+        return status;
+    }
+    //Enable rx module
+    status = bladerf_enable_module(dev, BLADERF_MODULE_RX, true);
+    if (status != 0){
+        fprintf(stderr, "Couldn't enable RX module: %s\n", bladerf_strerror(status));
+        return status;
+    }
+    return 0;
+}
+
+void radio_stop(struct bladerf *dev)
+{
+    int status;
+
+    if (dev == NULL){
+        return;
+    }
+    //Disable tx module
+    status = bladerf_enable_module(dev, BLADERF_MODULE_TX, false);
+    if (status != 0){
+        fprintf(stderr, "Couldn't disable TX module: %s\n", bladerf_strerror(status));
+    }
+    //Disable rx module
+    status = bladerf_enable_module(dev, BLADERF_MODULE_RX, false);
+    if (status != 0){
+        fprintf(stderr, "Couldn't disable RX module: %s\n", bladerf_strerror(status));
+    }
+}

--- a/host/utilities/bladeRF-fsk/c/src/radio_config.h
+++ b/host/utilities/bladeRF-fsk/c/src/radio_config.h
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * @brief   BladeRF radio configuration - setting of frequencies, gains, etc.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef RADIO_CONFIG_H
+#define RADIO_CONFIG_H
+
+#include <libbladeRF.h>
+#include <stdio.h>
+
+#include "common.h"
+
+#define SYNC_BUFFER_SIZE 16384
+//1.5MHz
+#define BLADERF_BANDWIDTH 1500000
+//2Msps
+#define BLADERF_SAMPLE_RATE 2000000
+
+/**
+ * Configure bladeRF device
+ *
+ * @param[in]   dev     pointer to bladeRF device handle
+ * @param[in]   params  pointer to radio_params struct specifying frequencies/gains
+ * 
+ * @return      0 on success, <0 on error
+ */
+int radio_init_and_configure(struct bladerf *dev, struct radio_params *params);
+
+/**
+ * Stop transmitting/receiving with bladerf. Device must be closed elsewhere.
+ *
+ * @param[in]   dev     pointer to bladeRF device handle to stop
+ */
+void radio_stop(struct bladerf *dev);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/rx_ch_filter.h
+++ b/host/utilities/bladeRF-fsk/c/src/rx_ch_filter.h
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * @brief   FIR filter coefficients for low-pass channel filter
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef RX_CHANNEL_FILTER_H_
+#define RX_CHANNEL_FILTER_H_
+
+#include <stdlib.h>
+
+/**
+ * 31st Order Equiripple Low-Pass Filter
+ * Pass band: Fs / 16
+ * Stop band: Fs / 6
+ *
+ * MATLAB command:
+ *      taps = firpm(31, [0 1/8 1/3 1], [1 1 0 0]);
+ *
+ * For FSK implementation with mod_index=pi/2, SPS=8, this filter was designed to:
+ *      - Pass the signal's main lobe
+ *      - Transition in the signal's first side lobe
+ *      - Provide >= 60 dB of rejection at and beyond the second side lobe
+ */
+static const float rx_ch_filter[] = {
+  -0.001419485011355f,
+  -0.002008975606412f,
+  -0.001265131815619f,
+   0.001949590314393f,
+   0.006879213394692f,
+   0.010409452708224f,
+   0.008177393348267f,
+  -0.002501030091427f,
+  -0.019324528756445f,
+  -0.033658544676913f,
+  -0.032963705706846f,
+  -0.006721606720265f,
+   0.046859333762514f,
+   0.117272556273597f,
+   0.184063253582650f,
+   0.224762721634701f,
+   0.224762721634701f,
+   0.184063253582650f,
+   0.117272556273597f,
+   0.046859333762514f,
+  -0.006721606720265f,
+  -0.032963705706846f,
+  -0.033658544676913f,
+  -0.019324528756445f,
+  -0.002501030091427f,
+   0.008177393348267f,
+   0.010409452708224f,
+   0.006879213394692f,
+   0.001949590314393f,
+  -0.001265131815619f,
+  -0.002008975606412f,
+  -0.001419485011355f,
+};
+
+static const size_t
+    rx_ch_filter_len = sizeof(rx_ch_filter) / sizeof(rx_ch_filter[0]);
+
+#endif

--- a/host/utilities/bladeRF-fsk/c/src/test_suite.c
+++ b/host/utilities/bladeRF-fsk/c/src/test_suite.c
@@ -1,0 +1,483 @@
+/**
+ * @file
+ * @brief   Various modem tests for phy.c, link.c, and fsk.c
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <libbladeRF.h>
+#include <stdlib.h>
+//Utility files
+#include "utils.h"
+#include "prng.h"
+//Units under test
+#include "phy.h"
+#include "link.h"
+#include "fsk.h"
+
+#ifdef DEBUG_MODE
+    #define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
+#else
+    #define DEBUG_MSG(...)
+#endif
+
+/**
+ * Test link layer code with data transfer between two devices
+ */
+int link_test(char *dev_id1, char *dev_id2, unsigned int tx_freq1, unsigned int tx_freq2)
+{
+    printf("------------BEGINNING LINK TEST-----------\n");
+    struct link_handle *link1 = NULL;
+    struct link_handle *link2 = NULL;
+    int status = 0;
+    int bytes_received;
+    uint8_t tx_data[900];
+    uint8_t tx_data2[900] = "Another message";
+    uint8_t rx_data[900];
+    struct radio_params params;
+    struct bladerf *dev1 = NULL, *dev2 = NULL;
+    char *result;
+
+    //Open bladeRFs
+    status = bladerf_open(&dev1, dev_id1);
+    if (status != 0){
+        fprintf(stderr, "Couldn't open bladeRF device #1: %s\n", bladerf_strerror(status));
+        goto out;
+    }
+    status = bladerf_open(&dev2, dev_id2);
+    if (status != 0){
+        fprintf(stderr, "Couldn't open bladeRF device #2: %s\n", bladerf_strerror(status));
+        goto out;
+    }
+
+    //Zero the tx_data buffer
+    memset(tx_data, 0, sizeof(tx_data));
+    //Prompt for a string
+    printf("Enter a string to tx using link1: ");
+    result = fgets((char *) tx_data, sizeof(tx_data), stdin);
+    if (result == NULL){
+        status = -1;
+        goto out;
+    }
+    //Remove newline character
+    tx_data[strlen((char *)tx_data) - 1] = '\0';
+
+    //Init link1
+    params.tx_freq         = tx_freq1;
+    params.tx_vga1_gain = -4;
+    params.tx_vga2_gain = 0;
+    params.rx_freq         = tx_freq2;
+    params.rx_lna_gain    = BLADERF_LNA_GAIN_MAX;
+    params.rx_vga1_gain = 23;
+    params.rx_vga2_gain = 0;
+    link1 = link_init(dev1, &params);
+    if (link1 == NULL){
+        fprintf(stderr, "Couldn't initialize link1\n");
+        status = -1;
+        goto out;
+    }
+    //Init link2
+    params.tx_freq         = tx_freq2;
+    params.rx_freq         = tx_freq1;
+    link2 = link_init(dev2, &params);
+    if (link2 == NULL){
+        fprintf(stderr, "Couldn't initialize link2\n");
+        status = -1;
+        goto out;
+    }
+
+    //Transmit with link1
+    status = link_send_data(link1, tx_data, (unsigned int) strlen((char *)tx_data) + 1);
+    if (status != 0){
+        fprintf(stderr, "Couldn't send data with link1\n");
+        goto out;
+    }
+
+    //Receive with link2
+    bytes_received = link_receive_data(link2, (int)strlen((char *)tx_data) + 1, 5, rx_data);
+    if (bytes_received < 0){
+        fprintf(stderr, "Couldn't receive data with link2\n");
+        goto out;
+    }else if (bytes_received != (int)(strlen((char *) tx_data) + 1)){
+        fprintf(stderr, "link2 receive timed out\n");
+        goto out;
+    }
+    printf("Received on link2: '%s'\n", rx_data);
+    //Transmit with link1
+    status = link_send_data(link1, tx_data2, sizeof(tx_data2));
+    if (status != 0){
+        fprintf(stderr, "Couldn't send data with link1\n");
+        goto out;
+    }
+
+    //Receive with link2
+    bytes_received = link_receive_data(link2, 900, 5, rx_data);
+    if (bytes_received < 0){
+        fprintf(stderr, "Couldn't receive data with link2\n");
+        goto out;
+    }else if (bytes_received != 900){
+        fprintf(stderr, "link2 receive timed out\n");
+        goto out;
+    }
+    printf("Received on link2: '%s'\n", rx_data);
+
+    out:
+        DEBUG_MSG("Closing link 1\n");
+        link_close(link1);
+        DEBUG_MSG("Closing link 2\n");
+        link_close(link2);
+        DEBUG_MSG("Closing bladeRFs\n");
+        bladerf_close(dev1);
+        bladerf_close(dev2);
+        printf("------------ENDING LINK TEST--------------\n");
+        return status;
+}
+
+/**
+ * Test phy layer code with data transfer between two devices
+ */
+int phy_test(char *dev_id1, char *dev_id2, unsigned int tx_freq1, unsigned int tx_freq2)
+{
+    printf("------------BEGINNING PHY TEST------------\n");
+    struct phy_handle *phy1 = NULL;
+    struct phy_handle *phy2 = NULL;
+    uint8_t tx_data[DATA_FRAME_LENGTH];
+    uint8_t *tx_data3 = NULL;
+    uint8_t *rx_data;
+    uint64_t prng_seed = 29398283513841632;
+    int status = 0, ret;
+    bool rx_on = false, tx_on = false;
+    struct radio_params params;
+    struct bladerf *dev1 = NULL, *dev2 = NULL;
+    char *result;
+
+    //Zero the tx_data buffer
+    memset(tx_data, 0, sizeof(tx_data));
+    //Set first byte to data frame code
+    tx_data[0] = DATA_FRAME_CODE;
+    //Prompt for a string
+    printf("Enter a string to tx using phy1 (frame #1): ");
+    result = fgets((char *) &tx_data[1], sizeof(tx_data)-1, stdin);
+    if (result == NULL){
+        status = -1;
+        goto out;
+    }
+    //Remove newline character
+    tx_data[strlen((char *)&tx_data[1])] = '\0';
+
+    //Init phy1
+    status = bladerf_open(&dev1, dev_id1);
+    if (status != 0){
+        fprintf(stderr, "Couldn't open bladeRF device #1: %s\n", bladerf_strerror(status));
+        goto out;
+    }
+    params.tx_freq         = tx_freq1;
+    params.tx_vga1_gain = -4;
+    params.tx_vga2_gain = 0;
+    params.rx_freq         = tx_freq2;
+    params.rx_lna_gain    = BLADERF_LNA_GAIN_MAX;
+    params.rx_vga1_gain = 23;
+    params.rx_vga2_gain = 0;
+    phy1 = phy_init(dev1, &params);
+    if (phy1 == NULL){
+        fprintf(stderr, "Couldn't initialize phy1\n");
+        status = -1;
+        goto out;
+    }
+
+    //Init phy2
+    status = bladerf_open(&dev2, dev_id2);
+    if (status != 0){
+        fprintf(stderr, "Couldn't open bladeRF device #2: %s\n", bladerf_strerror(status));
+        goto out;
+    }
+    params.tx_freq         = tx_freq2;
+    params.rx_freq         = tx_freq1;
+    phy2 = phy_init(dev2, &params);
+    if (phy2 == NULL){
+        fprintf(stderr, "Couldn't initialize phy2\n");
+        status = -1;
+        goto out;
+    }
+
+    //Start receiving on phy2
+    DEBUG_MSG("Starting phy2 receiver\n");
+
+    status = phy_start_receiver(phy2);
+    if (status != 0){
+        fprintf(stderr, "Couldn't start phy2 receiver\n");
+        goto out;
+    }
+    rx_on = true;
+
+    //Transmit on phy1
+    DEBUG_MSG("Starting phy1 transmitter\n");
+    status = phy_start_transmitter(phy1);
+    if (status != 0){
+        fprintf(stderr, "Couldn't start phy1 transmitter\n");
+        goto out;
+    }
+    tx_on = true;
+    DEBUG_MSG("Transmitting on phy1\n");
+    status = phy_fill_tx_buf(phy1, tx_data, sizeof(tx_data));
+    if (status != 0){
+        fprintf(stderr, "Couldn't fill tx buffer\n");
+        goto out;
+    }
+
+    //Get the received frame from phy2
+    rx_data = phy_request_rx_buf(phy2, 60000);
+    if (rx_data == NULL){
+        fprintf(stderr, "Request buffer failed\n");
+        goto out;
+    }
+    printf("Received from phy2: ");
+    //print what is in the buffer
+    print_chars(&rx_data[1], DATA_FRAME_LENGTH-1);
+    //Release the rx buffer
+    phy_release_rx_buf(phy2);
+
+
+    //Transmit a pseudo random sequence with phy1
+    tx_data3 = prng_fill(&prng_seed, DATA_FRAME_LENGTH);
+    tx_data3[0] = 0x00;        //Set frame type to data frame
+    DEBUG_MSG("Transmitting pseudo random sequence on phy1\n");
+    status = phy_fill_tx_buf(phy1, tx_data3, DATA_FRAME_LENGTH);
+    if (status != 0){
+        fprintf(stderr, "Couldn't transmit frame\n");
+        goto out;
+    }
+    //Receive
+    rx_data = phy_request_rx_buf(phy2, 2000);
+    if (rx_data == NULL){
+        fprintf(stderr, "Request buffer failed\n");
+        goto out;
+    }
+    //Compare with transmitted data
+    if (strncmp((char *)tx_data3, (char *)rx_data, DATA_FRAME_LENGTH) != 0){
+        fprintf(stderr, "RX data did not match TX data. Test failed.\n");
+        status = -1;
+    }else{
+        printf("RX data matched TX data. Test passed.\n");
+    }
+    phy_release_rx_buf(phy2);
+
+    out:
+        ret = status;
+        //Stop transmitters/receivers
+        if (tx_on){
+            status = phy_stop_transmitter(phy1);
+            if (status != 0){
+                fprintf(stderr, "Couldn't stop phy1 transmitter\n");
+            }
+        }
+        if (rx_on){
+            status = phy_stop_receiver(phy2);
+            if (status != 0){
+                fprintf(stderr, "Couldn't stop phy2 receiver\n");
+            }
+        }
+        free(tx_data3);
+        DEBUG_MSG("\tClosing phy1 and phy2\n");
+        phy_close(phy1);
+        phy_close(phy2);
+        DEBUG_MSG("\tClosing bladeRFs\n");
+        bladerf_close(dev1);
+        bladerf_close(dev2);
+        printf("------------ENDING PHY TEST---------------\n");
+        return ret;
+}
+
+/**
+ * Test phy receiver thread to see if it's using too much CPU. If ENABLE_NOTES is
+ * defined, overrun messages will be seen if the PHY receiver is at ~100% CPU.
+ */
+int phy_receive_test(void)
+{
+    printf("------------BEGINNING PHY RECEIVER TEST------------\n");
+    struct phy_handle *phy = NULL;
+    uint8_t *rx_data;
+    int status = 0, ret;
+    bool rx_on = false;
+    struct radio_params params;
+    struct bladerf *dev = NULL;
+
+    //Init phy
+    status = bladerf_open(&dev, NULL);
+    if (status != 0){
+        fprintf(stderr, "Couldn't open bladeRF device: %s\n", bladerf_strerror(status));
+        goto out;
+    }
+    params.tx_freq         = 904000000;
+    params.tx_vga1_gain = -4;
+    params.tx_vga2_gain = 0;
+    params.rx_freq         = 924000000;
+    params.rx_lna_gain    = BLADERF_LNA_GAIN_MAX;
+    params.rx_vga1_gain = 23;
+    params.rx_vga2_gain = 0;
+    phy = phy_init(dev, &params);
+    if (phy == NULL){
+        fprintf(stderr, "Couldn't initialize phy\n");
+        status = -1;
+        goto out;
+    }
+
+    //Start receiving
+    DEBUG_MSG("Starting phy receiver\n");
+    status = phy_start_receiver(phy);
+    if (status != 0){
+        fprintf(stderr, "Couldn't start phy receiver\n");
+        goto out;
+    }
+    rx_on = true;
+
+    //Request data
+    rx_data = phy_request_rx_buf(phy, 10000);
+    if (rx_data == NULL){
+        fprintf(stderr, "Request buffer failed\n");
+        goto out;
+    }
+    phy_release_rx_buf(phy);
+
+
+    out:
+        ret = status;
+        //Stop transmitters/receivers
+        if (rx_on){
+            status = phy_stop_receiver(phy);
+            if (status != 0){
+                fprintf(stderr, "Couldn't stop phy receiver\n");
+            }
+        }
+        DEBUG_MSG("\tClosing phy\n");
+        phy_close(phy);
+        DEBUG_MSG("\tClosing bladeRF\n");
+        bladerf_close(dev);
+        printf("------------ENDING PHY RECEIVE TEST---------------\n");
+        return ret;
+}
+
+/**
+ * FSK mod/demod test. 
+ * Tests the case where part of a byte is received from first set of samples,
+ * and the rest is received from the next set of samples
+ */
+int fsk_test1(void)
+{
+    printf("------------BEGINNING FSK TEST 1-------------\n");
+    //tx
+    struct complex_sample *tx_samples = NULL;
+    uint8_t tx_data[] = "=Hello-there=";
+    unsigned int num_samples_tx;
+    //rx
+    unsigned int num_bytes_rx1, num_bytes_rx2;
+    struct fsk_handle *fsk = NULL;
+    unsigned int num_samples_rx1;
+    unsigned int num_samples_rx2;
+    int status = 0;
+    uint8_t rx_data[512];
+
+    //Open fsk handle
+    fsk = fsk_init();
+    if (fsk == NULL){
+        fprintf(stderr, "Couldn't initialize fsk\n");
+        status = -1;
+        goto out;
+    }
+
+    num_samples_tx = sizeof(tx_data)*8*SAMP_PER_SYMB+1;
+
+    //Allocate tx samples
+    tx_samples = malloc(num_samples_tx * sizeof(struct complex_sample));
+    if (tx_samples == NULL){
+        perror("malloc");
+        status = -1;
+        goto out;
+    }
+    //Initial sample
+    tx_samples[0].i = 2047;
+    tx_samples[0].q = 0;
+    //Modulate
+    fsk_mod(fsk, tx_data, sizeof(tx_data), &tx_samples[1]);
+    printf("Modulating: '%s'\n", tx_data);
+    printf("%u tx samples\n", num_samples_tx);
+
+    num_samples_rx1 = 304;
+    num_samples_rx2 = num_samples_tx - num_samples_rx1;
+
+    printf("1st demod will receive %u samples\n", num_samples_rx1);
+    printf("2nd demod will receive %u samples\n", num_samples_rx2);
+
+    //Demod part 1
+    num_bytes_rx1 = fsk_demod(fsk, tx_samples, num_samples_rx1, true, -1, rx_data);
+    printf("Demodulated %u bytes\n", num_bytes_rx1);
+    print_chars(rx_data, num_bytes_rx1);
+
+    //Demod part 2
+    num_bytes_rx2 = fsk_demod(fsk, &tx_samples[num_samples_rx1], num_samples_rx2, false,
+                                sizeof(tx_data)-num_bytes_rx1, &rx_data[num_bytes_rx1]);
+    printf("Demodulated %u bytes\n", num_bytes_rx2);
+    print_chars(&rx_data[num_bytes_rx1], num_bytes_rx2);
+
+    printf("Received %u bytes total: ", num_bytes_rx1+num_bytes_rx2);
+    print_chars(rx_data, num_bytes_rx1+num_bytes_rx2);
+
+    //Check
+    if (strcmp((char *)rx_data, (char *)tx_data) != 0){
+        fprintf(stderr, "Received data is incorrect. Test failed.\n");
+        status = -1;
+    }
+
+    out:
+        free(tx_samples);
+        fsk_close(fsk);
+        if (status != 0){
+            fprintf(stderr, "ERROR: Test did not complete successfully\n");
+        }
+        printf("------------ENDING FSK TEST 1----------------\n");
+        return status;
+}
+
+/**
+ * Run all tests
+ */
+int main(int argc, char *argv[])
+{
+    char *dev_id1;
+    char *dev_id2;
+
+    //Parse arguments
+    if (argc < 3){
+        fprintf(stderr, "Usage: %s [bladeRF device ID 1] [bladeRF device ID 2]\n",
+                argv[0]);
+        return 0;
+    }
+
+    dev_id1 = argv[1];
+    dev_id2 = argv[2];
+
+    fsk_test1();
+    phy_receive_test();
+    phy_test(dev_id1, dev_id2, 904000000, 924000000);
+    phy_test(dev_id2, dev_id1, 904000000, 924000000);
+    link_test(dev_id1, dev_id2, 904000000, 924000000);
+
+    return 0;
+}

--- a/host/utilities/bladeRF-fsk/c/src/utils.c
+++ b/host/utilities/bladeRF-fsk/c/src/utils.c
@@ -1,0 +1,301 @@
+/**
+ * @brief   Utility functions: loading/saving samples from/to a file,
+ *          conversions, etc.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "utils.h"
+
+int load_samples_from_csv_file(char *filename, bool pad_zeros, int buffer_size,
+                                int16_t **samples)
+{
+    int i, result, num_samples;
+    int samples_buf_size;        //Max number of samples in buffer
+    int buf_inc_size;            //Number of additional samples to add space for on a realloc()
+    bool reachedEOF;
+    int16_t temp_sample1, temp_sample2;
+
+    //Open csv file
+    FILE *fp = fopen(filename, "r");
+    if (fp == NULL){
+        perror("fopen");
+        *samples = NULL;
+        return -1;
+    }
+
+    if (pad_zeros){
+        buf_inc_size = buffer_size;
+    }else{
+        buf_inc_size = 1024;
+    }
+
+    //Allocate initial memory for tx_samples
+    *samples = malloc(buf_inc_size * 2 * sizeof(int16_t));
+    if (*samples == NULL){
+        perror("malloc");
+        fclose(fp);
+        return -1;
+    }
+
+    //Initial size of allocated memory
+    samples_buf_size = buf_inc_size;
+
+    //Read in samples, and reallocate more memory if needed
+    i = 0;
+    num_samples = 0;
+    reachedEOF = false;
+    while(true){
+        //Check to see if the samples buffer is full
+        if (num_samples == samples_buf_size){
+            //Before allocating more memory, check to see if there are no more samples
+            result = fscanf(fp, "%hi,%hi\n", &temp_sample1, &temp_sample2 );
+            if(result == EOF || reachedEOF){
+                break;
+            }
+            //allocate more memory. Add space for another 'buf_inc_size' samples
+            samples_buf_size += buf_inc_size;
+            int16_t *tmp_ptr = realloc(*samples, samples_buf_size * 2 * sizeof(int16_t));
+            if (tmp_ptr == NULL){
+                perror("realloc");
+                free(*samples);
+                *samples = NULL;
+                fclose(fp);
+                return -1;
+            }
+            *samples = tmp_ptr;
+            (*samples)[i] = temp_sample1;
+            (*samples)[i+1] = temp_sample2;
+            num_samples++;
+            i += 2;
+            continue;
+        }
+        if (!reachedEOF){
+            result = fscanf(fp, "%hi,%hi\n", &(*samples)[i], &(*samples)[i+1] );
+            if (result == EOF){
+                reachedEOF = true;
+            }
+        }
+        if (reachedEOF){
+            if (pad_zeros){
+                //pad with zeros to fill the rest of the buffer
+                (*samples)[i] = 0;
+                (*samples)[i+1] = 0;
+            }else{
+                break;
+            }
+        }
+        num_samples++;
+        i += 2;        //increment index
+    }
+    fclose(fp);
+
+    return num_samples;
+}
+
+int load_struct_samples_from_csv_file(char *filename, bool pad_zeros, int buffer_size,
+                                        struct complex_sample **samples)
+{
+    int i, result;
+    int samples_buf_size;        //Max number of samples in buffer
+    int buf_inc_size;            //Number of additional samples to add space for on a realloc()
+    bool reachedEOF;
+    int16_t temp_sample1, temp_sample2;
+
+    //Open csv file
+    FILE *fp = fopen(filename, "r");
+    if (fp == NULL){
+        perror("fopen");
+        *samples = NULL;
+        return -1;
+    }
+
+    if (pad_zeros){
+        buf_inc_size = buffer_size;
+    }else{
+        buf_inc_size = 1024;
+    }
+
+    //Allocate initial memory for tx_samples
+    *samples = malloc(buf_inc_size * sizeof(struct complex_sample));
+    if (*samples == NULL){
+        perror("malloc");
+        fclose(fp);
+        return -1;
+    }
+
+    //Initial size of allocated memory
+    samples_buf_size = buf_inc_size;
+
+    //Read in samples, and reallocate more memory if needed
+    i = 0;
+    reachedEOF = false;
+    while(true){
+        //Check to see if the samples buffer is full
+        if (i == samples_buf_size){
+            //Before allocating more memory, check to see if there are no more samples
+            result = fscanf(fp, "%hi,%hi\n", &temp_sample1, &temp_sample2 );
+            if(result == EOF || reachedEOF){
+                break;
+            }
+            //allocate more memory. Add space for another 'buf_inc_size' samples
+            samples_buf_size += buf_inc_size;
+            struct complex_sample *tmp_ptr = realloc(*samples,
+                                       samples_buf_size * sizeof(struct complex_sample));
+            if (tmp_ptr == NULL){
+                perror("realloc");
+                free(*samples);
+                *samples = NULL;
+                fclose(fp);
+                return -1;
+            }
+            *samples = tmp_ptr;
+            (*samples)[i].i = temp_sample1;
+            (*samples)[i].q = temp_sample2;
+            i++;
+            continue;
+        }
+        if (!reachedEOF){
+            result = fscanf(fp, "%hi,%hi\n", &(*samples)[i].i, &(*samples)[i].q);
+            if (result == EOF){
+                reachedEOF = true;
+            }
+        }
+        if (reachedEOF){
+            if (pad_zeros){
+                //pad with zeros to fill the rest of the buffer
+                (*samples)[i].i = 0;
+                (*samples)[i].q = 0;
+            }else{
+                break;
+            }
+        }
+        i++;        //increment index
+    }
+    fclose(fp);
+
+    return i;
+}
+
+int write_samples_to_csv_file(char *filename, int16_t *samples, int num_samples)
+{
+    int i;
+    //Open file
+    FILE *fp = fopen(filename, "w");
+    if (fp == NULL){
+        perror("fopen");
+        return -1;
+    }
+    //Write file
+    //Loop through all samples
+    //First int is the I sample. Second int is the Q sample
+    for (i = 0; i < num_samples*2; i+= 2){
+        fprintf(fp, "%hi,%hi\n", samples[i], samples[i+1]);
+    }
+    fclose(fp);
+
+    return 0;
+}
+
+int write_struct_samples_to_csv_file(char *filename, struct complex_sample *samples,
+                                        int num_samples)
+{
+    int i;
+    //Open file
+    FILE *fp = fopen(filename, "w");
+    if (fp == NULL){
+        perror("fopen");
+        return -1;
+    }
+    //Write file
+    //Loop through all samples
+    //First int is the I sample. Second int is the Q sample
+    for (i = 0; i < num_samples; i++){
+        fprintf(fp, "%hi,%hi\n", samples[i].i, samples[i].q);
+    }
+    fclose(fp);
+
+    return 0;
+}
+
+void print_chars(uint8_t *data, int num_bytes)
+{
+    int i;
+
+    printf("'");
+    for (i = 0; i < num_bytes; i++){
+        printf("%c", data[i]);
+    }
+    printf("'\n");
+}
+
+void print_hex_contents(uint8_t *data, int num_bytes)
+{
+    int i;
+
+    for (i = 0; i < num_bytes; i++){
+        printf("%.2X ", data[i]);
+    }
+    printf("\n");
+}
+
+int create_timeout_abs(unsigned int timeout_ms, struct timespec *timeout_abs)
+{
+    int status;
+
+    //Get the current time
+    status = clock_gettime(CLOCK_REALTIME, timeout_abs);
+    if(status != 0){
+        perror("clock_gettime");
+        return -1;
+    }
+
+    //Add the timeout onto the current time
+    timeout_abs->tv_sec += timeout_ms/1000;
+    timeout_abs->tv_nsec += (timeout_ms % 1000) * 1000000;
+    //Check for overflow in nsec
+    if (timeout_abs->tv_nsec >= 1000000000){
+        timeout_abs->tv_sec += timeout_abs->tv_nsec / 1000000000;
+        timeout_abs->tv_nsec %= 1000000000;
+    }
+
+    return 0;
+}
+
+void conv_samples_to_struct(int16_t *samples, unsigned int num_samples,
+                            struct complex_sample *struct_samples)
+{
+    unsigned int i;
+
+    for (i = 0; i < (num_samples*2); i += 2){
+        struct_samples[i/2].i = samples[i];
+        struct_samples[i/2].q = samples[i+1];
+    }
+}
+
+void conv_struct_to_samples(struct complex_sample *struct_samples, unsigned int num_samples,
+                            int16_t *samples)
+{
+    unsigned int i;
+
+    for (i = 0; i < (num_samples*2); i += 2){
+        samples[i] = struct_samples[i/2].i;
+        samples[i+1] = struct_samples[i/2].q;
+    }
+}

--- a/host/utilities/bladeRF-fsk/c/src/utils.h
+++ b/host/utilities/bladeRF-fsk/c/src/utils.h
@@ -1,0 +1,134 @@
+/**
+ * @file
+ * @brief   Utility functions: loading/saving samples from/to a file,
+ *          conversions, etc.
+ *
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2016 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "host_config.h"
+
+#if BLADERF_OS_WINDOWS || BLADERF_OS_OSX
+    #include "clock_gettime.h"
+#else
+    #include <time.h>
+#endif
+
+#include "common.h"
+
+/**
+ * Write samples to csv file
+ *
+ * @param[in]   filename        name of csv file to write
+ * @param[in]   samples         buffer containing IQ samples to write
+ * @param[in]   num_samples     number of IQ samples to write to the file
+ *
+ * @return      0 on success, -1 on failure
+ */
+int write_samples_to_csv_file(char *filename, int16_t *samples, int num_samples);
+
+/**
+ * Load samples from csv file into heap memory buffer. Caller is responsible for
+ * freeing the the buffer when done using it.
+ *
+ * @param[in]   filename        file name to load samples from
+ * @param[in]   pad_zeros       If true, the function will pad zeros onto the end until
+ *                              the samples fill to a multiple of 'buffer_size' samples
+ * @param[in]   buffer_size     buffer size to fill multiples of, if pad_zeros is true.
+ *                              Parameter ignored if pad_zeros is false.
+ * @param[out]  samples         pointer to the loaded sample buffer. Buffer set to NULL
+ *                              on failure. If successful, the buffer must be freed when
+ *                              done using it.
+ * @return      number of samples loaded on success; -1 on failure
+ */
+int load_samples_from_csv_file(char *filename, bool pad_zeros, int buffer_size,
+                                int16_t **samples);
+
+/**
+ * Write 'struct complex_sample' samples to csv file
+ *
+ * @param[in]   filename        name of csv file to write
+ * @param[in]   samples         buffer containing IQ samples to write
+ * @param[in]   num_samples     number of IQ samples to write to the file
+ *
+ * @return      0 on success, -1 on failure
+ */
+int write_struct_samples_to_csv_file(char *filename, struct complex_sample *samples,
+                                        int num_samples);
+
+/**
+ * Load 'struct complex_sample' samples from csv file into heap memory buffer.
+ * Caller is responsible for freeing the the buffer when done using it.
+ *
+ * @param[in]   filename        file name to load samples from
+ * @param[in]   pad_zeros       If true, the function will pad zeros onto the end until
+ *                              the samples fill to a multiple of 'buffer_size' samples
+ * @param[in]   buffer_size     buffer size to fill multiples of, if pad_zeros is true.
+ *                              Parameter ignored if pad_zeros is false.
+ * @param[out]  samples         pointer to the loaded sample buffer. Buffer set to NULL
+ *                              on failure. If successful, the buffer must be freed when
+ *                              done using it.
+ * @return      number of samples loaded on success; -1 on failure
+ */
+int load_struct_samples_from_csv_file(char *filename, bool pad_zeros, int buffer_size,
+                                        struct complex_sample **samples);
+
+void print_chars(uint8_t *data, int num_bytes);
+void print_hex_contents(uint8_t *data, int num_bytes);
+
+/**
+ * Converts a relative timeout to an absolute time (i.e. 5000 ms to 07/02/2016 20:32:10)
+ *
+ * @param[in]   timeout_ms      the timeout to create in ms
+ * @param[out]  timeout_abs     pointer to timespec struct to fill
+ *
+ * @return      0 on success, -1 on failure
+ */
+int create_timeout_abs(unsigned int timeout_ms, struct timespec *timeout_abs);
+
+/**
+ * Converts an array of int16_t IQ samples to an array of 'complex_sample' structs.
+ * Caller is responsible for memory allocation.
+ * 
+ * @param[in]   samples         array of IQ samples to convert
+ * @param[in]   num_samples     number of samples to convert
+ * @param[out]  struct_samples  buffer to place converted samples in
+ */
+void conv_samples_to_struct(int16_t *samples, unsigned int num_samples,
+                            struct complex_sample *struct_samples);
+
+/**
+ * Converts an array of complex_sample structs into an array of int16_t
+ * samples. Caller is responsible for memory allocation.
+ * 
+ * @param[in]   struct_samples  complex_sample array to convert
+ * @param[in]   num_samples     number of samples to convert
+ * @param[out]  samples         buffer to place converted samples in
+ */
+void conv_struct_to_samples(struct complex_sample *struct_samples, unsigned int num_samples,
+                            int16_t *samples);
+
+#endif

--- a/host/utilities/bladeRF-fsk/matlab/README.txt
+++ b/host/utilities/bladeRF-fsk/matlab/README.txt
@@ -1,0 +1,46 @@
+This set of MATLAB files will generate/receive binary CPFSK baseband waveforms.
+Works on both MATLAB and GNU Octave.
+
+Run fsk.m to simulate the FSK modem just in MATLAB.
+Run fsk_csv.m to write/read IQ samples to/from a csv file so they can be
+    transmitted/received on an RF carrier with a bladeRF. In order to run this
+    successfully you need to add bladeRF/host/misc/matlab to your matlab path
+    (for the save_csv() and load_csv() functions)
+
+fsk_mod(): FSK baseband modulator function
+- generates CPFSK baseband IQ waveform of the given set of bits
+
+fsk_demod(): FSK baseband demodulator function
+- extracts the bit sequence of the given CPFSK baseband waveform
+
+fsk_transmit(): Generates baseband signal for an FSK frame
+- Calls fsk_mod() with FSK frame, which includes training sequence and preamble
+  in addition to user data
+- Adds a ramp up/ramp down to the beginning/end of the signal
+
+fsk_receive(): Receives an FSK frame from a baseband signal
+- Low-pass filters and normalizes the input signal
+- Correlates the input signal with the given preamble waveform to determine
+  start of FSK data
+- Calls fsk_demod() to extract bits from the FSK data signal
+
+fsk.m: Script for simulating mod/demod just in MATLAB
+- prompts for an input string (spaces are welcome)
+- converts ASCII string to a set of bits
+- calls fsk_transmit to generate the CPFSK baseband IQ waveform
+- adds attenuation and noise to the signal to simulate a channel
+- calls fsk_receive to process the waveform and extract data bits
+- converts bits to ASCII string
+- prints received string to command window
+
+fsk_csv.m: Script for using the modulator/demodulator with samples csv files
+- prompts for an input string (spaces are welcome)
+- converts ASCII string to a set of bits
+- calls fsk_transmit to generate the CPFSK baseband IQ waveform
+- writes the samples to a tx csv file
+- waits for the user to transmit the samples and receive IQ samples
+  in a different csv file (e.g. rx_samples.csv)
+- reads in samples from the rx csv file
+- calls fsk_receive to process the waveform and extract data bits
+- converts bits to ASCII string
+- prints received string to command window

--- a/host/utilities/bladeRF-fsk/matlab/fsk.m
+++ b/host/utilities/bladeRF-fsk/matlab/fsk.m
@@ -1,0 +1,154 @@
+%-------------------------------------------------------------------------
+% fsk.m: Simulation of PHY portion of CPFSK modem. When compared to the C
+% modem this code has the following differences:
+%   1) Simpler/less rigorous power normalization
+%   2) No scrambling.
+%
+% Notes: Change 'noise_pow' for different amount of channel AWGN noise.
+% Change 'gain' for different amount of channel gain. Change 'null_amt' for
+% different amount of flat samples placed at front/back of tx waveform
+%
+% This file is part of the bladeRF project
+%
+% Copyright (C) 2016 Nuand LLC
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%-------------------------------------------------------------------------
+
+clear;               %Clear workspace variables
+
+Fs = 2e6;            %Sample rate of 2 Msps (500ns sample period)
+samps_per_symb = 8;  %Samples per symbol
+h = pi/2;            %Phase modulation index (phase deviation per symbol)
+					 %Note: preamble has been optimized for h = pi/2
+dec_factor = 2;      %Amount to decimate by when performing correlation
+                     %with preamble
+
+%32 bit training sequence
+%hex: AA, AA, AA, AA
+%Note: In order for the preamble waveform not to be messed up, the last
+%sample of the modulated training sequence MUST be 1 + 0j
+training_seq = ['10101010';
+                '10101010';
+                '10101010';
+                '10101010'];
+%32-bit preamble - hex: 2E, 69, 2C, F0
+preamble = ['00101110'; ...
+            '01101001'; ...
+            '00101100'; ...
+            '11110000'];
+
+%%-------------------TRANSMIT-----------------------------
+%Noise power desired in channel (units dBW)
+noise_pow = -25;
+%gain desired in channel (this should be less than 1)
+gain = 0.6;
+%Amount of flat samples (0+0j) to add to the beginning/end of tx signal
+null_amt = 200;
+
+%Prompt for string to transmit
+prompt = 'Enter a string to tx: ';
+str = input(prompt, 's');
+%Convert to bit matrix
+tx_bits = dec2bin(uint8(str), 8);
+
+%Make FSK signal
+tx_sig = fsk_transmit(training_seq, preamble, tx_bits, samps_per_symb, h);
+%Add some flat output to the front and back of the signal
+tx_sig(null_amt+1:length(tx_sig)+null_amt) = tx_sig;
+tx_sig(1:null_amt) = 0 + 0j;
+tx_sig(length(tx_sig)+1:length(tx_sig)+null_amt) = 0 + 0j;
+
+%time vector: 1/Fs increments
+t = 0 : 1/Fs : (length(tx_sig)-1)/Fs;
+
+%---------------------CHANNEL-------------------------
+%Add gaussian noise and attenuation to signal
+noise = wgn(1, length(tx_sig), noise_pow) + ...
+        1j*wgn(1, length(tx_sig), noise_pow);
+rx_sig = gain*tx_sig + noise;
+
+%%---------------------RECEIVE---------------------------
+%clamp signal to [-1.0, 1.0]
+rx_sig_i = real(rx_sig);
+rx_sig_q = imag(rx_sig);
+rx_sig_i(rx_sig_i > 1.0) = 1.0;
+rx_sig_i(rx_sig_i < -1.0) = -1.0;
+rx_sig_q(rx_sig_q > 1.0) = 1.0;
+rx_sig_q(rx_sig_q < -1.0) = -1.0;
+rx_sig = rx_sig_i + 1j*rx_sig_q;
+%Get the modulated IQ waveform for the preamble
+preamble_waveform = fsk_mod(preamble, samps_per_symb, h, 0);
+%Filter/Normalize/Detect/Demodulate FSK signal
+[rx_bits, rx_info] = fsk_receive(preamble_waveform, rx_sig, dec_factor, ...
+                                samps_per_symb, h, size(tx_bits, 1));
+
+%----------------------Plot some stuff---------------------
+%TX IQ samples
+figure('position', [960 775 960 200]);
+plot(t, real(tx_sig), 'Color', [0,.447,.741]);
+hold on;
+plot(t, imag(tx_sig), 'Color', [.85,.325,.098]);
+title('TX IQ samples vs time');
+
+%RX IQ samples
+figure('position', [960 525 960 200]);
+plot(t, real(rx_sig), 'Color', [0,.447,.741]);
+hold on;
+plot(t, imag(rx_sig), 'Color', [.85,.325,.098]);
+ylim([-1, 1]);
+title('RX raw IQ samples vs time');
+
+%RX raw spectrum
+figure('position', [960 275 960 200]);
+if (exist('OCTAVE_VERSION', 'builtin') ~= 0)
+	pwelch(rx_sig, [], [], 256, Fs, 'centerdc');
+else
+	pwelch(rx_sig, [], [], [], Fs, 'centered');
+end
+title('RX raw spectrum');
+
+%RX filtered IQ samples
+figure('position', [960 0 960 200]);
+plot(real(rx_info.iq_filt_norm), 'Color', [0,.447,.741]);
+hold on;
+plot(imag(rx_info.iq_filt_norm), 'Color', [.85,.325,.098]);
+title('RX filtered & normalized IQ samples');
+
+%RX cross correlation with preamble. Plot power (i^2 + q^2).
+figure('position', [0 775 960 200]);
+plot(abs(rx_info.preamble_corr).^2);
+title('RX cross correlation with preamble (power)');
+
+%RX dphase (data signal only, training/preamble not included)
+if (rx_info.dphase ~= -1)
+    figure('position', [0 500 960, 200]);
+    plot(rx_info.dphase);
+    title('RX dphase (data signal only)');
+end
+
+%---------------------Print received data-------------------
+if (rx_bits(1) ~= -1)
+    fprintf('Received: ''%s''\n', bin2dec(rx_bits));
+    if isequal(rx_bits, tx_bits)
+        fprintf('RX data matched TX data\n');
+    else
+        fprintf(2, 'RX data did not match TX data\n');
+    end
+end
+
+fprintf('Press any key to close figures...\n');
+pause;
+close all;

--- a/host/utilities/bladeRF-fsk/matlab/fsk_csv.m
+++ b/host/utilities/bladeRF-fsk/matlab/fsk_csv.m
@@ -1,0 +1,156 @@
+%-------------------------------------------------------------------------
+% fsk_csv.m: MATLAB implementation of PHY portion of CPFSK modem, which
+% writes TX samples to a file and reads RX samples from a file. When compared
+% to the C modem this code has the following differences:
+%   1) Simpler/less rigorous power normalization
+%   2) No scrambling.
+%
+% Notes: In order to run this successfully you need the save_csv() and
+% load_csv() functions from the bladeRF repository. If you have the repository
+% cloned on your local machine, simply add bladeRF/host/misc/matlab to your
+% MATLAB path.
+% Change 'null_amt' for different amount of flat samples placed at
+% front/back of tx waveform
+%
+% This file is part of the bladeRF project
+%
+% Copyright (C) 2016 Nuand LLC
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%-------------------------------------------------------------------------
+
+clear;                %Clear workspace variables
+txfile = 'tx_samples.csv';
+rxfile = 'rx_samples.csv';
+
+Fs = 2e6;            %Sample rate of 2 Msps (500ns sample period)
+samps_per_symb = 8;  %Samples per symbol
+h = pi/2;            %Modulation index (phase deviation per symbol)
+                     %Note: preamble has been optimized for h = pi/2
+dec_factor = 2;      %Amount to decimate by when performing correlation
+                     %with preamble
+
+%32 bit training sequence
+%hex: AA, AA, AA, AA
+%Note: In order for the preamble waveform not to be messed up, the last
+%sample of the modulated training sequence MUST be 1 + 0j
+training_seq = ['10101010';
+                '10101010';
+                '10101010';
+                '10101010'];
+%32-bit preamble - hex: 2E, 69, 2C, F0
+preamble = ['00101110'; ...
+            '01101001'; ...
+            '00101100'; ...
+            '11110000'];
+
+%%-------------------TRANSMIT-----------------------------
+%Amount of flat samples (0+0j) to add to the beginning/end of tx signal
+null_amt = 200;
+
+%Prompt for string to transmit
+prompt = 'Enter a string to tx: ';
+str = input(prompt, 's');
+%Convert to bit matrix
+tx_bits = dec2bin(uint8(str), 8);
+
+%Make FSK signal
+tx_sig = fsk_transmit(training_seq, preamble, tx_bits, samps_per_symb, h);
+%Add some flat output to the front and back of the signal
+tx_sig(null_amt+1:length(tx_sig)+null_amt) = tx_sig;
+tx_sig(1:null_amt) = 0 + 0j;
+tx_sig(length(tx_sig)+1:length(tx_sig)+null_amt) = 0 + 0j;
+
+%time vector: 1/Fs increments
+t = 0 : 1/Fs : (length(tx_sig)-1)/Fs;
+
+%Write to csv file
+save_csv(txfile, tx_sig.');
+
+%TX IQ samples
+figure('position', [960 775 960 200]);
+plot(t, real(tx_sig), 'Color', [0,.447,.741]);
+hold on;
+plot(t, imag(tx_sig), 'Color', [.85,.325,.098]);
+title('TX IQ samples vs time');
+
+%Wait for user to transmit/receive these samples with bladeRF
+disp('Press any key when rx samples file is ready...');
+pause;
+
+%%---------------------RECEIVE---------------------------
+%Demodulate the set of samples given in 'rxfile' and print the received
+%string.
+%Load csv from file
+rx_sig = load_csv(rxfile).';
+%Get the modulated IQ waveform for the preamble
+preamble_waveform = fsk_mod(preamble, samps_per_symb, h, 0);
+%Filter/Normalize/Detect/Demodulate FSK signal
+[rx_bits, rx_info] = fsk_receive(preamble_waveform, rx_sig, dec_factor, ...
+                                    samps_per_symb, h, size(tx_bits, 1));
+
+%----------------------Plot some stuff---------------------
+%time vector: 1/Fs increments
+t = 0 : 1/Fs : (length(rx_sig)-1)/Fs;
+
+%RX IQ samples
+figure('position', [960 525 960 200]);
+plot(t, real(rx_sig), 'Color', [0,.447,.741]);
+hold on;
+plot(t, imag(rx_sig), 'Color', [.85,.325,.098]);
+ylim([-1, 1]);
+title('RX raw IQ samples vs time');
+
+%RX raw spectrum
+figure('position', [960 275 960 200]);
+if (exist('OCTAVE_VERSION', 'builtin') ~= 0)
+	pwelch(rx_sig, [], [], 256, Fs, 'centerdc');
+else
+	pwelch(rx_sig, [], [], [], Fs, 'centered');
+end
+title('RX raw spectrum');
+
+%RX filtered IQ samples
+figure('position', [960 0 960 200]);
+plot(real(rx_info.iq_filt_norm), 'Color', [0,.447,.741]);
+hold on;
+plot(imag(rx_info.iq_filt_norm), 'Color', [.85,.325,.098]);
+title('RX filtered & normalized IQ samples');
+
+%RX cross correlation with preamble. Plot power (i^2 + q^2).
+figure('position', [0 775 960 200]);
+plot(abs(rx_info.preamble_corr).^2);
+title('RX cross correlation with preamble (power)');
+
+%RX dphase (data signal only, training/preamble not included)
+if (rx_info.dphase ~= -1)
+    figure('position', [0 500 960, 200]);
+    plot(rx_info.dphase);
+    title('RX dphase (data signal only)');
+end
+
+%---------------------Print received data-------------------
+if (rx_bits(1) ~= -1)
+    fprintf('Received: ''%s''\n', bin2dec(rx_bits));
+    if isequal(rx_bits, tx_bits)
+        fprintf('RX data matched TX data\n');
+    else
+        fprintf(2, 'RX data did not match TX data\n');
+    end
+end
+
+fprintf('Press any key to close figures...\n');
+pause;
+close all;

--- a/host/utilities/bladeRF-fsk/matlab/fsk_demod.m
+++ b/host/utilities/bladeRF-fsk/matlab/fsk_demod.m
@@ -1,0 +1,85 @@
+%-------------------------------------------------------------------------
+% This file is part of the bladeRF project
+%
+% Copyright (C) 2016 Nuand LLC
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%-------------------------------------------------------------------------
+
+function [bits, dphase] = fsk_demod(fsk_signal, samps_per_symb, num_bytes)
+% FSK_DEMOD Produce demodulated bit stream from baseband CPFSK signal
+%    Demodulated bit stream contains (nrows*ncols) bits. A '1' corresponds
+%    to a positive frequency (increasing phase) while a '0' corresponds to a
+%    negative frequency (decreasing phase).
+%    [FSK_SIGNAL] = fsk_demod(FSK_SIGNAL, SAMPS_PER_SYMB, NROWS, NCOLS)
+%
+%    FSK_SIGNAL is the resulting complex (IQ) FSK modulated baseband signal
+%    with real and imaginary components within the range [-1.0, 1.0].
+%
+%    SAMPS_PER_SYMB number of samples per symbol
+%
+%    NUM_BYTES number of bytes to demodulate from the signal
+%
+%    BITS is an Nx8 matrix of received bits. Each bit element in
+%    the matrix is a char which can either be '1' or '0'. Each row of the
+%    matrix is a byte - containing 8 of these bit elements. Each byte is
+%    received in order from smallest row index to largest row index. Each
+%    bit in the byte is received in order from largest column index to
+%    smallest column index (i.e. LSb first, MSb last))
+%          Example: if bits is   | '0' '0' '0' '0' '1' '1' '1' '1'|
+%                                | '0' '0' '1' '1' '1' '0' '1' '0'|
+%                   then the received bit stream was:
+%                                      "11110000 01011100"
+%    Note: You can use dec2bin('test string', 8) to convert a string to
+%    this bit matrix format, and bin2dec(bits) to convert a bit matrix to a
+%    string
+
+%Check to make sure the iq signal is long enough to demod 'num_bytes' bytes
+if (length(fsk_signal) < samps_per_symb*num_bytes*8)
+    fprintf(2, ['fsk_demod(): Signal is not long enough to demod the', ...
+                ' desired number of bytes (%d)\n'], num_bytes);
+    bits = -1;
+    dphase = -1;
+    return;
+end
+
+%Sum up all changes in phase during symbol period
+%If total change is positive -> a 1 was sent
+%If total change is negative -> a 0 was sent
+
+currPos = 2;    %First sample just defines initial phase
+%Loop through each expected byte
+for byte = 1:num_bytes
+    %Loop through 8 bits
+    for bit = 8:-1:1
+        %Unwrap 1+samps_per_symb angles corresponding to these
+        %samps_per_symb samples AND the sample preceding them
+        phase = unwrap(angle(fsk_signal(currPos-1:currPos+samps_per_symb-1)));
+        dphase_tot = 0;                %Initialize dphase_tot to 0
+        for samp = 2:samps_per_symb+1
+            dphase_tot = dphase_tot + (phase(samp) - phase(samp-1));
+            %Update dphase array
+            dphase(currPos - 1) = phase(samp) - phase(samp-1);
+            currPos = currPos + 1;
+        end
+        if dphase_tot > 0
+            bits(byte, bit) = '1';
+        else
+            bits(byte, bit) = '0';
+        end
+    end
+end
+
+end

--- a/host/utilities/bladeRF-fsk/matlab/fsk_mod.m
+++ b/host/utilities/bladeRF-fsk/matlab/fsk_mod.m
@@ -1,0 +1,79 @@
+%-------------------------------------------------------------------------
+% This file is part of the bladeRF project
+%
+% Copyright (C) 2016 Nuand LLC
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%-------------------------------------------------------------------------
+
+function [fsk_signal] = fsk_mod(bits, samps_per_symb, mod_index, initial_phase)
+% FSK_MOD Produce baseband FSK signal of the input bit stream. A '1'
+% corresponds to a positive frequency (increasing phase), while a '0'
+% corresponds to a negative frequency (decreasing phase).
+%    [FSK_SIGNAL] = fsk_mod(BITS, SAMPS_PER_SYMB, MOD_INDEX, INITIAL_PHASE)
+%
+%    BITS is an Nx8 matrix of bits to transmit. Each bit element in
+%    the matrix is a char which can either be '1' or '0'. Each row of the
+%    matrix is a byte - containing 8 of these bit elements. Each byte is
+%    transmitted in order from smallest row index to largest row index. Each
+%    bit in the byte is transmitted in order from largest column index to
+%    smallest column index (i.e. LSb first, MSb last))
+%          Example: if bits is   | '0' '0' '0' '0' '1' '1' '1' '1'|
+%                                | '0' '0' '1' '1' '1' '0' '1' '0'|
+%                   then the transmitted bit stream will be:
+%                                         "11110000 01011100"
+%    Note: You can use dec2bin('test string', 8) to convert a string to
+%    this bit matrix format, and bin2dec(bits) to convert a bit matrix to a
+%    string
+%
+%    SAMPS_PER_SYMB number of samples per symbol
+%
+%    MOD_INDEX phase modulation index: the phase deviation per symbol
+%
+%    FSK_SIGNAL is the resulting complex (IQ) CPFSK modulated baseband
+%    signal with real and imaginary components within the range [-1.0, 1.0].
+%
+%    INITIAL_PHASE Initial phase to use as a reference (every sample is a
+%    change in phase, so an initial phase needs to be defined)
+
+%Calculate phase change per sample
+dphase_abs = mod_index / samps_per_symb;
+
+phase = initial_phase;        %Set initial phase
+i = 1;                        %Current samples position
+%Loop through each byte
+for byte = 1:size(bits,1)
+    %loop through each bit in the byte in reverse index order
+    for bit = 8:-1:1
+        if bits(byte, bit) == '1'    %Transmit 1
+            dphase = +dphase_abs;
+        elseif bits(byte, bit) == '0'
+            dphase = -dphase_abs;
+        else
+            fprintf(2, 'Unidentified character ''%c''. Skipping.\n', ...
+                        bits(byte, bit));
+            continue;
+        end
+        %Loop through each of the 'samps_per_symb' samples in the symbol
+        for samp = 1:samps_per_symb
+            phase_prev = phase;
+            phase = mod(phase_prev + dphase, 2*pi);
+            fsk_signal(i) = exp(1j * phase);
+            i = i + 1;
+        end
+    end
+end
+
+end

--- a/host/utilities/bladeRF-fsk/matlab/fsk_receive.m
+++ b/host/utilities/bladeRF-fsk/matlab/fsk_receive.m
@@ -1,0 +1,117 @@
+%-------------------------------------------------------------------------
+% This file is part of the bladeRF project
+%
+% Copyright (C) 2016 Nuand LLC
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%-------------------------------------------------------------------------
+
+function [bits, info] = fsk_receive(preamble_waveform, iq_signal, ...
+                                    decimation_factor, samps_per_symb, ...
+                                    h, num_bytes)
+% FSK_RECEIVE Demodulate/receive data bits from an FSK baseband IQ signal.
+% Correlates the iq_signal with the given preamble waveform to find the
+% start of the data signal
+%    [BITS, INFO] = fsk_receive(PREAMBLE_WAVEFORM, IQ_SIGNAL,
+%                              SAMPS_PER_SYMB, NUM_BYTES);
+%
+%    PREAMBLE_WAVEFORM preamble iq samples waveform to determine start of
+%    data in the the iq_signal
+%
+%    IQ_SIGNAL baseband CPFSK signal to receive
+%
+%    DECIMATION_FACTOR amount to decimate by when performing correlation
+%    with preamble. 1 = no decimation. 2 = use every other sample.
+%
+%    SAMPS_PER_SYMB number of samples per symbol
+%
+%    H modulation index used on the transmitted signal
+%
+%    NUM_BYTES number of data bytes to demodulate from the iq_signal
+%
+%    BITS is an Nx8 matrix of received bits. Each bit element in
+%    the matrix is a char which can either be '1' or '0'. Each row of the
+%    matrix is a byte - containing 8 of these bit elements. Each byte is
+%    received in order from smallest row index to largest row index. Each
+%    bit in the byte is received in order from largest column index to
+%    smallest column index (i.e. LSb first, MSb last))
+%          Example: if bits is   | '0' '0' '0' '0' '1' '1' '1' '1'|
+%                                | '0' '0' '1' '1' '1' '0' '1' '0'|
+%                   then the received bit stream was:
+%                                     "11110000 01011100"
+%    Note: You can use dec2bin('test string', 8) to convert a string to
+%    this bit matrix format, and bin2dec(bits) to convert a bit matrix to a
+%    string
+%
+%    INFO a struct containing information to use for debug plots
+%        INFO.iq_filt_norm  = filtered + normalized IQ signal
+%        INFO.preamble_corr = cross correlation of .iq_filt_norm and
+%                                preamble waveform
+%        INFO.dphase        = vector of phase changes in the .iq_filt_norm
+
+info = struct(    'iq_filt_norm', -1, ...
+                'preamble_corr', -1, ...
+                'dphase', -1);
+
+corr_peak_thresh = 0.5625 * (length(preamble_waveform)/decimation_factor)^2;
+
+%Low pass filter the IQ signal
+passband = 1/samps_per_symb * h*2/pi;
+stopband = 1/3 * 8/samps_per_symb * h*2/pi;
+if (stopband < 1)
+	%Design filter
+    b = remez(31, [0 passband stopband 1], [1 1 0 0]);
+    iq_signal = filter(b, 1, iq_signal);
+end
+
+%Normalize signal to [-1, 1]
+iq_signal = iq_signal / max([ max(real(iq_signal)) max(imag(iq_signal)) ]);
+info.iq_filt_norm = iq_signal;
+
+%Correlate input IQ signal with known preamble waveform
+%Decimate iq signal and preamble waveform
+iq_signal_dec = iq_signal(1:decimation_factor:end);
+preamble_waveform_dec = preamble_waveform(1:decimation_factor:end);
+corr = xcorr(iq_signal_dec, preamble_waveform_dec);
+info.preamble_corr = corr;
+
+%Find peaks in cross correlation power (i^2 + q^2)
+[peaks, peak_locs] = findpeaks(abs(corr).^2);
+%Attempt to find a peak which passes the threshold
+peak_index = -1;
+for i = 1:length(peaks)
+    if (peaks(i) >= corr_peak_thresh)
+        peak_index = peak_locs(i);
+        break;
+    end
+end
+%Stop if no preamble match
+if (peak_index == -1)
+    fprintf(2, 'fsk_receive(): No preamble match in signal\n');
+    bits = -1;
+    return;
+end
+%Calculate iq_signal start index based on this peak
+%Number of zeros that were padded to the end of preamble waveform inside
+%the xcorr() function so that both vectors were the same length:
+num_padded_zeros = length(iq_signal_dec) - length(preamble_waveform_dec);
+sig_start_index = peak_index - num_padded_zeros;
+%Calculate the un-decimated iq_signal start index
+sig_start_index = sig_start_index * decimation_factor - (decimation_factor-1);
+
+%Demodulate bits from the IQ signal at the start index
+[bits, info.dphase] = fsk_demod(iq_signal(sig_start_index:end), samps_per_symb, num_bytes);
+
+end

--- a/host/utilities/bladeRF-fsk/matlab/fsk_transmit.m
+++ b/host/utilities/bladeRF-fsk/matlab/fsk_transmit.m
@@ -1,0 +1,92 @@
+%-------------------------------------------------------------------------
+% This file is part of the bladeRF project
+%
+% Copyright (C) 2016 Nuand LLC
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 2 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%-------------------------------------------------------------------------
+
+function [iq_samples] = fsk_transmit(training_seq, preamble, data, ...
+                                    samps_per_symb, mod_index)
+% FSK_TRANSMIT Produce a baseband FSK signal of the input binary data, with
+% a ramp up/ramp down at the beginning/end of the signal.
+%    [IQ_SAMPLES] = fsk_transmit(TRAINING_SEQ, PREAMBLE, DATA,
+%                                SAMPS_PER_SYMB, MOD_INDEX);
+%
+%    TRAINING_SEQ is a matrix of training sequence bits to transmit. Format
+%    specified below.
+%
+%    PREAMBLE is a matrix of preamble bits to transmit. Format specified
+%    below
+%
+%    DATA is a matrix of data bits to transmit. Format specified below.
+%
+%    Bits matrix format: Each bit element in the matrix is a char which can
+%    either be '1' or '0'. Each row of the matrix is a byte - containing 8
+%    of these bit elements. Each byte is transmitted in order from smallest
+%    row index to largest row index. Each bit in the byte is transmitted in
+%    order from largest column index to smallest column index
+%    (i.e. LSb first, MSb last))
+%     Example: if the matrix is  | '0' '0' '0' '0' '1' '1' '1' '1'|
+%                                | '0' '0' '1' '1' '1' '0' '1' '0'|
+%               then the transmitted bit stream will be:
+%                                    "11110000 01011100"
+%    Note: You can use dec2bin('test string', 8) to convert a string to
+%    this bit matrix format, and bin2dec(bits) to convert a bit matrix to a
+%    string
+%
+%    SAMPS_PER_SYMB number of samples per symbol
+%
+%    MOD_INDEX phase modulation index: the phase deviation per symbol
+%
+%    IQ_SAMPLES is the resulting complex (IQ) FSK modulated baseband
+%    signal with real and imaginary components within the range [-1.0, 1.0].
+%    The following shows the content and ordering of this signal:
+%    / ramp up | training_seq | preamble | data | ramp down \
+%    The ramps at the beginning/end of the signal have a length of
+%    'samps_per_symb'
+
+%----Assemble bitstream to transmit
+%| training sequence | preamble | data |
+bits = training_seq;
+bits(size(bits, 1)+1 : size(bits,1)+size(preamble, 1), :) = preamble;
+bits(size(bits, 1)+1 : size(bits,1)+size(data, 1), :) = data;
+
+%----Construct IQ samples vector
+%-Ramp up the I samples from 0 to 1, and leave Q samples as zeros
+%Length of the ramp is 'samps_per_symb' samples
+iq_samples(1:samps_per_symb) = 1/samps_per_symb : 1/samps_per_symb: 1;
+
+%Modulate the bit stream, and add to iq_samples
+sig = fsk_mod(bits, samps_per_symb, mod_index, angle(iq_samples(end)));
+iq_samples(length(iq_samples)+1:length(iq_samples)+length(sig)) = sig;
+
+%-Ramp down the samples (either I or Q) to 0.
+%Length of the ramp is 'samps_per_symb' samples
+last_samp = iq_samples(end);
+if (real(last_samp) ~= 0)
+    rampdown_I = real(last_samp): -real(last_samp)/samps_per_symb: 0;
+else
+    rampdown_I(1:samps_per_symb+1) = 0;
+end
+if (imag(last_samp) ~= 0)
+    rampdown_Q = imag(last_samp): -imag(last_samp)/samps_per_symb: 0;
+else
+    rampdown_Q(1:samps_per_symb+1) = 0;
+end
+iq_samples(length(iq_samples)+1 : length(iq_samples)+samps_per_symb) = ...
+    rampdown_I(2:samps_per_symb+1) + 1j*rampdown_Q(2:samps_per_symb+1);
+
+end


### PR DESCRIPTION
This commit introduces a new utility which is a bladeRF-to-bladeRF text/file
transfer program. The program uses a custom FSK software modem (implemented in
host-side C code) to send/receive data. Included is a Matlab/Octave
simulation/implementation of the modem's physical layer. Supports
Windows/Linux/OSX. More info can be found in the README.md.

This utility now builds/installs as part of the bladeRF host side code. Meaning
it is included when building the host software from the source.