### PR TITLE
Fix build on macOS Sierra.

### DIFF
--- a/host/common/include/osx/clock_gettime.h
+++ b/host/common/include/osx/clock_gettime.h
@@ -27,6 +27,10 @@
 
 #include <time.h>
 
+#include "AvailabilityMacros.h"
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,6 +46,8 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 
 #ifdef __cplusplus
 } /* extern "C" */
+#endif
+
 #endif
 
 #endif

--- a/host/common/src/osx/clock_gettime.c
+++ b/host/common/src/osx/clock_gettime.c
@@ -1,3 +1,7 @@
+#include "AvailabilityMacros.h"
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
+
 /*
  * clock_gettime() wrapper for OSX based upon jbenet's github "gist":
  *   https://gist.github.com/jbenet/1087739
@@ -56,3 +60,5 @@ clock_gettime_out:
         return 0;
     }
 }
+
+#endif


### PR DESCRIPTION
The 2016.06 release (and also current master) does not build on macOS Sierra.  I found this when attempting to install on macOS Sierra via Homebrew.

This change properly builds using the simplest CMake build on macOS Sierra but has not been tested on earlier versions of macOS.

```cmake
$ mkdir build
$ cd build
$ cmake ..
$ make
```

I ran the most basic test of running the `bladerf-cli` program, but did not run any tests against a bladeRF device.  Is there a mechanism for doing this and reporting results?
