### PR TITLE
Fix wrong usage of str2bool

### DIFF
--- a/host/libraries/libbladeRF/src/config.c
+++ b/host/libraries/libbladeRF/src/config.c
@@ -194,12 +194,12 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
 
         status = bladerf_set_bandwidth(dev, BLADERF_MODULE_TX, bw, NULL);
     } else if (!strcasecmp(opt.key, "agc")) {
-        gain_mode = str2bool(opt.value, &ok) ? BLADERF_GAIN_AUTOMATIC
-                                            : BLADERF_GAIN_MANUAL;
+        ok = str2bool(opt.value, &val);
         printf("%s %d \n", opt.value, ok);
-        if (!ok)
+        if (ok != 0)
             return BLADERF_ERR_INVAL;
 
+        gain_mode = (val & 1) ? BLADERF_GAIN_AUTOMATIC : BLADERF_GAIN_MANUAL;
         status = bladerf_set_gain_mode(dev, BLADERF_MODULE_RX, gain_mode);
     } else if (!strcasecmp(opt.key, "gpio")) {
         val = str2uint(opt.key, 0, -1, &ok);


### PR DESCRIPTION
This leads to AGC being disabled on every call of bladeRF-cli.
Please see https://github.com/Nuand/bladeRF/blob/master/host/utilities/bladeRF-cli/src/cmd/xb300.c#L117 for the proper usage.

I'm not sure if only checking LSB is the proper way to do it, as val (uint32_t) is uninitialized and str2bool sees it as bool (on my machine "off" is 2048 and "on" is 2049), but it would even work if those "else if's" are being
reordered, thus initialized by something else to a non-zero value, or you could zero it right before the str2bool call.
The printf call might not be needed anymore.

Notes:
With the latest changes in kalibrate-bladeRF (add win32 support), changing the buffer sizes of m_x_cb, m_y_cb, m_e_cb, the results of the program look even more odd. Were those changes intended? Either the outputs are correct
before and after the patch, or one BTS has the worst clock in history. I think it's the second one.
With the latest FPGA change (0.7.0 -> 0.7.1, using edge_detector instead of pulse_gen), even setting the sample rate can sometimes lead to a failure. (At least on my board, only shortly after power-on)

Have a nice weekend!

Signed-off-by: Christian Inci <chris.gh@broke-the-inter.net>