### PR TITLE
fx3: fix cmake invocation in README.md

### DIFF
--- a/fx3_firmware/README.md
+++ b/fx3_firmware/README.md
@@ -38,7 +38,7 @@ Adjust the paths as necessary on your system, depending where you installed the 
 ```
 $ mkdir build
 $ cd build
-$ cmake -DFX3_INSTALL_PATH=/opt/cypress/fx3_sdk -DCMAKE_TOOLCHAIN_FILE=../cmake/fx3-toolchain ../
+$ cmake -DFX3_INSTALL_PATH=/opt/cypress/fx3_sdk -DCMAKE_TOOLCHAIN_FILE=../cmake/fx3-toolchain.cmake ../
 $ make
 ```
 


### PR DESCRIPTION
The cmake invocation was incorrect and pointed at a non-existant
filename.

Initial report: https://nuand.com/forums/viewtopic.php?f=4&t=3977