### PR TITLE
host: trim most, but not all, of the pathname from log messages

### DIFF
--- a/host/cmake/modules/ShortFileMacro.cmake
+++ b/host/cmake/modules/ShortFileMacro.cmake
@@ -1,0 +1,11 @@
+# Define a SHORT_FILE_ macro on a per-file basis to yield
+# something akin to __FILE__, but with only the file name
+#
+# Parameters:
+#
+# SRC_TO_SHORTEN -   List of source files to create short names for
+foreach(FILE ${SRC_TO_SHORTEN})
+    get_filename_component(FILE_NAME ${FILE} NAME)
+    set_source_files_properties(${FILE} PROPERTIES
+                                COMPILE_FLAGS -DSHORT_FILE_=\"${FILE_NAME}\")
+endforeach()

--- a/host/cmake/modules/ShortFileMacro.cmake
+++ b/host/cmake/modules/ShortFileMacro.cmake
@@ -24,6 +24,13 @@ get_filename_component(BASEPATH "${PROJECT_ROOT_DIR}" REALPATH)
 foreach(FILE ${SRC_TO_SHORTEN})
     get_filename_component(FULL_FILE_NAME ${FILE} REALPATH)
     string(REPLACE "${BASEPATH}/" "" FILE_NAME ${FULL_FILE_NAME})
+
+    # We can trim off a few remaining filename chunks without ambiguity
+    string(REGEX REPLACE "^host/libraries/" "" FILE_NAME ${FILE_NAME})
+    string(REGEX REPLACE "^host/utilities/" "" FILE_NAME ${FILE_NAME})
+
     set_source_files_properties(${FILE} PROPERTIES
                                 COMPILE_FLAGS -DSHORT_FILE_=\"${FILE_NAME}\")
+
+    #message(STATUS "Shortening: ${FULL_FILE_NAME} -> ${FILE_NAME}")
 endforeach()

--- a/host/cmake/modules/ShortFileMacro.cmake
+++ b/host/cmake/modules/ShortFileMacro.cmake
@@ -1,11 +1,29 @@
 # Define a SHORT_FILE_ macro on a per-file basis to yield
-# something akin to __FILE__, but with only the file name
+# something akin to __FILE__, but with only the relative path
+#
+# We assume this file is located in a directory three levels deep from the
+# root of the project, e.g. host/cmake/modules/.  If not, change the number
+# of "/.." appearing in the PROJECT_ROOT_DIR setting below, or set it in
+# CMakeLists.txt.
+#
+# Note: while CMAKE_HOME_DIRECTORY is a reasonable choice, it will vary
+# depending on whether you build from the root, or from host/.
 #
 # Parameters:
 #
+# PROJECT_ROOT_DIR - Root directory of the full project (optional)
 # SRC_TO_SHORTEN -   List of source files to create short names for
+
+if(NOT PROJECT_ROOT_DIR)
+    set(PROJECT_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
+endif()
+
+# Resolve PROJECT_ROOT_DIR into an absolute path
+get_filename_component(BASEPATH "${PROJECT_ROOT_DIR}" REALPATH)
+
 foreach(FILE ${SRC_TO_SHORTEN})
-    get_filename_component(FILE_NAME ${FILE} NAME)
+    get_filename_component(FULL_FILE_NAME ${FILE} REALPATH)
+    string(REPLACE "${BASEPATH}/" "" FILE_NAME ${FULL_FILE_NAME})
     set_source_files_properties(${FILE} PROPERTIES
                                 COMPILE_FLAGS -DSHORT_FILE_=\"${FILE_NAME}\")
 endforeach()

--- a/host/common/include/log.h
+++ b/host/common/include/log.h
@@ -39,9 +39,7 @@ extern "C" {
 #ifdef SHORT_FILE_
 #   define  THIS_FILE  SHORT_FILE_
 #else
-#if 0
 #   warning "SHORT_FILE_ was not defined. Using __FILE__ instead."
-#endif
 #   define  THIS_FILE   __FILE__
 #endif
 

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -361,6 +361,8 @@ if(MSVC)
     endif()
 endif()
 
+set(SRC_TO_SHORTEN ${LIBBLADERF_SOURCE})
+include(ShortFileMacro)
 add_library(libbladerf_shared SHARED ${LIBBLADERF_SOURCE})
 
 ################################################################################

--- a/host/libraries/libbladeRF_test/test_fw_check/CMakeLists.txt
+++ b/host/libraries/libbladeRF_test/test_fw_check/CMakeLists.txt
@@ -19,6 +19,9 @@ set(SRC
     ${BLADERF_HOST_COMMON_SOURCE_DIR}/log.c
 )
 
+set(SRC_TO_SHORTEN ${SRC})
+include(ShortFileMacro)
+
 add_definitions(-DLOGGING_ENABLED)
 add_definitions(-DTEST_FX3_FW_VALIDATION)
 add_definitions(-DLIBBLADERF_SEARCH_PREFIX="${CMAKE_INSTALL_PREFIX}")

--- a/host/libraries/libbladeRF_test/test_sync/CMakeLists.txt
+++ b/host/libraries/libbladeRF_test/test_sync/CMakeLists.txt
@@ -36,6 +36,9 @@ if(MSVC)
     )
 endif()
 
+set(SRC_TO_SHORTEN ${SRC})
+include(ShortFileMacro)
+
 include_directories(${TEST_SYNC_INCLUDES})
 add_executable(libbladeRF_test_sync ${SRC})
 target_link_libraries(libbladeRF_test_sync ${TEST_SYNC_LIBS})

--- a/host/utilities/bladeRF-cli/CMakeLists.txt
+++ b/host/utilities/bladeRF-cli/CMakeLists.txt
@@ -188,6 +188,8 @@ if(APPLE)
     )
 endif()
 
+set(SRC_TO_SHORTEN ${BLADERF_CLI_SOURCE})
+include(ShortFileMacro)
 add_executable(bladeRF-cli ${BLADERF_CLI_SOURCE})
 
 ################################################################################


### PR DESCRIPTION
Commit dccc4ed removed ambiguity in filenames displayed in log_*() output, but by displaying the full pathname, it made them very long (and also variable from build-to-build).

This PR removes the root of the filenames in question, so they are relative to the base of the git checkout.  Additionally, host/libraries/ and host/utilities/ are pruned from the pathnames.

Tested OK on Linux and Windows builds.