### PR TITLE
Add a 'fabric register' interface to read/write registers in custom FPGA designs.

### DIFF
--- a/fpga_common/include/nios_pkt_8x32.h
+++ b/fpga_common/include/nios_pkt_8x32.h
@@ -100,10 +100,14 @@
 #define NIOS_PKT_8x32_IDX_RESV2      9
 
 /* Target IDs */
-#define NIOS_PKT_8x32_TARGET_VERSION 0x00   /* FPGA version (read only) */
-#define NIOS_PKT_8x32_TARGET_CONTROL 0x01   /* FPGA control/config register */
-#define NIOS_PKT_8x32_TARGET_ADF4351 0x02   /* XB-200 ADF4351 register access
-                                             * (write-only) */
+/* FPGA version (read only) */
+#define NIOS_PKT_8x32_TARGET_VERSION                0x00
+/* FPGA control/config register */
+#define NIOS_PKT_8x32_TARGET_CONTROL                0x01
+/* XB-200 ADF4351 register access (write-only) */
+#define NIOS_PKT_8x32_TARGET_ADF4351                0x02
+/* FPGA logic register access */
+#define NIOS_PKT_8x32_TARGET_FABRIC_REGISTER_PROBE  0x03
 
 /* IDs 0x80 through 0xff will not be assigned by Nuand. These are reserved
  * for user customizations */

--- a/hdl/fpga/ip/altera/nios_system/nios_system.qsys
+++ b/hdl/fpga/ip/altera/nios_system/nios_system.qsys
@@ -13,7 +13,7 @@
    {
       datum _sortIndex
       {
-         value = "19";
+         value = "20";
          type = "int";
       }
    }
@@ -29,7 +29,7 @@
    {
       datum _sortIndex
       {
-         value = "21";
+         value = "22";
          type = "int";
       }
    }
@@ -45,7 +45,7 @@
    {
       datum _sortIndex
       {
-         value = "23";
+         value = "24";
          type = "int";
       }
    }
@@ -61,7 +61,7 @@
    {
       datum _sortIndex
       {
-         value = "20";
+         value = "21";
          type = "int";
       }
    }
@@ -77,7 +77,7 @@
    {
       datum _sortIndex
       {
-         value = "22";
+         value = "23";
          type = "int";
       }
    }
@@ -93,7 +93,7 @@
    {
       datum _sortIndex
       {
-         value = "24";
+         value = "25";
          type = "int";
       }
    }
@@ -151,6 +151,14 @@
       {
          value = "36928";
          type = "String";
+      }
+   }
+   element fabric_probe
+   {
+      datum _sortIndex
+      {
+         value = "19";
+         type = "int";
       }
    }
    element iq_corr_rx_phase_gain
@@ -429,7 +437,31 @@
  <parameter name="testBenchDutName" value="" />
  <parameter name="timeStamp" value="0" />
  <parameter name="useTestBenchNamingPattern" value="false" />
- <instanceScript></instanceScript>
+ <instanceParameter
+   name="enable_fabric_register_inputs"
+   displayName="enable_fabric_register_inputs"
+   type="integer"
+   defaultValue="0"
+   legalRanges="0 1"
+   description="" />
+ <instanceParameter
+   name="enable_fabric_register_outputs"
+   displayName="enable_fabric_register_outputs"
+   type="integer"
+   defaultValue="0"
+   legalRanges="0 1"
+   description="" />
+ <instanceScript><![CDATA[# request a specific version of the scripting API
+package require -exact qsys 16.1
+
+# Set the name of the procedure to manipulate parameters
+set_module_property COMPOSITION_CALLBACK compose
+
+proc compose {} {
+    set_instance_parameter_value fabric_probe enable_inputs [ get_parameter_value enable_fabric_register_inputs ]
+    set_instance_parameter_value fabric_probe enable_outputs [ get_parameter_value enable_fabric_register_outputs ]
+}
+]]></instanceScript>
  <interface
    name="agc_dc_i_max"
    internal="agc_dc_i_max.external_connection"
@@ -482,6 +514,22 @@
    internal="peripheral_spi.external"
    type="conduit"
    dir="end" />
+ <interface
+   name="fabric_probe_in"
+   internal="fabric_probe.in"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="fabric_probe_out"
+   internal="fabric_probe.out"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="fabric_register_probe_0_registers_in"
+   internal="fabric_probe.registers_in" />
+ <interface
+   name="fabric_register_probe_0_registers_out"
+   internal="fabric_probe.registers_out" />
  <interface
    name="gpio"
    internal="control.external_connection"
@@ -660,6 +708,14 @@
   <parameter name="width" value="32" />
  </module>
  <module
+   name="fabric_probe"
+   kind="fabric_register_probe"
+   version="1.0"
+   enabled="1">
+  <parameter name="enable_inputs" value="true" />
+  <parameter name="enable_outputs" value="true" />
+ </module>
+ <module
    name="iq_corr_rx_phase_gain"
    kind="altera_avalon_pio"
    version="17.0"
@@ -739,7 +795,7 @@
   <parameter name="dataAddrWidth" value="16" />
   <parameter name="dataMasterHighPerformanceAddrWidth" value="1" />
   <parameter name="dataMasterHighPerformanceMapParam" value="" />
-  <parameter name="dataSlaveMapParam"><![CDATA[<address-map><slave name='ram.s1' start='0x4000' end='0x8000' type='altera_avalon_onchip_memory2.s1' /><slave name='nios2.debug_mem_slave' start='0x8800' end='0x9000' type='altera_nios2_gen2.debug_mem_slave' /><slave name='control.s1' start='0x9040' end='0x9060' type='altera_avalon_pio.s1' /><slave name='peripheral_spi.spi_control_port' start='0x9060' end='0x9080' type='altera_avalon_spi.spi_control_port' /><slave name='xb_gpio_dir.s1' start='0x90A0' end='0x90B0' type='altera_avalon_pio.s1' /><slave name='xb_gpio.s1' start='0x90B0' end='0x90C0' type='altera_avalon_pio.s1' /><slave name='iq_corr_tx_phase_gain.s1' start='0x90C0' end='0x90D0' type='altera_avalon_pio.s1' /><slave name='iq_corr_rx_phase_gain.s1' start='0x90D0' end='0x90E0' type='altera_avalon_pio.s1' /><slave name='opencores_i2c.bladerf_oc_i2c_master' start='0x90F0' end='0x90F8' type='bladerf_oc_i2c_master.bladerf_oc_i2c_master' /><slave name='jtag_uart.avalon_jtag_slave' start='0x9100' end='0x9108' type='altera_avalon_jtag_uart.avalon_jtag_slave' /><slave name='command_uart.avalon_slave' start='0x9120' end='0x9140' type='command_uart.avalon_slave' /><slave name='tx_tamer.avalon_slave_0' start='0x9140' end='0x9160' type='time_tamer.avalon_slave_0' /><slave name='rx_tamer.avalon_slave_0' start='0x9160' end='0x9180' type='time_tamer.avalon_slave_0' /><slave name='lms_spi.avalon_slave_0' start='0x9200' end='0x9300' type='lms6_spi_controller.avalon_slave_0' /><slave name='vctcxo_tamer_0.avalon_slave_0' start='0x9300' end='0x9400' type='vctcxo_tamer.avalon_slave_0' /><slave name='rx_trigger_ctl.s1' start='0x9400' end='0x9420' type='altera_avalon_pio.s1' /><slave name='tx_trigger_ctl.s1' start='0x9420' end='0x9440' type='altera_avalon_pio.s1' /><slave name='arbiter_0.avalon_slave_0' start='0x9500' end='0x9520' type='arbiter.avalon_slave_0' /><slave name='agc_dc_i_max.s1' start='0x9600' end='0x9610' type='altera_avalon_pio.s1' /><slave name='agc_dc_q_max.s1' start='0x9610' end='0x9620' type='altera_avalon_pio.s1' /><slave name='agc_dc_i_mid.s1' start='0x9620' end='0x9630' type='altera_avalon_pio.s1' /><slave name='agc_dc_q_mid.s1' start='0x9630' end='0x9640' type='altera_avalon_pio.s1' /><slave name='agc_dc_i_min.s1' start='0x9640' end='0x9650' type='altera_avalon_pio.s1' /><slave name='agc_dc_q_min.s1' start='0x9650' end='0x9660' type='altera_avalon_pio.s1' /></address-map>]]></parameter>
+  <parameter name="dataSlaveMapParam"><![CDATA[<address-map><slave name='fabric_probe.mm' start='0x0' end='0x20' type='fabric_register_probe.mm' /><slave name='ram.s1' start='0x4000' end='0x8000' type='altera_avalon_onchip_memory2.s1' /><slave name='nios2.debug_mem_slave' start='0x8800' end='0x9000' type='altera_nios2_gen2.debug_mem_slave' /><slave name='control.s1' start='0x9040' end='0x9060' type='altera_avalon_pio.s1' /><slave name='peripheral_spi.spi_control_port' start='0x9060' end='0x9080' type='altera_avalon_spi.spi_control_port' /><slave name='xb_gpio_dir.s1' start='0x90A0' end='0x90B0' type='altera_avalon_pio.s1' /><slave name='xb_gpio.s1' start='0x90B0' end='0x90C0' type='altera_avalon_pio.s1' /><slave name='iq_corr_tx_phase_gain.s1' start='0x90C0' end='0x90D0' type='altera_avalon_pio.s1' /><slave name='iq_corr_rx_phase_gain.s1' start='0x90D0' end='0x90E0' type='altera_avalon_pio.s1' /><slave name='opencores_i2c.bladerf_oc_i2c_master' start='0x90F0' end='0x90F8' type='bladerf_oc_i2c_master.bladerf_oc_i2c_master' /><slave name='jtag_uart.avalon_jtag_slave' start='0x9100' end='0x9108' type='altera_avalon_jtag_uart.avalon_jtag_slave' /><slave name='command_uart.avalon_slave' start='0x9120' end='0x9140' type='command_uart.avalon_slave' /><slave name='tx_tamer.avalon_slave_0' start='0x9140' end='0x9160' type='time_tamer.avalon_slave_0' /><slave name='rx_tamer.avalon_slave_0' start='0x9160' end='0x9180' type='time_tamer.avalon_slave_0' /><slave name='lms_spi.avalon_slave_0' start='0x9200' end='0x9300' type='lms6_spi_controller.avalon_slave_0' /><slave name='vctcxo_tamer_0.avalon_slave_0' start='0x9300' end='0x9400' type='vctcxo_tamer.avalon_slave_0' /><slave name='rx_trigger_ctl.s1' start='0x9400' end='0x9420' type='altera_avalon_pio.s1' /><slave name='tx_trigger_ctl.s1' start='0x9420' end='0x9440' type='altera_avalon_pio.s1' /><slave name='arbiter_0.avalon_slave_0' start='0x9500' end='0x9520' type='arbiter.avalon_slave_0' /><slave name='agc_dc_i_max.s1' start='0x9600' end='0x9610' type='altera_avalon_pio.s1' /><slave name='agc_dc_q_max.s1' start='0x9610' end='0x9620' type='altera_avalon_pio.s1' /><slave name='agc_dc_i_mid.s1' start='0x9620' end='0x9630' type='altera_avalon_pio.s1' /><slave name='agc_dc_q_mid.s1' start='0x9630' end='0x9640' type='altera_avalon_pio.s1' /><slave name='agc_dc_i_min.s1' start='0x9640' end='0x9650' type='altera_avalon_pio.s1' /><slave name='agc_dc_q_min.s1' start='0x9650' end='0x9660' type='altera_avalon_pio.s1' /></address-map>]]></parameter>
   <parameter name="data_master_high_performance_paddr_base" value="0" />
   <parameter name="data_master_high_performance_paddr_size" value="0" />
   <parameter name="data_master_paddr_base" value="0" />
@@ -1114,6 +1170,15 @@
   <parameter name="baseAddress" value="0x8800" />
   <parameter name="defaultConnection" value="false" />
  </connection>
+ <connection
+   kind="avalon"
+   version="17.0"
+   start="nios2.data_master"
+   end="fabric_probe.mm">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
  <connection kind="avalon" version="17.0" start="nios2.data_master" end="ram.s1">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x4000" />
@@ -1349,6 +1414,11 @@
    kind="clock"
    version="17.0"
    start="system_clock.clk"
+   end="fabric_probe.clock" />
+ <connection
+   kind="clock"
+   version="17.0"
+   start="system_clock.clk"
    end="opencores_i2c.clock_sink" />
  <connection
    kind="clock"
@@ -1527,6 +1597,11 @@
    version="17.0"
    start="system_clock.clk_reset"
    end="agc_dc_q_min.reset" />
+ <connection
+   kind="reset"
+   version="17.0"
+   start="system_clock.clk_reset"
+   end="fabric_probe.reset" />
  <connection
    kind="reset"
    version="17.0"

--- a/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/devices.c
+++ b/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/devices.c
@@ -195,6 +195,16 @@ void vctcxo_tamer_write(uint8_t addr, uint8_t data) {
     IOWR_8DIRECT(VCTCXO_TAMER_0_BASE, addr, data);
 }
 
+void fabric_register_probe_write(uint8_t addr, uint32_t data) {
+    addr = (addr & 0x07) << 2;
+    IOWR_32DIRECT(FABRIC_PROBE_BASE, addr, data);
+}
+
+uint32_t fabric_register_probe_read(uint8_t addr) {
+    addr = (addr & 0x07) << 2;
+    return (uint32_t)IORD_32DIRECT(FABRIC_PROBE_BASE, addr);
+}
+
 void tamer_schedule(bladerf_module m, uint64_t time) {
     uint32_t base = (m == BLADERF_MODULE_RX) ? RX_TAMER_BASE : TX_TAMER_BASE ;
 

--- a/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/devices.h
+++ b/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/devices.h
@@ -171,6 +171,23 @@ void vctcxo_trim_dac_write(uint8_t cmd, uint16_t val);
 void vctcxo_trim_dac_read(uint8_t cmd, uint16_t *val);
 
 /**
+ * Write a value to a fabric register
+ *
+ * @param   addr    fabric register addess
+ * @param   val     fabric register value
+ */
+void fabric_register_probe_write(uint8_t addr, uint32_t data);
+
+/**
+ * Read a value from a fabric register
+ *
+ * @param   addr    fabric register addess
+ *
+ * @return  The read register value
+ */
+uint32_t fabric_register_probe_read(uint8_t addr);
+
+/**
  * Write a value to the ADF4351 synthesizer (on the XB-200)
  *
  * @param   val     Value to write

--- a/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/fpga_version.h
+++ b/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/fpga_version.h
@@ -7,7 +7,7 @@
 
 #define FPGA_VERSION_ID         0x7777
 #define FPGA_VERSION_MAJOR      0
-#define FPGA_VERSION_MINOR      7
+#define FPGA_VERSION_MINOR      8
 #define FPGA_VERSION_PATCH      0
 #define FPGA_VERSION ((uint32_t)( FPGA_VERSION_MAJOR        | \
                                  (FPGA_VERSION_MINOR << 8)  | \

--- a/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/pkt_8x32.c
+++ b/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/pkt_8x32.c
@@ -45,6 +45,10 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint32_t *data)
             *data = 0x00;
             return false;
 
+        case NIOS_PKT_8x32_TARGET_FABRIC_REGISTER_PROBE:
+            *data = fabric_register_probe_read(addr);
+            break;
+
         default:
             DBG("Invalid id: 0x%02x\n", id);
             *data = 0x00;
@@ -67,6 +71,10 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint32_t data)
 
         case NIOS_PKT_8x32_TARGET_ADF4351:
             adf4351_write(data);
+            break;
+
+        case NIOS_PKT_8x32_TARGET_FABRIC_REGISTER_PROBE:
+            fabric_register_probe_write(addr, data);
             break;
 
         default:

--- a/hdl/fpga/ip/thasti/fabric_register_probe/qsys/fabric_register_probe_hw.tcl
+++ b/hdl/fpga/ip/thasti/fabric_register_probe/qsys/fabric_register_probe_hw.tcl
@@ -1,0 +1,182 @@
+# 
+# fabric_register_probe "BladeRF Fabric Register Probe" v1.0
+# Stefan Biereigel 2017.05.18.14:28:15
+# Can be used to probe FPGA registers from libbladeRF
+# 
+
+# 
+# request TCL package from ACDS 15.0
+# 
+package require -exact qsys 15.0
+
+
+# 
+# module fabric_register_probe
+# 
+set_module_property DESCRIPTION "Can be used to probe FPGA registers from libbladeRF"
+set_module_property NAME fabric_register_probe
+set_module_property VERSION 1.0
+set_module_property INTERNAL false
+set_module_property OPAQUE_ADDRESS_MAP true
+set_module_property GROUP Peripherals
+set_module_property AUTHOR "Stefan Biereigel"
+set_module_property DISPLAY_NAME "BladeRF Fabric Register Probe"
+set_module_property INSTANTIATE_IN_SYSTEM_MODULE true
+set_module_property EDITABLE true
+set_module_property REPORT_TO_TALKBACK false
+set_module_property ALLOW_GREYBOX_GENERATION false
+set_module_property REPORT_HIERARCHY false
+
+
+# 
+# file sets
+# 
+add_fileset QUARTUS_SYNTH QUARTUS_SYNTH "" ""
+set_fileset_property QUARTUS_SYNTH TOP_LEVEL fabric_register_probe
+set_fileset_property QUARTUS_SYNTH ENABLE_RELATIVE_INCLUDE_PATHS false
+set_fileset_property QUARTUS_SYNTH ENABLE_FILE_OVERWRITE_MODE false
+add_fileset_file fabric_register_probe.vhd VHDL PATH ../vhdl/fabric_register_probe.vhd TOP_LEVEL_FILE
+
+
+# 
+# parameters
+# 
+add_parameter enable_outputs BOOLEAN false
+set_parameter_property enable_outputs DEFAULT_VALUE false
+set_parameter_property enable_outputs TYPE BOOLEAN
+set_parameter_property enable_outputs HDL_PARAMETER false
+set_parameter_property enable_outputs AFFECTS_ELABORATION true
+set_parameter_property enable_outputs VISIBLE true
+
+add_parameter enable_inputs BOOLEAN false
+set_parameter_property enable_inputs DEFAULT_VALUE false
+set_parameter_property enable_inputs TYPE BOOLEAN
+set_parameter_property enable_inputs HDL_PARAMETER false
+set_parameter_property enable_inputs AFFECTS_ELABORATION true
+set_parameter_property enable_inputs VISIBLE true
+
+# 
+# display items
+# 
+
+# 
+# connection point reset
+# 
+add_interface reset reset end
+set_interface_property reset associatedClock clock
+set_interface_property reset synchronousEdges DEASSERT
+set_interface_property reset ENABLED true
+set_interface_property reset EXPORT_OF ""
+set_interface_property reset PORT_NAME_MAP ""
+set_interface_property reset CMSIS_SVD_VARIABLES ""
+set_interface_property reset SVD_ADDRESS_GROUP ""
+
+add_interface_port reset reset reset Input 1
+
+# 
+# connection point clock
+# 
+add_interface clock clock end
+set_interface_property clock clockRate 0
+set_interface_property clock ENABLED true
+set_interface_property clock EXPORT_OF ""
+set_interface_property clock PORT_NAME_MAP ""
+set_interface_property clock CMSIS_SVD_VARIABLES ""
+set_interface_property clock SVD_ADDRESS_GROUP ""
+
+add_interface_port clock clk clk Input 1
+
+# 
+# connection point mm
+# 
+add_interface mm avalon end
+set_interface_property mm addressUnits SYMBOLS
+set_interface_property mm associatedClock clock
+set_interface_property mm associatedReset reset
+set_interface_property mm bitsPerSymbol 8
+set_interface_property mm burstOnBurstBoundariesOnly false
+set_interface_property mm burstcountUnits WORDS
+set_interface_property mm explicitAddressSpan 0
+set_interface_property mm holdTime 0
+set_interface_property mm linewrapBursts false
+set_interface_property mm maximumPendingReadTransactions 1
+set_interface_property mm maximumPendingWriteTransactions 0
+set_interface_property mm readLatency 0
+set_interface_property mm readWaitTime 1
+set_interface_property mm setupTime 0
+set_interface_property mm timingUnits Cycles
+set_interface_property mm writeWaitTime 0
+set_interface_property mm ENABLED true
+set_interface_property mm EXPORT_OF ""
+set_interface_property mm PORT_NAME_MAP ""
+set_interface_property mm CMSIS_SVD_VARIABLES ""
+set_interface_property mm SVD_ADDRESS_GROUP ""
+
+add_interface_port mm mm_begintransfer begintransfer Input 1
+add_interface_port mm mm_write write Input 1
+add_interface_port mm mm_address address Input 5
+add_interface_port mm mm_writedata writedata Input 32
+add_interface_port mm mm_read read Input 1
+add_interface_port mm mm_readdata readdata Output 32
+add_interface_port mm mm_readdatavalid readdatavalid Output 1
+set_interface_assignment mm embeddedsw.configuration.isFlash 0
+set_interface_assignment mm embeddedsw.configuration.isMemoryDevice 0
+set_interface_assignment mm embeddedsw.configuration.isNonVolatileStorage 0
+set_interface_assignment mm embeddedsw.configuration.isPrintableDevice 0
+
+# 
+# connection point conduit_end
+# 
+add_interface out conduit end
+set_interface_property out associatedClock clock
+set_interface_property out associatedReset ""
+set_interface_property out ENABLED false
+set_interface_property out EXPORT_OF ""
+set_interface_property out PORT_NAME_MAP ""
+set_interface_property out CMSIS_SVD_VARIABLES ""
+set_interface_property out SVD_ADDRESS_GROUP ""
+
+add_interface_port out register0_out register0_out Output 32
+add_interface_port out register1_out register1_out Output 32
+add_interface_port out register2_out register2_out Output 32
+add_interface_port out register3_out register3_out Output 32
+add_interface_port out register4_out register4_out Output 32
+add_interface_port out register5_out register5_out Output 32
+add_interface_port out register6_out register6_out Output 32
+add_interface_port out register7_out register7_out Output 32
+
+add_interface in conduit end
+set_interface_property in associatedClock clock
+set_interface_property in associatedReset ""
+set_interface_property in ENABLED false
+set_interface_property in EXPORT_OF ""
+set_interface_property in PORT_NAME_MAP ""
+set_interface_property in CMSIS_SVD_VARIABLES ""
+set_interface_property in SVD_ADDRESS_GROUP ""
+
+add_interface_port in register0_in register0_in Input 32
+add_interface_port in register1_in register1_in Input 32
+add_interface_port in register2_in register2_in Input 32
+add_interface_port in register3_in register3_in Input 32
+add_interface_port in register4_in register4_in Input 32
+add_interface_port in register5_in register5_in Input 32
+add_interface_port in register6_in register6_in Input 32
+add_interface_port in register7_in register7_in Input 32
+
+set_module_property ELABORATION_CALLBACK cb_elaborate
+
+proc cb_elaborate {} {
+    if { [get_parameter_value enable_inputs] == false } {
+        set_interface_property in ENABLED false
+    } else {
+        set_interface_property in ENABLED true
+    }
+    
+    if { [get_parameter_value enable_outputs] == false } {
+        set_interface_property out ENABLED false
+    } else {
+        set_interface_property out ENABLED true
+    }
+}
+
+

--- a/hdl/fpga/ip/thasti/fabric_register_probe/vhdl/fabric_register_probe.vhd
+++ b/hdl/fpga/ip/thasti/fabric_register_probe/vhdl/fabric_register_probe.vhd
@@ -1,0 +1,118 @@
+-- Copyright (c) 2017 Stefan Biereigel
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity fabric_register_probe is
+    port (
+        mm_begintransfer : in  std_logic                     := '0';
+        mm_write         : in  std_logic                     := '0';
+        mm_address       : in  std_logic_vector(4 downto 0)  := (others => '0');
+        mm_writedata     : in  std_logic_vector(31 downto 0) := (others => '0');
+        mm_read          : in  std_logic                     := '0';
+        mm_readdata      : out std_logic_vector(31 downto 0);
+        mm_readdatavalid : out std_logic;
+        clk              : in  std_logic                     := '0';
+        reset            : in  std_logic                     := '0';
+        register0_out    : out  std_logic_vector(31 downto 0);
+        register1_out    : out  std_logic_vector(31 downto 0);
+        register2_out    : out  std_logic_vector(31 downto 0);
+        register3_out    : out  std_logic_vector(31 downto 0);
+        register4_out    : out  std_logic_vector(31 downto 0);
+        register5_out    : out  std_logic_vector(31 downto 0);
+        register6_out    : out  std_logic_vector(31 downto 0);
+        register7_out    : out  std_logic_vector(31 downto 0);
+        register0_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register1_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register2_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register3_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register4_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register5_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register6_in     : in  std_logic_vector(31 downto 0) := (others => '0');
+        register7_in     : in  std_logic_vector(31 downto 0) := (others => '0')
+);
+end entity fabric_register_probe;
+
+architecture rtl of fabric_register_probe is
+    -- flip flops to store written values
+    signal register0_out_ff : std_logic_vector(31 downto 0);
+    signal register1_out_ff : std_logic_vector(31 downto 0);
+    signal register2_out_ff : std_logic_vector(31 downto 0);
+    signal register3_out_ff : std_logic_vector(31 downto 0);
+    signal register4_out_ff : std_logic_vector(31 downto 0);
+    signal register5_out_ff : std_logic_vector(31 downto 0);
+    signal register6_out_ff : std_logic_vector(31 downto 0);
+    signal register7_out_ff : std_logic_vector(31 downto 0);
+ 
+begin
+
+    register0_out <= register0_out_ff;
+    register1_out <= register1_out_ff;
+    register2_out <= register2_out_ff;
+    register3_out <= register3_out_ff;
+    register4_out <= register4_out_ff;
+    register5_out <= register5_out_ff;
+    register6_out <= register6_out_ff;
+    register7_out <= register7_out_ff;
+    
+    -- Avalon-MM interface for write requests
+    mm_writes : process(clk)
+    begin
+        if rising_edge(clk) then
+            if mm_write = '1' then
+                case to_integer(unsigned(mm_address)) is
+                    when  0| 1| 2| 3 => register0_out_ff <= mm_writedata;
+                    when  4| 5| 6| 7 => register1_out_ff <= mm_writedata;
+                    when  8| 9|10|11 => register2_out_ff <= mm_writedata;
+                    when 12|13|14|15 => register3_out_ff <= mm_writedata;
+                    when 16|17|18|19 => register4_out_ff <= mm_writedata;
+                    when 20|21|22|23 => register5_out_ff <= mm_writedata;
+                    when 24|25|26|27 => register6_out_ff <= mm_writedata;
+                    when 28|29|30|31 => register7_out_ff <= mm_writedata;
+                    when others => null;
+                end case;
+            end if;
+        end if;
+    end process;
+
+    -- Avanlon-MM interface for read requests
+    mm_reads : process(clk)
+    begin
+        if rising_edge(clk) then
+            mm_readdatavalid <= mm_read;
+            if mm_read = '1' then
+                case to_integer(unsigned(mm_address)) is
+                    when  0| 1| 2| 3 => mm_readdata <= register0_in;
+                    when  4| 5| 6| 7 => mm_readdata <= register1_in;
+                    when  8| 9|10|11 => mm_readdata <= register2_in;
+                    when 12|13|14|15 => mm_readdata <= register3_in;
+                    when 16|17|18|19 => mm_readdata <= register4_in;
+                    when 20|21|22|23 => mm_readdata <= register5_in;
+                    when 24|25|26|27 => mm_readdata <= register6_in;
+                    when 28|29|30|31 => mm_readdata <= register7_in;
+                    when others => mm_readdata <= (others => '0');
+                end case;
+            end if;
+        end if;
+    end process;
+
+end architecture rtl;

--- a/hdl/quartus/build_bladerf.sh
+++ b/hdl/quartus/build_bladerf.sh
@@ -85,6 +85,10 @@ fi
 # Default to NIOS II E (Tiny)
 nios_rev="Tiny"
 
+# Don't export the fabric register probe outputs for the default revisions
+export_fabric_register_outputs=0
+export_fabric_register_inputs=0
+
 while getopts ":fa:s:r:n:h" opt; do
     case $opt in
         h)
@@ -200,7 +204,9 @@ ip-generate \
     --system-info=DEVICE_FAMILY=Cyclone\ IV\ E \
     --system-info=DEVICE=EP4CE40F23C8 \
     --system-info=DEVICE_SPEEDGRADE=8 \
-    --component-file=$nios_system/nios_system.qsys
+    --component-file=$nios_system/nios_system.qsys \
+    --component-parameter=enable_fabric_register_inputs=$export_fabric_register_inputs \
+    --component-parameter=enable_fabric_register_outputs=$export_fabric_register_outputs
 
 ip-generate \
     --project-directory=$nios_system \
@@ -213,7 +219,9 @@ ip-generate \
     --system-info=DEVICE_FAMILY=Cyclone\ IV\ E \
     --system-info=DEVICE=EP4CE40F23C8 \
     --system-info=DEVICE_SPEEDGRADE=8 \
-    --component-file=$nios_system/nios_system.qsys
+    --component-file=$nios_system/nios_system.qsys \
+    --component-parameter=enable_fabric_register_inputs=$export_fabric_register_inputs \
+    --component-parameter=enable_fabric_register_outputs=$export_fabric_register_outputs
 
 echo ""
 echo "##########################################################################"

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -6,7 +6,7 @@ project(libbladeRF C)
 ################################################################################
 
 set(VERSION_INFO_MAJOR  1)
-set(VERSION_INFO_MINOR  8)
+set(VERSION_INFO_MINOR  9)
 set(VERSION_INFO_PATCH  0)
 
 if(NOT DEFINED VERSION_INFO_EXTRA)

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -50,7 +50,7 @@
  *
  *  https://github.com/Nuand/bladeRF/blob/master/doc/development/versioning.md
  */
-#define LIBBLADERF_API_VERSION (0x01080000)
+#define LIBBLADERF_API_VERSION (0x01090000)
 
 #ifdef __cplusplus
 extern "C" {
@@ -2751,6 +2751,32 @@ void CALL_CONV bladerf_log_set_verbosity(bladerf_log_level level);
  */
 API_EXPORT
 int CALL_CONV bladerf_get_fw_log(struct bladerf *dev, const char *filename);
+
+/**
+ * Read a register value from the programmable logic register probe
+ *
+ * @param[in]   dev     Device handle
+ * @param[in]   addr    FPGA register address
+ * @param[out]  value   FPGA register value
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_fabric_register_read(struct bladerf *dev,
+                                            uint8_t addr, uint32_t *value);
+
+/**
+ * Write a register value in the programmable logic register probe
+ *
+ * @param[in]   dev     Device handle
+ * @param[in]   addr    FPGA register probe address
+ * @param[in]   value   FPGA register probe value
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_fabric_register_write(struct bladerf *dev,
+                                            uint8_t addr, uint32_t value);
 
 /** @} (End of FN_MISC) */
 

--- a/host/libraries/libbladeRF/src/backend/backend.h
+++ b/host/libraries/libbladeRF/src/backend/backend.h
@@ -155,6 +155,13 @@ struct backend_fns {
     int (*get_vctcxo_tamer_mode)(struct bladerf *dev,
                                  bladerf_vctcxo_tamer_mode *mode);
 
+    /* Fabric register accessors */
+    int (*fabric_register_write)(struct bladerf *dev,
+                                    uint8_t addr, uint32_t value);
+
+    int (*fabric_register_read)(struct bladerf *dev,
+                                    uint8_t addr, uint32_t *value);
+
     /* Expansion board SPI */
     int (*xb_spi)(struct bladerf *dev, uint32_t value);
 

--- a/host/libraries/libbladeRF/src/backend/dummy.c
+++ b/host/libraries/libbladeRF/src/backend/dummy.c
@@ -213,6 +213,19 @@ static int dummy_vctcxo_dac_read(struct bladerf *dev, uint16_t *value)
     return 0;
 }
 
+static int dummy_fabric_register_write(struct bladerf *dev,
+                                    uint8_t addr, uint32_t value)
+{
+    return 0;
+}
+
+static int dummy_fabric_register_read(struct bladerf *dev,
+                                    uint8_t addr, uint32_t *value)
+{
+    *value = 0;
+    return 0;
+}
+
 static int dummy_xb_spi(struct bladerf *dev, uint32_t value)
 {
     return 0;
@@ -338,6 +351,9 @@ const struct backend_fns backend_fns_dummy = {
 
     FIELD_INIT(.vctcxo_dac_write, dummy_vctcxo_dac_write),
     FIELD_INIT(.vctcxo_dac_read,  dummy_vctcxo_dac_read),
+
+    FIELD_INIT(.fabric_register_write, dummy_fabric_register_write),
+    FIELD_INIT(.fabric_register_read,  dummy_fabric_register_read),
 
     FIELD_INIT(.set_vctcxo_tamer_mode, dummy_set_vctcxo_tamer_mode),
     FIELD_INIT(.get_vctcxo_tamer_mode, dummy_get_vctcxo_tamer_mode),

--- a/host/libraries/libbladeRF/src/backend/usb/nios_access.c
+++ b/host/libraries/libbladeRF/src/backend/usb/nios_access.c
@@ -522,6 +522,53 @@ int nios_get_vctcxo_tamer_mode(struct bladerf *dev,
     return status;
 }
 
+int nios_fabric_register_write(struct bladerf *dev,
+                                uint8_t addr, uint32_t value)
+{
+    int status;
+
+    if (!have_cap(dev, BLADERF_CAP_FABRIC_REGISTER_ACCESS)) {
+        log_debug("FPGA %s does not support fabric register access\n",
+                  dev->fpga_version.describe);
+
+        return BLADERF_ERR_UNSUPPORTED;
+    }
+
+
+    status = nios_8x32_write(dev, NIOS_PKT_8x32_TARGET_FABRIC_REGISTER_PROBE,
+                            addr, value);
+
+    if (status == 0) {
+        log_verbose("%s: Wrote addr=0x%02x, value=0x%08x\n", __FUNCTION__, addr, value);
+    }
+
+    return status;
+}
+
+int nios_fabric_register_read(struct bladerf *dev,
+                                uint8_t addr, uint32_t *value)
+{
+    int status;
+    uint32_t tmp;
+
+    *value = 0;
+
+    if (!have_cap(dev, BLADERF_CAP_FABRIC_REGISTER_ACCESS)) {
+        log_debug("FPGA %s does not support fabric register access\n",
+                  dev->fpga_version.describe);
+
+        return BLADERF_ERR_UNSUPPORTED;
+    }
+
+    status = nios_8x32_read(dev, NIOS_PKT_8x32_TARGET_FABRIC_REGISTER_PROBE,
+            addr, &tmp);
+    if (status == 0) {
+        log_verbose("%s: Read addr=0x%02x, value=0x%08x\n", __FUNCTION__, addr, tmp);
+        *value = tmp;
+    }
+
+    return status;
+}
 
 int nios_get_iq_gain_correction(struct bladerf *dev, bladerf_module module,
                                 int16_t *value)

--- a/host/libraries/libbladeRF/src/backend/usb/nios_access.h
+++ b/host/libraries/libbladeRF/src/backend/usb/nios_access.h
@@ -169,6 +169,30 @@ int nios_set_vctcxo_tamer_mode(struct bladerf *dev,
 int nios_get_vctcxo_tamer_mode(struct bladerf *dev,
                                bladerf_vctcxo_tamer_mode *mode);
 
+/*
+ * Write a register value in the programmable logic register probe
+ *
+ * @param[in]   dev     Device handle
+ * @param[in]   addr    FPGA register probe address
+ * @param[in]   value   FPGA register probe value
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+int nios_fabric_register_write(struct bladerf *dev,
+                                uint8_t addr, uint32_t value);
+
+/*
+ * Read a register value from the programmable logic register probe
+ *
+ * @param[in]   dev     Device handle
+ * @param[in]   addr    FPGA register address
+ * @param[out]  value   FPGA register value
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+int nios_fabric_register_read(struct bladerf *dev,
+                                uint8_t addr, uint32_t *value);
+
 /**
  * Read a IQ gain correction value
  *

--- a/host/libraries/libbladeRF/src/backend/usb/usb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/usb.c
@@ -1075,6 +1075,21 @@ static int get_vctcxo_tamer_mode_unsupported(struct bladerf *dev,
     return BLADERF_ERR_UNSUPPORTED;
 }
 
+static int fabric_register_write_unsupported(struct bladerf *dev,
+                                            uint8_t addr, uint32_t value)
+{
+    log_debug("Operation not supported with legacy NIOS packet format.\n");
+    return BLADERF_ERR_UNSUPPORTED;
+}
+
+static int fabric_register_read_unsupported(struct bladerf *dev,
+                                            uint8_t addr, uint32_t *value)
+{
+    *value = 0;
+    log_debug("Operation not supported with legacy NIOS packet format.\n");
+    return BLADERF_ERR_UNSUPPORTED;
+}
+
 static int usb_read_fw_log(struct bladerf *dev, logger_entry *e)
 {
     int status;
@@ -1142,6 +1157,9 @@ const struct backend_fns backend_fns_usb_legacy = {
 
     FIELD_INIT(.set_vctcxo_tamer_mode, set_vctcxo_tamer_mode_unsupported),
     FIELD_INIT(.get_vctcxo_tamer_mode, get_vctcxo_tamer_mode_unsupported),
+
+    FIELD_INIT(.fabric_register_write, fabric_register_write_unsupported),
+    FIELD_INIT(.fabric_register_read, fabric_register_read_unsupported),
 
     FIELD_INIT(.xb_spi, nios_legacy_xb200_synth_write),
 
@@ -1213,6 +1231,9 @@ const struct backend_fns backend_fns_usb = {
 
     FIELD_INIT(.set_vctcxo_tamer_mode, nios_set_vctcxo_tamer_mode),
     FIELD_INIT(.get_vctcxo_tamer_mode, nios_get_vctcxo_tamer_mode),
+
+    FIELD_INIT(.fabric_register_write, nios_fabric_register_write),
+    FIELD_INIT(.fabric_register_read, nios_fabric_register_read),
 
     FIELD_INIT(.xb_spi, nios_xb200_synth_write),
 

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -1978,6 +1978,33 @@ int bladerf_get_vctcxo_tamer_mode(struct bladerf *dev,
 }
 
 /*------------------------------------------------------------------------------
+ * Fabric register access
+ *----------------------------------------------------------------------------*/
+int bladerf_fabric_register_read(struct bladerf *dev,
+                                    uint8_t addr, uint32_t *value)
+{
+    int status;
+    MUTEX_LOCK(&dev->ctrl_lock);
+
+    status = dev->fn->fabric_register_read(dev, addr, value);
+
+    MUTEX_UNLOCK(&dev->ctrl_lock);
+    return status;
+}
+
+int bladerf_fabric_register_write(struct bladerf *dev,
+                                    uint8_t addr, uint32_t value)
+{
+    int status;
+    MUTEX_LOCK(&dev->ctrl_lock);
+
+    status = dev->fn->fabric_register_write(dev, addr, value);
+
+    MUTEX_UNLOCK(&dev->ctrl_lock);
+    return status;
+}
+
+/*------------------------------------------------------------------------------
  * XB SPI register write
  *----------------------------------------------------------------------------*/
 

--- a/host/libraries/libbladeRF/src/capabilities.c
+++ b/host/libraries/libbladeRF/src/capabilities.c
@@ -91,6 +91,9 @@ void capabilities_init_post_fpga_load(struct bladerf *dev)
     if (version_greater_or_equal(&dev->fpga_version, 0, 7, 0)) {
         dev->capabilities |= BLADERF_CAP_AGC_DC_LUT;
     }
+    if (version_greater_or_equal(&dev->fpga_version, 0, 8, 0)) {
+        dev->capabilities |= BLADERF_CAP_FABRIC_REGISTER_ACCESS;
+    }
 
     log_verbose("Capability mask after FPGA load: 0x%016"PRIx64"\n",
                  dev->capabilities);

--- a/host/libraries/libbladeRF/src/capabilities.h
+++ b/host/libraries/libbladeRF/src/capabilities.h
@@ -106,6 +106,12 @@
 #define BLADERF_CAP_AGC_DC_LUT          (1 << 10)
 
 /**
+ * FPGA v0.8.0 introduces the ability to access registers in the FPGA fabric
+ * from libbladeRF
+ */
+#define BLADERF_CAP_FABRIC_REGISTER_ACCESS (1 << 10)
+
+/**
  * Firmware 1.7.1 introduced firmware-based loopback
  */
 #define BLADERF_CAP_FW_LOOPBACK         (((uint64_t) 1) << 32)

--- a/host/libraries/libbladeRF/src/version_compat.c
+++ b/host/libraries/libbladeRF/src/version_compat.c
@@ -53,6 +53,7 @@ static const struct compat fw_compat_tbl[] = {
 
 static const struct compat fpga_compat_tbl[] = {
     /*    FPGA          requires >=        Firmware */
+    { VERSION(0, 8, 0),                 VERSION(1, 6, 1) },
     { VERSION(0, 7, 0),                 VERSION(1, 6, 1) },
     { VERSION(0, 6, 0),                 VERSION(1, 6, 1) },
     { VERSION(0, 5, 0),                 VERSION(1, 6, 1) },

--- a/host/utilities/bladeRF-cli/CMakeLists.txt
+++ b/host/utilities/bladeRF-cli/CMakeLists.txt
@@ -6,7 +6,7 @@ project(bladeRF-cli C)
 ################################################################################
 
 set(VERSION_INFO_MAJOR  1)
-set(VERSION_INFO_MINOR  5)
+set(VERSION_INFO_MINOR  6)
 set(VERSION_INFO_PATCH  0)
 
 if(NOT DEFINED VERSION_INFO_EXTRA)

--- a/host/utilities/bladeRF-cli/src/cmd/printset.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset.c
@@ -67,6 +67,7 @@ struct printset_entry {
 PRINTSET_DECL(bandwidth)
 PRINTSET_DECL(frequency)
 PRINTSET_DECL(agc)
+PRINTSET_DECL(fabric_register)
 PRINTSET_DECL(gpio)
 PRINTSET_DECL(loopback)
 PRINTSET_DECL(lnagain)
@@ -89,6 +90,7 @@ struct printset_entry printset_table[] = {
     PRINTSET_ENTRY(bandwidth,       PRINTALL_OPTION_APPEND_NEWLINE),
     PRINTSET_ENTRY(frequency,       PRINTALL_OPTION_APPEND_NEWLINE),
     PRINTSET_ENTRY(agc,             PRINTALL_OPTION_APPEND_NEWLINE),
+    PRINTSET_ENTRY(fabric_register, PRINTALL_OPTION_SKIP),
     PRINTSET_ENTRY(gpio,            PRINTALL_OPTION_APPEND_NEWLINE),
     PRINTSET_ENTRY(loopback,        PRINTALL_OPTION_APPEND_NEWLINE),
     PRINTSET_ENTRY(rx_mux,          PRINTALL_OPTION_APPEND_NEWLINE),
@@ -451,6 +453,82 @@ int set_agc(struct cli_state *state, int argc, char **argv)
         } else {
             printf( "   AGC: %-10s\n",
                     mode == BLADERF_GAIN_MANUAL ? "Disabled" : "Enabled" );
+        }
+    }
+    return rv;
+}
+
+int set_fabric_register(struct cli_state *state, int argc, char **argv)
+{
+    int rv = CLI_RET_OK, status;
+    uint8_t addr;
+    uint32_t val;
+    bool ok;
+
+    if ( argc != 4 ) {
+        rv = CLI_RET_NARGS;
+    }
+
+    if( argc == 2 ) {
+        printf( "Usage: set fabric_register <addr> <value>\n" );
+        printf( "\n" );
+        printf( "    addr   Register address\n" );
+        printf( "    value  Register value to write\n" );
+    }
+
+    if ( argc == 4 ) {
+        addr = str2uint(argv[2], 0, 255, &ok);
+        if (!ok) {
+            return CLI_RET_INVPARAM;
+        }
+
+        val = str2uint(argv[3], 0, UINT_MAX, &ok);
+        if (!ok) {
+            return CLI_RET_INVPARAM;
+        }
+
+        status = bladerf_fabric_register_write(state->dev, addr, val);
+        if (status < 0) {
+            state->last_lib_error = status;
+            rv = CLI_RET_LIBBLADERF;
+        } else {
+            printf("  Register %d set to value: %d\n", addr, val);
+        }
+
+    }
+
+    return rv;
+}
+
+int print_fabric_register(struct cli_state *state, int argc, char **argv)
+{
+    int rv = CLI_RET_OK, status;
+    uint8_t addr;
+    uint32_t val;
+    bool ok;
+
+    if ( argc != 3 ) {
+        rv = CLI_RET_NARGS;
+    }
+
+    if( argc == 2 ) {
+        printf( "Usage: print fabric_register <addr>\n" );
+        printf( "\n" );
+        printf( "    addr   Register address\n" );
+    }
+
+    if ( argc == 3 ) {
+        addr = str2uint(argv[2], 0, 255, &ok);
+	    if (!ok) {
+		    return CLI_RET_INVPARAM;
+	    }
+
+        status = bladerf_fabric_register_read(state->dev, addr, &val);
+        if (status < 0) {
+            state->last_lib_error = status;
+            rv = CLI_RET_LIBBLADERF;
+        } else {
+            printf("  Register %d value: %d\n", addr, val);
         }
     }
 


### PR DESCRIPTION
This component was designed as a tool to have an easy interface to custom FPGA applications . It can be used to set and read various control and status registers in custom FPGA applications.

Application examples may include (but are not limited to):
- set signal flow switches in the FPGA DSP
- switch between different modulations in a multi-demodulator-implementation
- read RSSI information, frequency offsets or lock detect outputs of receiver components

The main advantage this component offers is that there is not anymore a need to multiplex such information  into the FX3 stream interface, which allows using that one exclusively for receive/transmit data. I thought it would be nice to have it in the public repo to save other people developing for the FPGA the hassle of this task. 

The register probe currently exposes eight 32bit registers to the FPGA logic that can be written and read by the NIOS2 processor. The necessary API for libbladeRF and inclusion into bladeRF-cli is included. The minor version numbers of FPGA, libbladeRF and bladeRF-cli were incremented, as this can be considered  new functionality.

An instance variable for the NIOS2 component controls, whether nothing, only inputs, outputs or both are exposed as NIOS-system interfaces. For designs not using it, these are set to "don't expose anything" per default, and that can be changed in build_bladerf.sh, where new revisions have to be placed anyways.

libbladeRF and bladeRF-cli compile without additional warnings, the FPGA images build just like before - no changes to bladeRF-hosted - and with working functionality on a design using this component. Resource impact is extremely low (and probably not even there in the bladerf-hosted platform, as all registers are optimized away).

I would be interested in review of the following:
- Is a bladeRF-platform example needed to demonstrate other people how to use it? As an alternative, I offer adding a wiki entry (on the 'FPGA development' page) documenting how to use the functionality. I refrained from creating a platform that replicated all functionality from hosted (to avoid code duplication) but also did not want an example that contained only the register probe functionality (as it is basically useless) and probably not very educational. 
- The number of registers exposed (eight, 32 bits each) was somewhat arbitrary, the following were my considerations: One 32 bit register could be used for a pair of I/Q samples without hassle. One register could of course be shared for multiple status flags or signal switches. Considering typical receiver and transmitter applications, 256 bit might be enough for most monitoring and control applications. I would love a mechanism that allows a variable number of registers, but Qsys can not handle arrays of std_logic_vectors, therefore I considered the two variables for 'input/output expose' and a reasonable number of registers a suitable compromise. Any objections on that part?
- I added my IP to hdl/fpga/ip/thasti/ - is that okay for you?

Thanks for reviewing and maybe pulling this. I'll be happy to hear your suggestions.