### PR TITLE
macOS: detect clock_gettime presence directly, instead of inferring from version (#508)

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -70,6 +70,9 @@ if(WIN32)
     include(FindCyAPI)
 endif()
 
+include(CheckLibraryExists)
+check_library_exists(c clock_gettime "time.h" HAVE_CLOCK_GETTIME)
+
 ################################################################################
 # Compiler configuration
 ################################################################################

--- a/host/common/include/host_config.h.in
+++ b/host/common/include/host_config.h.in
@@ -41,6 +41,8 @@
 #error "Build configured for multiple operating systems"
 #endif
 
+#cmakedefine01  HAVE_CLOCK_GETTIME
+
 /*******************************************************************************
  * Endianness conversions
  *

--- a/host/common/include/osx/clock_gettime.h
+++ b/host/common/include/osx/clock_gettime.h
@@ -25,6 +25,7 @@
 #ifndef OSX_CLOCK_GETTIME_H_
 #define OSX_CLOCK_GETTIME_H_
 
+#include "host_config.h"
 #include <time.h>
 
 #if HAVE_CLOCK_GETTIME == 0

--- a/host/common/include/osx/clock_gettime.h
+++ b/host/common/include/osx/clock_gettime.h
@@ -2,7 +2,7 @@
  * This file is part of the bladeRF project:
  *   http://www.github.com/nuand/bladeRF
  *
- * Copyright (c) 2013 Nuand LLC
+ * Copyright (c) 2013-2017 Nuand LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,17 +27,15 @@
 
 #include <time.h>
 
-#include "AvailabilityMacros.h"
-
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
+#if HAVE_CLOCK_GETTIME == 0
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // __cplusplus
 
 #ifndef __MACH__
 #   error "This file is intended for use with OSX systems only."
-#endif
+#endif // __MACH__
 
 typedef int clockid_t;
 #define CLOCK_REALTIME 0
@@ -46,8 +44,8 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 
 #ifdef __cplusplus
 } /* extern "C" */
-#endif
+#endif // __cplusplus
 
-#endif
+#endif // !HAVE_CLOCK_GETTIME
 
-#endif
+#endif // OSX_CLOCK_GETTIME_H

--- a/host/common/src/osx/clock_gettime.c
+++ b/host/common/src/osx/clock_gettime.c
@@ -1,13 +1,9 @@
-#include "AvailabilityMacros.h"
-
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
-
 /*
  * clock_gettime() wrapper for OSX based upon jbenet's github "gist":
  *   https://gist.github.com/jbenet/1087739
  *
  * Copyright (c) 2011 Juan Batiz-Benet (https://github.com/jbenet)
- * Copyright (c) 2013 Nuand LLC
+ * Copyright (c) 2013-2017 Nuand LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +23,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
+#if HAVE_CLOCK_GETTIME == 0
+
 #include "clock_gettime.h"
 #include <errno.h>
 #include <mach/clock.h>
@@ -61,4 +60,4 @@ clock_gettime_out:
     }
 }
 
-#endif
+#endif // !HAVE_CLOCK_GETTIME

--- a/host/common/src/osx/clock_gettime.c
+++ b/host/common/src/osx/clock_gettime.c
@@ -24,8 +24,6 @@
  * THE SOFTWARE.
  */
 
-#if HAVE_CLOCK_GETTIME == 0
-
 #include "clock_gettime.h"
 #include <errno.h>
 #include <mach/clock.h>
@@ -59,5 +57,3 @@ clock_gettime_out:
         return 0;
     }
 }
-
-#endif // !HAVE_CLOCK_GETTIME

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -339,15 +339,21 @@ if(ENABLE_BACKEND_LINUX_DRIVER)
 endif()
 
 if(BLADERF_OS_OSX)
-    set(LIBBLADERF_SOURCE ${LIBBLADERF_SOURCE}
-        ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
-    )
+    if (NOT HAVE_CLOCK_GETTIME)
+        message(STATUS "Including clock_gettime.c shim for macOS")
+        set(LIBBLADERF_SOURCE ${LIBBLADERF_SOURCE}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/osx/clock_gettime.c
+        )
+    endif()
 endif()
 
 if(MSVC)
-    set(LIBBLADERF_SOURCE ${LIBBLADERF_SOURCE}
-        ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
-    )
+    if (NOT HAVE_CLOCK_GETTIME)
+        message(STATUS "Including clock_gettime.c shim for Windows")
+        set(LIBBLADERF_SOURCE ${LIBBLADERF_SOURCE}
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
+        )
+    endif()
 endif()
 
 set(SRC_TO_SHORTEN ${LIBBLADERF_SOURCE})


### PR DESCRIPTION
AvailabilityMacros.h is part of Xcode and not the underlying OS and is not a reliable indicator of what the underlying OS version is.  So, building with Xcode 8.x (with support for macOS 10.12, with clock_gettime) on macOS 10.11 (which does not have clock_gettime) fails.

Instead, we can use CMake's `check_library_exists` to directly test for clock_gettime in libc, and then build the shim if required.
