### PR TITLE
nios: fix si5338_write typo (#491)

### DIFF
--- a/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/devices.c
+++ b/hdl/fpga/ip/altera/nios_system/software/bladeRF_nios/src/devices.c
@@ -334,7 +334,7 @@ void si5338_write(uint8_t addr, uint8_t data)
     si5338_complete_transfer(1);
 
     IOWR_8DIRECT(I2C, OC_I2C_DATA, addr);
-    IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_CMD_STATUS | OC_I2C_WR);
+    IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_WR);
     si5338_complete_transfer(1);
 
     IOWR_8DIRECT(I2C, OC_I2C_DATA, data);


### PR DESCRIPTION
Unnecessary bit is being set when writing address.