### PR TITLE
host/libbladeRF/cyapi: ReleaseMutex before CloseHandle

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/cyapi.c
+++ b/host/libraries/libbladeRF/src/backend/usb/cyapi.c
@@ -249,6 +249,7 @@ static int open_via_info(void **driver, backend_probe_target probe_target,
 
     if (status != 0) {
         delete dev;
+        ReleaseMutex(cyapi_data->mutex);
         CloseHandle(cyapi_data->mutex);
     }
 
@@ -281,6 +282,7 @@ static void cyapi_close(void *driver)
     struct bladerf_cyapi *cyapi_data = get_backend_data(driver);
     cyapi_data->dev->Close();
     delete cyapi_data->dev;
+    ReleaseMutex(cyapi_data->mutex);
     CloseHandle(cyapi_data->mutex);
     free(driver);
 


### PR DESCRIPTION
When working on mutexes for the libusb backend, I noticed that I needed
to ReleaseMutex() when closing the device, or else that device would not
be usable again until all of the mutexes were released.

I have not tested this with CyAPI as yet, but I believe the same problem
will occur, and I also believe this may fix it.

Fixes #520