### PR TITLE
host/cmake: fix regression from #511

### DIFF
--- a/host/cmake/modules/Version.cmake
+++ b/host/cmake/modules/Version.cmake
@@ -101,11 +101,11 @@ if(VERSION_INFO_OVERRIDE)
     set(VERSION_INFO "${VERSION_INFO_BASE}-${VERSION_INFO_OVERRIDE}")
 
 # Intra-release builds
-elseif(${VERSION_INFO_EXTRA} STREQUAL "git")
+elseif("${VERSION_INFO_EXTRA}" STREQUAL "git")
     set(VERSION_INFO "${VERSION_INFO_BASE}-git${GIT_INFO}")
 
 # Versioned releases
-elseif(${VERSION_INFO_EXTRA} STREQUAL "")
+elseif("${VERSION_INFO_EXTRA}" STREQUAL "")
     set(VERSION_INFO "${VERSION_INFO_BASE}")
 
 # Invalid 


### PR DESCRIPTION
We explicitly set VERSION_INFO_EXTRA to "" for release builds, which
causes (${VERSION_INFO_EXTRA} STREQUAL "") to evaluate to
( STREQUAL ""), a syntax error.

Quoting ${VERSION_INFO_EXTRA} should not cause the ambigious condition
foretold in CMP0054, so doing that.