### PR TITLE
Fix permissions on downloaded FPGA/firmware images in debian package

### DIFF
--- a/debian/bladerf-firmware-fx3.postinst
+++ b/debian/bladerf-firmware-fx3.postinst
@@ -26,6 +26,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 		# We're good!  Copy it to its new home.
 		echo "Download successful, copying to ${DATAFILE}"
 		mv ${NEWFILE} ${DATAFILE}
+		chmod 0444 ${DATAFILE}
 	else
 		# It failed!  Print an error and nuke the temporary file.
 		rm -f ${NEWFILE}

--- a/debian/bladerf-fpga-hostedx115.postinst
+++ b/debian/bladerf-fpga-hostedx115.postinst
@@ -26,6 +26,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 		# We're good!  Copy it to its new home.
 		echo "Download successful, copying to ${DATAFILE}"
 		mv ${NEWFILE} ${DATAFILE}
+		chmod 0444 ${DATAFILE}
 	else
 		# It failed!  Print an error and nuke the temporary file.
 		rm -f ${NEWFILE}

--- a/debian/bladerf-fpga-hostedx40.postinst
+++ b/debian/bladerf-fpga-hostedx40.postinst
@@ -26,6 +26,7 @@ if [ ! -s ${DATAFILE} ] || ! checkfile ${DATAFILE}; then
 		# We're good!  Copy it to its new home.
 		echo "Download successful, copying to ${DATAFILE}"
 		mv ${NEWFILE} ${DATAFILE}
+		chmod 0444 ${DATAFILE}
 	else
 		# It failed!  Print an error and nuke the temporary file.
 		rm -f ${NEWFILE}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
 bladerf (2017.07) unstable; urgency=low
 
+  [ Robert Ghilduta ]
   * Add Automatic Gain Control
+
+  [ Rey Tucker ]
+  * debian: fix permissions on FPGA and firmware binaries after downloading
 
  -- Robert Ghilduta <robert.ghilduta@nuand.com>  Sun, 02 Jul 2017 21:14:15 -0400
 

--- a/host/libraries/libbladeRF/src/file_ops.c
+++ b/host/libraries/libbladeRF/src/file_ops.c
@@ -115,6 +115,8 @@ int file_read_buffer(const char *filename, uint8_t **buf_ret, size_t *size_ret)
 
     f = fopen(filename, "rb");
     if (!f) {
+        log_error("%s: could not open %s: %s\n", __FUNCTION__, filename,
+                  strerror(errno));
         switch (errno) {
             case ENOENT:
                 return BLADERF_ERR_NO_FILE;


### PR DESCRIPTION
The change from directly overwriting the files in /usr/share/Nuand/bladeRF to creating an intermediate temp file introduced an issue where the binaries are only readable by the root user, because mktemp creates temp files chmod 0600.

This pull request has two fixes:

1) Do a chmod 0444 on these files after moving them into place
2) When file_read_buffer fails, print out a more useful error message to call attention to this issue