### PR TITLE
Don't fail postinst entirely on FPGA download error

### DIFF
--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -40,6 +40,8 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 
 		EOMSG
 
+		# exit successfully, as otherwise the package is left
+		# half-configured and the surrounding install/upgrade fails
 		exit 0
 	fi
 fi

--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -40,7 +40,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 
 		EOMSG
 
-		exit 1
+		exit 0
 	fi
 fi
 

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -40,6 +40,8 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 
 		EOMSG
 
+		# exit successfully, as otherwise the package is left
+		# half-configured and the surrounding install/upgrade fails
 		exit 0
 	fi
 fi

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -40,7 +40,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 
 		EOMSG
 
-		exit 1
+		exit 0
 	fi
 fi
 


### PR DESCRIPTION
Failing the postinst breaks the overall install operation and leaves packages half-configured.