### PR TITLE
host: libbladeRF_bindings: matlab: update libbladeRF_proto.m

### DIFF
--- a/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
+++ b/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
@@ -46,8 +46,8 @@ switch arch
     case 'win64'
         libname   = 'libbladeRF_thunk_pcwin64';
         libsuffix = '.dll';
-        bool_arg  = 'uint8';
-        bool_ret  = 'uint8';
+        bool_arg  = 'bool';
+        bool_ret  = '_Bool';
         u64_type  = 'uint64';
         pathsep   = ';';
 

--- a/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
+++ b/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
@@ -39,15 +39,11 @@ switch arch
         libname   = 'libbladeRF_thunk_glnxa64';
         libsuffix = '.so';
         pathsep   = ':';
-        bool_arg  = 'bool';
-        bool_ret  = '_Bool';
         u64_type  = 'ulong';
 
     case 'win64'
         libname   = 'libbladeRF_thunk_pcwin64';
         libsuffix = '.dll';
-        bool_arg  = 'bool';
-        bool_ret  = '_Bool';
         u64_type  = 'uint64';
         pathsep   = ';';
 
@@ -96,10 +92,10 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get
 fcns.thunkname{fcnNum}='int32cstringvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_devinfo_from_str'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'cstring', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
 
 % _Bool bladerf_devinfo_matches ( const struct bladerf_devinfo * a , const struct bladerf_devinfo * b );
-fcns.thunkname{fcnNum}=[bool_ret 'voidPtrvoidPtrThunk'];fcns.name{fcnNum}='bladerf_devinfo_matches'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=bool_arg; fcns.RHS{fcnNum}={'bladerf_devinfoPtr', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='_BoolvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_devinfo_matches'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='bool'; fcns.RHS{fcnNum}={'bladerf_devinfoPtr', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
 
 % _Bool bladerf_devstr_matches ( const char * dev_str , struct bladerf_devinfo * info );
-fcns.thunkname{fcnNum}=[bool_ret 'cstringvoidPtrThunk'];fcns.name{fcnNum}='bladerf_devstr_matches'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=bool_arg; fcns.RHS{fcnNum}={'cstring', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='_BoolcstringvoidPtrThunk';fcns.name{fcnNum}='bladerf_devstr_matches'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='bool'; fcns.RHS{fcnNum}={'cstring', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_open_with_devinfo ( struct bladerf ** device , struct bladerf_devinfo * devinfo );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_open_with_devinfo'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtrPtr', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
@@ -111,7 +107,7 @@ fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_ope
 fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_close'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
 
 % void bladerf_set_usb_reset_on_open ( _Bool enabled );
-fcns.thunkname{fcnNum}=['void' bool_ret 'Thunk'];fcns.name{fcnNum}='bladerf_set_usb_reset_on_open'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={bool_arg};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='void_BoolThunk';fcns.name{fcnNum}='bladerf_set_usb_reset_on_open'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bool'};fcnNum=fcnNum+1;
 
 % int bladerf_get_serial ( struct bladerf * dev , char * serial );
 fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_get_serial'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'cstring'};fcnNum=fcnNum+1;
@@ -135,7 +131,7 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_fpg
 fcns.thunkname{fcnNum}='bladerf_dev_speedvoidPtrThunk';fcns.name{fcnNum}='bladerf_device_speed'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='bladerf_dev_speed'; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_enable_module ( struct bladerf * dev , bladerf_module m , _Bool enable );
-fcns.thunkname{fcnNum}=['int32voidPtrbladerf_module' bool_ret 'Thunk'];fcns.name{fcnNum}='bladerf_enable_module'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', bool_arg};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_module_BoolThunk';fcns.name{fcnNum}='bladerf_enable_module'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bool'};fcnNum=fcnNum+1;
 
 % int bladerf_set_txvga2 ( struct bladerf * dev , int gain );
 fcns.thunkname{fcnNum}='int32voidPtrint32Thunk';fcns.name{fcnNum}='bladerf_set_txvga2'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'int32'};fcnNum=fcnNum+1;
@@ -170,14 +166,32 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get
 % int bladerf_set_gain ( struct bladerf * dev , bladerf_module mod , int gain );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleint32Thunk';fcns.name{fcnNum}='bladerf_set_gain'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'int32'};fcnNum=fcnNum+1;
 
+% int bladerf_set_gain_mode ( struct bladerf * dev , bladerf_module mod , bladerf_gain_mode mode );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_gain_modeThunk';fcns.name{fcnNum}='bladerf_set_gain_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_gain_mode'};fcnNum=fcnNum+1;
+
+% int bladerf_get_gain_mode ( struct bladerf * dev , bladerf_module mod , bladerf_gain_mode * mode );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_gain_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_gain_modePtr'};fcnNum=fcnNum+1;
+
 % int bladerf_set_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int rate , unsigned int * actual );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
 
 % int bladerf_set_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
 
+% int bladerf_get_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int * rate );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_get_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
+
 % int bladerf_set_sampling ( struct bladerf * dev , bladerf_sampling sampling );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_samplingThunk';fcns.name{fcnNum}='bladerf_set_sampling'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_sampling'};fcnNum=fcnNum+1;
+
+% int bladerf_set_rx_mux ( struct bladerf * dev , bladerf_rx_mux mux );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_rx_muxThunk';fcns.name{fcnNum}='bladerf_set_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_mux'};fcnNum=fcnNum+1;
+
+% int bladerf_get_rx_mux ( struct bladerf * dev , bladerf_rx_mux * mode );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_muxPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_get_sampling ( struct bladerf * dev , bladerf_sampling * sampling );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sampling'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_samplingPtr'};fcnNum=fcnNum+1;
@@ -201,7 +215,7 @@ fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}='bladerf_set_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32'};fcnNum=fcnNum+1;
 
 % int bladerf_schedule_retune ( struct bladerf * dev , bladerf_module module , uint64_t timestamp , unsigned int frequency , struct bladerf_quick_tune * quick_tune );
-fcns.thunkname{fcnNum}=['int32voidPtrbladerf_module' u64_type 'uint32voidPtrThunk'];fcns.name{fcnNum}='bladerf_schedule_retune'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', u64_type, 'uint32', 'bladerf_quick_tunePtr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint64uint32voidPtrThunk';fcns.name{fcnNum}='bladerf_schedule_retune'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint64', 'uint32', 'bladerf_quick_tunePtr'};fcnNum=fcnNum+1;
 
 % int bladerf_cancel_scheduled_retunes ( struct bladerf * dev , bladerf_module module );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleThunk';fcns.name{fcnNum}='bladerf_cancel_scheduled_retunes'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module'};fcnNum=fcnNum+1;
@@ -221,35 +235,47 @@ fcns.thunkname{fcnNum}='int32voidPtrbladerf_loopbackThunk';fcns.name{fcnNum}='bl
 % int bladerf_get_loopback ( struct bladerf * dev , bladerf_loopback * l );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_loopback'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_loopbackPtr'};fcnNum=fcnNum+1;
 
+% int bladerf_set_smb_mode ( struct bladerf * dev , bladerf_smb_mode mode );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_smb_modeThunk';fcns.name{fcnNum}='bladerf_set_smb_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_smb_mode'};fcnNum=fcnNum+1;
+
+% int bladerf_get_smb_mode ( struct bladerf * dev , bladerf_smb_mode * mode );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_smb_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_smb_modePtr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
+
 % int bladerf_set_smb_frequency ( struct bladerf * dev , uint32_t rate , uint32_t * actual );
 fcns.thunkname{fcnNum}='int32voidPtruint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
 
 % int bladerf_get_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
 
-% int bladerf_set_rx_mux ( struct bladerf * dev , bladerf_rx_mux mux );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_rx_muxThunk';fcns.name{fcnNum}='bladerf_set_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_mux'};fcnNum=fcnNum+1;
-
-% int bladerf_get_rx_mux ( struct bladerf * dev , bladerf_rx_mux * mux );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_muxPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int * rate );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
-
 % int bladerf_get_smb_frequency ( struct bladerf * dev , unsigned int * rate );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_trigger_init ( struct bladerf * dev , bladerf_module module , bladerf_trigger_signal signal , struct bladerf_trigger * trigger );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_trigger_signalvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_init'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_trigger_signal', 'bladerf_triggerPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_trigger_arm ( struct bladerf * dev , const struct bladerf_trigger * trigger , _Bool arm , uint64_t resv1 , uint64_t resv2 );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtr_Booluint64uint64Thunk';fcns.name{fcnNum}='bladerf_trigger_arm'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr', 'bool', 'uint64', 'uint64'};fcnNum=fcnNum+1;
+
+% int bladerf_trigger_fire ( struct bladerf * dev , const struct bladerf_trigger * trigger );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_fire'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_trigger_state ( struct bladerf * dev , const struct bladerf_trigger * trigger , _Bool * is_armed , _Bool * has_fired , _Bool * fire_requested , uint64_t * resv1 , uint64_t * resv2 );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrvoidPtrvoidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_state'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr', 'boolPtr', 'boolPtr', 'boolPtr', 'uint64Ptr', 'uint64Ptr'};fcnNum=fcnNum+1;
 
 % int bladerf_set_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t value );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionint16Thunk';fcns.name{fcnNum}='bladerf_set_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16'};fcnNum=fcnNum+1;
 
 % int bladerf_get_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t * value );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_vctcxo_tamer_mode ( struct bladerf * dev , bladerf_vctcxo_tamer_mode mode );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_vctcxo_tamer_modeThunk';fcns.name{fcnNum}='bladerf_set_vctcxo_tamer_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_vctcxo_tamer_mode'};fcnNum=fcnNum+1;
+
+% int bladerf_get_vctcxo_tamer_mode ( struct bladerf * dev , bladerf_vctcxo_tamer_mode * mode );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_vctcxo_tamer_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_vctcxo_tamer_modePtr'};fcnNum=fcnNum+1;
 
 % int bladerf_dac_write ( struct bladerf * dev , uint16_t val );
 fcns.thunkname{fcnNum}='int32voidPtruint16Thunk';fcns.name{fcnNum}='bladerf_dac_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16'};fcnNum=fcnNum+1;
@@ -274,6 +300,21 @@ fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_xb200_pathThunk';fcns.
 
 % int bladerf_xb200_get_path ( struct bladerf * dev , bladerf_module module , bladerf_xb200_path * path );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_xb200_get_path'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_xb200_pathPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_xb300_set_trx ( struct bladerf * dev , bladerf_xb300_trx trx );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_xb300_trxThunk';fcns.name{fcnNum}='bladerf_xb300_set_trx'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_xb300_trx'};fcnNum=fcnNum+1;
+
+% int bladerf_xb300_get_trx ( struct bladerf * dev , bladerf_xb300_trx * trx );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_xb300_get_trx'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_xb300_trxPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_xb300_set_amplifier_enable ( struct bladerf * dev , bladerf_xb300_amplifier amp , _Bool enable );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_xb300_amplifier_BoolThunk';fcns.name{fcnNum}='bladerf_xb300_set_amplifier_enable'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_xb300_amplifier', 'bool'};fcnNum=fcnNum+1;
+
+% int bladerf_xb300_get_amplifier_enable ( struct bladerf * dev , bladerf_xb300_amplifier amp , _Bool * enable );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_xb300_amplifiervoidPtrThunk';fcns.name{fcnNum}='bladerf_xb300_get_amplifier_enable'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_xb300_amplifier', 'boolPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_xb300_get_output_power ( struct bladerf * dev , float * val );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_xb300_get_output_power'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'singlePtr'};fcnNum=fcnNum+1;
 
 % int bladerf_expansion_gpio_read ( struct bladerf * dev , uint32_t * val );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_expansion_gpio_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
@@ -302,8 +343,26 @@ fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_version'; f
 % void bladerf_log_set_verbosity ( bladerf_log_level level );
 fcns.thunkname{fcnNum}='voidbladerf_log_levelThunk';fcns.name{fcnNum}='bladerf_log_set_verbosity'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_log_level'};fcnNum=fcnNum+1;
 
+% int bladerf_get_fw_log ( struct bladerf * dev , const char * filename );
+fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_get_fw_log'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'cstring'};fcnNum=fcnNum+1;
+
 % int bladerf_get_timestamp ( struct bladerf * dev , bladerf_module mod , uint64_t * value );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', [u64_type 'Ptr']};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint64Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_init_stream ( struct bladerf_stream ** stream , struct bladerf * dev , bladerf_stream_cb callback , void *** buffers , size_t num_buffers , bladerf_format format , size_t samples_per_buffer , size_t num_transfers , void * user_data );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrvoidPtruint64bladerf_formatuint64uint64voidPtrThunk';fcns.name{fcnNum}='bladerf_init_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtrPtr', 'bladerfPtr', 'FcnPtr', 'voidPtrPtrPtr', 'uint64', 'bladerf_format', 'uint64', 'uint64', 'voidPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_stream ( struct bladerf_stream * stream , bladerf_module module );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleThunk';fcns.name{fcnNum}='bladerf_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'bladerf_module'};fcnNum=fcnNum+1;
+
+% int bladerf_submit_stream_buffer ( struct bladerf_stream * stream , void * buffer , unsigned int timeout_ms );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32Thunk';fcns.name{fcnNum}='bladerf_submit_stream_buffer'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'voidPtr', 'uint32'};fcnNum=fcnNum+1;
+
+% int bladerf_submit_stream_buffer_nb ( struct bladerf_stream * stream , void * buffer );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_submit_stream_buffer_nb'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'voidPtr'};fcnNum=fcnNum+1;
+
+% void bladerf_deinit_stream ( struct bladerf_stream * stream );
+fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_deinit_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_streamPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_set_stream_timeout ( struct bladerf * dev , bladerf_module module , unsigned int timeout );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}='bladerf_set_stream_timeout'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32'};fcnNum=fcnNum+1;
@@ -389,6 +448,12 @@ fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_xb_s
 % int bladerf_calibrate_dc ( struct bladerf * dev , bladerf_cal_module module );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_cal_moduleThunk';fcns.name{fcnNum}='bladerf_calibrate_dc'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_cal_module'};fcnNum=fcnNum+1;
 
+% int bladerf_read_trigger ( struct bladerf * dev , bladerf_module module , bladerf_trigger_signal signal , uint8_t * val );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_trigger_signalvoidPtrThunk';fcns.name{fcnNum}='bladerf_read_trigger'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_trigger_signal', 'uint8Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_write_trigger ( struct bladerf * dev , bladerf_module module , bladerf_trigger_signal signal , uint8_t val );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_trigger_signaluint8Thunk';fcns.name{fcnNum}='bladerf_write_trigger'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_trigger_signal', 'uint8'};fcnNum=fcnNum+1;
+
 % int bladerf_erase_flash ( struct bladerf * dev , uint32_t erase_block , uint32_t count );
 fcns.thunkname{fcnNum}='int32voidPtruint32uint32Thunk';fcns.name{fcnNum}='bladerf_erase_flash'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32'};fcnNum=fcnNum+1;
 
@@ -429,11 +494,18 @@ structs.bladerf_quick_tune.members=struct('freqsel', 'uint8', ...
                                           'nfrac',   'uint32', ...
                                           'flags', 'uint8');
 
+structs.bladerf_trigger.members=struct('module',    'bladerf_module', ...
+                                       'role',      'bladerf_trigger_role', ...
+                                       'signal',    'bladerf_trigger_signal', ...
+                                       'options',   'uint64');
+
 structs.bladerf_metadata.members=struct('timestamp',     u64_type, ...
                                         'flags',        'uint32', ...
                                         'status',       'uint32', ...
                                         'actual_count', 'uint32', ...
                                         'reserved',     'uint8#32');
+
+structs.bladerf_stream.members=struct('');
 
 structs.bladerf_image.members=struct('magic',     'int8#8', ...
                                      'checksum',  'uint8#32', ...
@@ -495,6 +567,9 @@ enuminfo.bladerf_log_level=struct('BLADERF_LOG_LEVEL_VERBOSE',  0, ...
                                   'BLADERF_LOG_LEVEL_CRITICAL', 5, ...
                                   'BLADERF_LOG_LEVEL_SILENT',   6);
 
+enuminfo.bladerf_gain_mode=struct('BLADERF_GAIN_AUTOMATIC', 0, ...
+                                  'BLADERF_GAIN_MANUAL',    1);
+
 enuminfo.bladerf_format=struct('BLADERF_FORMAT_SC16_Q11',       0, ...
                                'BLADERF_FORMAT_SC16_Q11_META',  1);
 
@@ -509,6 +584,16 @@ enuminfo.bladerf_fpga_size=struct('BLADERF_FPGA_UNKNOWN',   0,  ...
                                   'BLADERF_FPGA_40KLE',     40, ...
                                   'BLADERF_FPGA_115KLE',    115);
 
+enuminfo.bladerf_xb300_trx=struct('BLADERF_XB300_TRX_INVAL',   -1, ...
+                                  'BLADERF_XB300_TRX_TX',       0, ...
+                                  'BLADERF_XB300_TRX_RX',       1, ...
+                                  'BLADERF_XB300_TRX_UNSET',    2);
+
+enuminfo.bladerf_xb300_amplifier=struct('BLADERF_XB300_AMP_INVAL', -1, ...
+                                        'BLADERF_XB300_AMP_PA',     0, ...
+                                        'BLADERF_XB300_AMP_LNA',    1, ...
+                                        'BLADERF_XB300_AMP_PA_AUX', 2);
+
 enuminfo.bladerf_rx_mux=struct('BLADERF_RX_MUX_INVALID',            -1, ...
                                'BLADERF_RX_MUX_BASEBAND_LMS',        0, ...
                                'BLADERF_RX_MUX_12BIT_COUNTER',       1, ...
@@ -519,6 +604,12 @@ enuminfo.bladerf_rx_mux=struct('BLADERF_RX_MUX_INVALID',            -1, ...
 enuminfo.bladerf_dev_speed=struct('BLADERF_DEVICE_SPEED_UNKNOWN',   0, ...
                                   'BLADERF_DEVICE_SPEED_HIGH',      1, ...
                                   'BLADERF_DEVICE_SPEED_SUPER',     2);
+
+enuminfo.bladerf_smb_mode=struct('BLADERF_SMB_MODE_INVALID',   -1, ...
+                                 'BLADERF_SMB_MODE_DISABLED',   0, ...
+                                 'BLADERF_SMB_MODE_OUTPUT',     1, ...
+                                 'BLADERF_SMB_MODE_INPUT',      2, ...
+                                 'BLADERF_SMB_MODE_UNAVAILBLE', 3);
 
 enuminfo.bladerf_tuning_mode=struct('BLADERF_TUNING_MODE_INVALID', -1, ...
                                     'BLADERF_TUNING_MODE_HOST',     0, ...
@@ -549,6 +640,16 @@ enuminfo.bladerf_backend=struct('BLADERF_BACKEND_ANY',      0, ...
 enuminfo.bladerf_module=struct('BLADERF_MODULE_RX', 0, ...
                                'BLADERF_MODULE_TX', 1);
 
+enuminfo.bladerf_vctcxo_tamer_mode=struct('BLADERF_VCTCXO_TAMER_INVALID',  -1, ...
+                                          'BLADERF_VCTCXO_TAMER_DISABLED',  0, ...
+                                          'BLADERF_VCTCXO_TAMER_1_PPS',     1, ...
+                                          'BLADERF_VCTCXO_TAMER_10_MHZ',    2);
+
+enuminfo.bladerf_trigger_role=struct('BLADERF_TRIGGER_ROLE_INVALID',   -1, ...
+                                     'BLADERF_TRIGGER_ROLE_DISABLED',   0, ...
+                                     'BLADERF_TRIGGER_ROLE_MASTER',     1, ...
+                                     'BLADERF_TRIGGER_ROLE_SLAVE',      2);
+
 enuminfo.bladerf_correction=struct('BLADERF_CORR_LMS_DCOFF_I',  0, ...
                                    'BLADERF_CORR_LMS_DCOFF_Q',  1, ...
                                    'BLADERF_CORR_FPGA_PHASE',   2, ...
@@ -556,6 +657,17 @@ enuminfo.bladerf_correction=struct('BLADERF_CORR_LMS_DCOFF_I',  0, ...
 
 enuminfo.bladerf_xb200_path=struct('BLADERF_XB200_BYPASS',  0, ...
                                    'BLADERF_XB200_MIX',     1);
+
+enuminfo.bladerf_trigger_signal=struct('BLADERF_TRIGGER_INVALID',  -1,   ...
+                                       'BLADERF_TRIGGER_J71_4',     0,   ...
+                                       'BLADERF_TRIGGER_USER_0',    128, ...
+                                       'BLADERF_TRIGGER_USER_1',    129, ...
+                                       'BLADERF_TRIGGER_USER_2',    130, ...
+                                       'BLADERF_TRIGGER_USER_3',    131, ...
+                                       'BLADERF_TRIGGER_USER_4',    132, ...
+                                       'BLADERF_TRIGGER_USER_5',    133, ...
+                                       'BLADERF_TRIGGER_USER_6',    134, ...
+                                       'BLADERF_TRIGGER_USER_7',    135);
 
 enuminfo.bladerf_lna_gain=struct('BLADERF_LNA_GAIN_UNKNOWN',    0, ...
                                  'BLADERF_LNA_GAIN_BYPASS',     1, ...

--- a/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
+++ b/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
@@ -1,5 +1,5 @@
 %
-% Copyright (c) 2015 Nuand LLC
+% Copyright (c) 2015-2018 Nuand LLC
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
@@ -86,18 +86,6 @@ fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_get_device
 % void bladerf_free_device_list ( struct bladerf_devinfo * devices );
 fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_free_device_list'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
 
-% int bladerf_open_with_devinfo ( struct bladerf ** device , struct bladerf_devinfo * devinfo );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_open_with_devinfo'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtrPtr', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_open ( struct bladerf ** device , const char * device_identifier );
-fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_open'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtrPtr', 'cstring'};fcnNum=fcnNum+1;
-
-% void bladerf_close ( struct bladerf * device );
-fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_close'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
-
-% void bladerf_set_usb_reset_on_open ( _Bool enabled );
-fcns.thunkname{fcnNum}=['void' bool_ret 'Thunk'];fcns.name{fcnNum}='bladerf_set_usb_reset_on_open'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={bool_arg};fcnNum=fcnNum+1;
-
 % void bladerf_init_devinfo ( struct bladerf_devinfo * info );
 fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_init_devinfo'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
 
@@ -113,59 +101,41 @@ fcns.thunkname{fcnNum}=[bool_ret 'voidPtrvoidPtrThunk'];fcns.name{fcnNum}='blade
 % _Bool bladerf_devstr_matches ( const char * dev_str , struct bladerf_devinfo * info );
 fcns.thunkname{fcnNum}=[bool_ret 'cstringvoidPtrThunk'];fcns.name{fcnNum}='bladerf_devstr_matches'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=bool_arg; fcns.RHS{fcnNum}={'cstring', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
 
-% const char * bladerf_backend_str ( bladerf_backend backend );
-fcns.thunkname{fcnNum}='cstringbladerf_backendThunk';fcns.name{fcnNum}='bladerf_backend_str'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='cstring'; fcns.RHS{fcnNum}={'bladerf_backend'};fcnNum=fcnNum+1;
+% int bladerf_open_with_devinfo ( struct bladerf ** device , struct bladerf_devinfo * devinfo );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_open_with_devinfo'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtrPtr', 'bladerf_devinfoPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_open ( struct bladerf ** device , const char * device_identifier );
+fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_open'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtrPtr', 'cstring'};fcnNum=fcnNum+1;
+
+% void bladerf_close ( struct bladerf * device );
+fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_close'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
+
+% void bladerf_set_usb_reset_on_open ( _Bool enabled );
+fcns.thunkname{fcnNum}=['void' bool_ret 'Thunk'];fcns.name{fcnNum}='bladerf_set_usb_reset_on_open'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={bool_arg};fcnNum=fcnNum+1;
+
+% int bladerf_get_serial ( struct bladerf * dev , char * serial );
+fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_get_serial'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'cstring'};fcnNum=fcnNum+1;
+
+% int bladerf_get_vctcxo_trim ( struct bladerf * dev , uint16_t * trim );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_vctcxo_trim'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_get_fpga_size ( struct bladerf * dev , bladerf_fpga_size * size );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_fpga_size'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_fpga_sizePtr'};fcnNum=fcnNum+1;
+
+% int bladerf_fw_version ( struct bladerf * dev , struct bladerf_version * version );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_fw_version'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_versionPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_is_fpga_configured ( struct bladerf * dev );
+fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_is_fpga_configured'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_fpga_version ( struct bladerf * dev , struct bladerf_version * version );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_fpga_version'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_versionPtr'};fcnNum=fcnNum+1;
+
+% bladerf_dev_speed bladerf_device_speed ( struct bladerf * dev );
+fcns.thunkname{fcnNum}='bladerf_dev_speedvoidPtrThunk';fcns.name{fcnNum}='bladerf_device_speed'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='bladerf_dev_speed'; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_enable_module ( struct bladerf * dev , bladerf_module m , _Bool enable );
 fcns.thunkname{fcnNum}=['int32voidPtrbladerf_module' bool_ret 'Thunk'];fcns.name{fcnNum}='bladerf_enable_module'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', bool_arg};fcnNum=fcnNum+1;
-
-% int bladerf_set_loopback ( struct bladerf * dev , bladerf_loopback l );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_loopbackThunk';fcns.name{fcnNum}='bladerf_set_loopback'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_loopback'};fcnNum=fcnNum+1;
-
-% int bladerf_get_loopback ( struct bladerf * dev , bladerf_loopback * l );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_loopback'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_loopbackPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_rx_mux ( struct bladerf * dev , bladerf_rx_mux mux );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_rx_muxThunk';fcns.name{fcnNum}='bladerf_set_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_mux'};fcnNum=fcnNum+1;
-
-% int bladerf_get_rx_mux ( struct bladerf * dev , bladerf_rx_mux * mux );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_muxPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int rate , unsigned int * actual );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_sampling ( struct bladerf * dev , bladerf_sampling sampling );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_samplingThunk';fcns.name{fcnNum}='bladerf_set_sampling'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_sampling'};fcnNum=fcnNum+1;
-
-% int bladerf_get_sampling ( struct bladerf * dev , bladerf_sampling * sampling );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sampling'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_samplingPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int * rate );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_smb_frequency ( struct bladerf * dev , uint32_t rate , uint32_t * actual );
-fcns.thunkname{fcnNum}='int32voidPtruint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_smb_frequency ( struct bladerf * dev , unsigned int * rate );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_set_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t value );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionint16Thunk';fcns.name{fcnNum}='bladerf_set_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16'};fcnNum=fcnNum+1;
-
-% int bladerf_get_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t * value );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16Ptr'};fcnNum=fcnNum+1;
 
 % int bladerf_set_txvga2 ( struct bladerf * dev , int gain );
 fcns.thunkname{fcnNum}='int32voidPtrint32Thunk';fcns.name{fcnNum}='bladerf_set_txvga2'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'int32'};fcnNum=fcnNum+1;
@@ -200,6 +170,18 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get
 % int bladerf_set_gain ( struct bladerf * dev , bladerf_module mod , int gain );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleint32Thunk';fcns.name{fcnNum}='bladerf_set_gain'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'int32'};fcnNum=fcnNum+1;
 
+% int bladerf_set_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int rate , unsigned int * actual );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_sampling ( struct bladerf * dev , bladerf_sampling sampling );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_samplingThunk';fcns.name{fcnNum}='bladerf_set_sampling'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_sampling'};fcnNum=fcnNum+1;
+
+% int bladerf_get_sampling ( struct bladerf * dev , bladerf_sampling * sampling );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sampling'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_samplingPtr'};fcnNum=fcnNum+1;
+
 % int bladerf_set_bandwidth ( struct bladerf * dev , bladerf_module module , unsigned int bandwidth , unsigned int * actual );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_bandwidth'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
 
@@ -233,6 +215,48 @@ fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum
 % int bladerf_set_tuning_mode ( struct bladerf * dev , bladerf_tuning_mode mode );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_tuning_modeThunk';fcns.name{fcnNum}='bladerf_set_tuning_mode'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_tuning_mode'};fcnNum=fcnNum+1;
 
+% int bladerf_set_loopback ( struct bladerf * dev , bladerf_loopback l );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_loopbackThunk';fcns.name{fcnNum}='bladerf_set_loopback'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_loopback'};fcnNum=fcnNum+1;
+
+% int bladerf_get_loopback ( struct bladerf * dev , bladerf_loopback * l );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_loopback'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_loopbackPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_smb_frequency ( struct bladerf * dev , uint32_t rate , uint32_t * actual );
+fcns.thunkname{fcnNum}='int32voidPtruint32voidPtrThunk';fcns.name{fcnNum}='bladerf_set_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_get_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_rx_mux ( struct bladerf * dev , bladerf_rx_mux mux );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_rx_muxThunk';fcns.name{fcnNum}='bladerf_set_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_mux'};fcnNum=fcnNum+1;
+
+% int bladerf_get_rx_mux ( struct bladerf * dev , bladerf_rx_mux * mux );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rx_mux'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rx_muxPtr'};fcnNum=fcnNum+1;
+
+% int bladerf_get_sample_rate ( struct bladerf * dev , bladerf_module module , unsigned int * rate );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_get_rational_sample_rate ( struct bladerf * dev , bladerf_module module , struct bladerf_rational_rate * rate );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_rational_sample_rate'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_rational_smb_frequency ( struct bladerf * dev , struct bladerf_rational_rate * rate , struct bladerf_rational_rate * actual );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_set_rational_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_rational_ratePtr', 'bladerf_rational_ratePtr'};fcnNum=fcnNum+1;
+
+% int bladerf_get_smb_frequency ( struct bladerf * dev , unsigned int * rate );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_smb_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_set_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t value );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionint16Thunk';fcns.name{fcnNum}='bladerf_set_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16'};fcnNum=fcnNum+1;
+
+% int bladerf_get_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t * value );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_dac_write ( struct bladerf * dev , uint16_t val );
+fcns.thunkname{fcnNum}='int32voidPtruint16Thunk';fcns.name{fcnNum}='bladerf_dac_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16'};fcnNum=fcnNum+1;
+
+% int bladerf_dac_read ( struct bladerf * dev , uint16_t * val );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_dac_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16Ptr'};fcnNum=fcnNum+1;
+
 % int bladerf_expansion_attach ( struct bladerf * dev , bladerf_xb xb );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_xbThunk';fcns.name{fcnNum}='bladerf_expansion_attach'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_xb'};fcnNum=fcnNum+1;
 
@@ -251,6 +275,36 @@ fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_xb200_pathThunk';fcns.
 % int bladerf_xb200_get_path ( struct bladerf * dev , bladerf_module module , bladerf_xb200_path * path );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_xb200_get_path'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_xb200_pathPtr'};fcnNum=fcnNum+1;
 
+% int bladerf_expansion_gpio_read ( struct bladerf * dev , uint32_t * val );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_expansion_gpio_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_expansion_gpio_write ( struct bladerf * dev , uint32_t val );
+fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32'};fcnNum=fcnNum+1;
+
+% int bladerf_expansion_gpio_masked_write ( struct bladerf * dev , uint32_t mask , uint32_t value );
+fcns.thunkname{fcnNum}='int32voidPtruint32uint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_masked_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32'};fcnNum=fcnNum+1;
+
+% int bladerf_expansion_gpio_dir_read ( struct bladerf * dev , uint32_t * outputs );
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_expansion_gpio_dir_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
+
+% int bladerf_expansion_gpio_dir_write ( struct bladerf * dev , uint32_t outputs );
+fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_dir_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32'};fcnNum=fcnNum+1;
+
+% int bladerf_expansion_gpio_dir_masked_write ( struct bladerf * dev , uint32_t mask , uint32_t outputs );
+fcns.thunkname{fcnNum}='int32voidPtruint32uint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_dir_masked_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32'};fcnNum=fcnNum+1;
+
+% const char * bladerf_backend_str ( bladerf_backend backend );
+fcns.thunkname{fcnNum}='cstringbladerf_backendThunk';fcns.name{fcnNum}='bladerf_backend_str'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='cstring'; fcns.RHS{fcnNum}={'bladerf_backend'};fcnNum=fcnNum+1;
+
+% void bladerf_version ( struct bladerf_version * version );
+fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_version'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_versionPtr'};fcnNum=fcnNum+1;
+
+% void bladerf_log_set_verbosity ( bladerf_log_level level );
+fcns.thunkname{fcnNum}='voidbladerf_log_levelThunk';fcns.name{fcnNum}='bladerf_log_set_verbosity'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_log_level'};fcnNum=fcnNum+1;
+
+% int bladerf_get_timestamp ( struct bladerf * dev , bladerf_module mod , uint64_t * value );
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', [u64_type 'Ptr']};fcnNum=fcnNum+1;
+
 % int bladerf_set_stream_timeout ( struct bladerf * dev , bladerf_module module , unsigned int timeout );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}='bladerf_set_stream_timeout'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32'};fcnNum=fcnNum+1;
 
@@ -265,27 +319,6 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32voidPtruint32Thunk';fcns.name{f
 
 % int bladerf_sync_rx ( struct bladerf * dev , void * samples , unsigned int num_samples , struct bladerf_metadata * metadata , unsigned int timeout_ms );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_sync_rx'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'voidPtr', 'uint32', 'bladerf_metadataPtr', 'uint32'};fcnNum=fcnNum+1;
-
-% int bladerf_get_serial ( struct bladerf * dev , char * serial );
-fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_get_serial'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'cstring'};fcnNum=fcnNum+1;
-
-% int bladerf_get_vctcxo_trim ( struct bladerf * dev , uint16_t * trim );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_vctcxo_trim'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_get_fpga_size ( struct bladerf * dev , bladerf_fpga_size * size );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get_fpga_size'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_fpga_sizePtr'};fcnNum=fcnNum+1;
-
-% int bladerf_fw_version ( struct bladerf * dev , struct bladerf_version * version );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_fw_version'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_versionPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_is_fpga_configured ( struct bladerf * dev );
-fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_is_fpga_configured'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_fpga_version ( struct bladerf * dev , struct bladerf_version * version );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_fpga_version'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_versionPtr'};fcnNum=fcnNum+1;
-
-% bladerf_dev_speed bladerf_device_speed ( struct bladerf * dev );
-fcns.thunkname{fcnNum}='bladerf_dev_speedvoidPtrThunk';fcns.name{fcnNum}='bladerf_device_speed'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='bladerf_dev_speed'; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_flash_firmware ( struct bladerf * dev , const char * firmware );
 fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_flash_firmware'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'cstring'};fcnNum=fcnNum+1;
@@ -305,14 +338,11 @@ fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_device_res
 % int bladerf_jump_to_bootloader ( struct bladerf * dev );
 fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_jump_to_bootloader'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr'};fcnNum=fcnNum+1;
 
-% const char * bladerf_strerror ( int error );
-fcns.thunkname{fcnNum}='cstringint32Thunk';fcns.name{fcnNum}='bladerf_strerror'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='cstring'; fcns.RHS{fcnNum}={'int32'};fcnNum=fcnNum+1;
+% int bladerf_get_bootloader_list ( struct bladerf_devinfo ** list );
+fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_get_bootloader_list'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_devinfoPtrPtr'};fcnNum=fcnNum+1;
 
-% void bladerf_version ( struct bladerf_version * version );
-fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_version'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_versionPtr'};fcnNum=fcnNum+1;
-
-% void bladerf_log_set_verbosity ( bladerf_log_level level );
-fcns.thunkname{fcnNum}='voidbladerf_log_levelThunk';fcns.name{fcnNum}='bladerf_log_set_verbosity'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_log_level'};fcnNum=fcnNum+1;
+% int bladerf_load_fw_from_bootloader ( const char * device_identifier , bladerf_backend backend , uint8_t bus , uint8_t addr , const char * file );
+fcns.thunkname{fcnNum}='int32cstringbladerf_backenduint8uint8cstringThunk';fcns.name{fcnNum}='bladerf_load_fw_from_bootloader'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'cstring', 'bladerf_backend', 'uint8', 'uint8', 'cstring'};fcnNum=fcnNum+1;
 
 % struct bladerf_image * bladerf_alloc_image ( bladerf_image_type type , uint32_t address , uint32_t length );
 fcns.thunkname{fcnNum}='voidPtrbladerf_image_typeuint32uint32Thunk';fcns.name{fcnNum}='bladerf_alloc_image'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='bladerf_imagePtr'; fcns.RHS{fcnNum}={'bladerf_image_type', 'uint32', 'uint32'};fcnNum=fcnNum+1;
@@ -328,24 +358,6 @@ fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_ima
 
 % int bladerf_image_read ( struct bladerf_image * image , const char * file );
 fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_image_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_imagePtr', 'cstring'};fcnNum=fcnNum+1;
-
-% int bladerf_expansion_gpio_read ( struct bladerf * dev , uint32_t * val );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_expansion_gpio_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_expansion_gpio_write ( struct bladerf * dev , uint32_t val );
-fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32'};fcnNum=fcnNum+1;
-
-% int bladerf_expansion_gpio_masked_write ( struct bladerf * dev , uint32_t mask , uint32_t value );
-fcns.thunkname{fcnNum}='int32voidPtruint32uint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_masked_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32'};fcnNum=fcnNum+1;
-
-% int bladerf_expansion_gpio_dir_read ( struct bladerf * dev , uint32_t * outputs );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_expansion_gpio_dir_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32Ptr'};fcnNum=fcnNum+1;
-
-% int bladerf_expansion_gpio_dir_write ( struct bladerf * dev , uint32_t outputs );
-fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_dir_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32'};fcnNum=fcnNum+1;
-
-% int bladerf_expansion_gpio_dir_masked_write ( struct bladerf * dev , uint32_t mask , uint32_t outputs );
-fcns.thunkname{fcnNum}='int32voidPtruint32uint32Thunk';fcns.name{fcnNum}='bladerf_expansion_gpio_dir_masked_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32', 'uint32'};fcnNum=fcnNum+1;
 
 % int bladerf_si5338_read ( struct bladerf * dev , uint8_t address , uint8_t * val );
 fcns.thunkname{fcnNum}='int32voidPtruint8voidPtrThunk';fcns.name{fcnNum}='bladerf_si5338_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint8', 'uint8Ptr'};fcnNum=fcnNum+1;
@@ -371,15 +383,6 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_con
 % int bladerf_config_gpio_write ( struct bladerf * dev , uint32_t val );
 fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_config_gpio_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32'};fcnNum=fcnNum+1;
 
-% int bladerf_get_timestamp ( struct bladerf * dev , bladerf_module mod , uint64_t * value );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', [u64_type 'Ptr']};fcnNum=fcnNum+1;
-
-% int bladerf_dac_write ( struct bladerf * dev , uint16_t val );
-fcns.thunkname{fcnNum}='int32voidPtruint16Thunk';fcns.name{fcnNum}='bladerf_dac_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16'};fcnNum=fcnNum+1;
-
-% int bladerf_dac_read ( struct bladerf * dev , uint16_t * val );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_dac_read'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint16Ptr'};fcnNum=fcnNum+1;
-
 % int bladerf_xb_spi_write ( struct bladerf * dev , uint32_t val );
 fcns.thunkname{fcnNum}='int32voidPtruint32Thunk';fcns.name{fcnNum}='bladerf_xb_spi_write'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint32'};fcnNum=fcnNum+1;
 
@@ -395,11 +398,8 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32uint32Thunk';fcns.name{fcnNum}=
 % int bladerf_write_flash ( struct bladerf * dev , const uint8_t * buf , uint32_t page , uint32_t count );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32uint32Thunk';fcns.name{fcnNum}='bladerf_write_flash'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'uint8Ptr', 'uint32', 'uint32'};fcnNum=fcnNum+1;
 
-% int bladerf_get_bootloader_list ( struct bladerf_devinfo ** list );
-fcns.thunkname{fcnNum}='int32voidPtrThunk';fcns.name{fcnNum}='bladerf_get_bootloader_list'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_devinfoPtrPtr'};fcnNum=fcnNum+1;
-
-% int bladerf_load_fw_from_bootloader ( const char * device_identifier , bladerf_backend backend , uint8_t bus , uint8_t addr , const char * file );
-fcns.thunkname{fcnNum}='int32cstringbladerf_backenduint8uint8cstringThunk';fcns.name{fcnNum}='bladerf_load_fw_from_bootloader'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'cstring', 'bladerf_backend', 'uint8', 'uint8', 'cstring'};fcnNum=fcnNum+1;
+% const char * bladerf_strerror ( int error );
+fcns.thunkname{fcnNum}='cstringint32Thunk';fcns.name{fcnNum}='bladerf_strerror'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='cstring'; fcns.RHS{fcnNum}={'int32'};fcnNum=fcnNum+1;
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -413,6 +413,11 @@ structs.bladerf_devinfo.members=struct('backend',  'bladerf_backend', ...
                                        'usb_bus',  'uint8', ...
                                        'usb_addr', 'uint8', ...
                                        'instance', 'uint32');
+
+structs.bladerf_version.members=struct('major',    'uint16', ...
+                                       'minor',    'uint16', ...
+                                       'patch',    'uint16', ...
+                                       'describe', 'cstring');
 
 structs.bladerf_rational_rate.members=struct('integer', u64_type, ...
                                              'num',     u64_type, ...
@@ -429,11 +434,6 @@ structs.bladerf_metadata.members=struct('timestamp',     u64_type, ...
                                         'status',       'uint32', ...
                                         'actual_count', 'uint32', ...
                                         'reserved',     'uint8#32');
-
-structs.bladerf_version.members=struct('major',    'uint16', ...
-                                       'minor',    'uint16', ...
-                                       'patch',    'uint16', ...
-                                       'describe', 'cstring');
 
 structs.bladerf_image.members=struct('magic',     'int8#8', ...
                                      'checksum',  'uint8#32', ...
@@ -465,37 +465,17 @@ structs.bladerf_devinfo.packing=4;
 % Enumerations
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-enuminfo.bladerf_tuning_mode=struct('BLADERF_TUNING_MODE_INVALID', -1, ...
-                                    'BLADERF_TUNING_MODE_HOST',     0, ...
-                                    'BLADERF_TUNING_MODE_FPGA',     1);
-
-enuminfo.bladerf_format=struct('BLADERF_FORMAT_SC16_Q11',       0, ...
-                               'BLADERF_FORMAT_SC16_Q11_META',  1);
-
 enuminfo.bladerf_lpf_mode=struct('BLADERF_LPF_NORMAL',      0, ...
                                  'BLADERF_LPF_BYPASSED',    1, ...
                                  'BLADERF_LPF_DISABLED',    2);
 
-enuminfo.bladerf_xb200_path=struct('BLADERF_XB200_BYPASS',  0, ...
-                                   'BLADERF_XB200_MIX',     1);
+enuminfo.bladerf_xb=struct('BLADERF_XB_NONE',   0, ...
+                           'BLADERF_XB_100',    1, ...
+                           'BLADERF_XB_200',    2);
 
-enuminfo.bladerf_correction=struct('BLADERF_CORR_LMS_DCOFF_I',  0, ...
-                                   'BLADERF_CORR_LMS_DCOFF_Q',  1, ...
-                                   'BLADERF_CORR_FPGA_PHASE',   2, ...
-                                   'BLADERF_CORR_FPGA_GAIN',    3);
-
-enuminfo.bladerf_cal_module=struct('BLADERF_DC_CAL_LPF_TUNING', 0, ...
-                                   'BLADERF_DC_CAL_TX_LPF',     1, ...
-                                   'BLADERF_DC_CAL_RX_LPF',     2, ...
-                                   'BLADERF_DC_CAL_RXVGA2',     3);
-
-enuminfo.bladerf_log_level=struct('BLADERF_LOG_LEVEL_VERBOSE',  0, ...
-                                  'BLADERF_LOG_LEVEL_DEBUG',    1, ...
-                                  'BLADERF_LOG_LEVEL_INFO',     2, ...
-                                  'BLADERF_LOG_LEVEL_WARNING',  3, ...
-                                  'BLADERF_LOG_LEVEL_ERROR',    4, ...
-                                  'BLADERF_LOG_LEVEL_CRITICAL', 5, ...
-                                  'BLADERF_LOG_LEVEL_SILENT',   6);
+enuminfo.bladerf_sampling=struct('BLADERF_SAMPLING_UNKNOWN',    0, ...
+                                 'BLADERF_SAMPLING_INTERNAL',   1, ...
+                                 'BLADERF_SAMPLING_EXTERNAL',   2);
 
 enuminfo.bladerf_loopback=struct('BLADERF_LB_FIRMWARE',         1, ...
                                  'BLADERF_LB_BB_TXLPF_RXVGA2',  2, ...
@@ -507,35 +487,16 @@ enuminfo.bladerf_loopback=struct('BLADERF_LB_FIRMWARE',         1, ...
                                  'BLADERF_LB_RF_LNA3',          8, ...
                                  'BLADERF_LB_NONE',             9);
 
-enuminfo.bladerf_lna_gain=struct('BLADERF_LNA_GAIN_UNKNOWN',    0, ...
-                                 'BLADERF_LNA_GAIN_BYPASS',     1, ...
-                                 'BLADERF_LNA_GAIN_MID',        2, ...
-                                 'BLADERF_LNA_GAIN_MAX',        3);
+enuminfo.bladerf_log_level=struct('BLADERF_LOG_LEVEL_VERBOSE',  0, ...
+                                  'BLADERF_LOG_LEVEL_DEBUG',    1, ...
+                                  'BLADERF_LOG_LEVEL_INFO',     2, ...
+                                  'BLADERF_LOG_LEVEL_WARNING',  3, ...
+                                  'BLADERF_LOG_LEVEL_ERROR',    4, ...
+                                  'BLADERF_LOG_LEVEL_CRITICAL', 5, ...
+                                  'BLADERF_LOG_LEVEL_SILENT',   6);
 
-enuminfo.bladerf_sampling=struct('BLADERF_SAMPLING_UNKNOWN',    0, ...
-                                 'BLADERF_SAMPLING_INTERNAL',   1, ...
-                                 'BLADERF_SAMPLING_EXTERNAL',   2);
-
-enuminfo.bladerf_module=struct('BLADERF_MODULE_RX', 0, ...
-                               'BLADERF_MODULE_TX', 1);
-
-enuminfo.bladerf_dev_speed=struct('BLADERF_DEVICE_SPEED_UNKNOWN',   0, ...
-                                  'BLADERF_DEVICE_SPEED_HIGH',      1, ...
-                                  'BLADERF_DEVICE_SPEED_SUPER',     2);
-
-enuminfo.bladerf_xb=struct('BLADERF_XB_NONE',   0, ...
-                           'BLADERF_XB_100',    1, ...
-                           'BLADERF_XB_200',    2);
-
-enuminfo.bladerf_backend=struct('BLADERF_BACKEND_ANY',      0, ...
-                                'BLADERF_BACKEND_LINUX',    1, ...
-                                'BLADERF_BACKEND_LIBUSB',   2, ...
-                                'BLADERF_BACKEND_CYPRESS',  3, ...
-                                'BLADERF_BACKEND_DUMMY',    100);
-
-enuminfo.bladerf_fpga_size=struct('BLADERF_FPGA_UNKNOWN',   0,  ...
-                                  'BLADERF_FPGA_40KLE',     40, ...
-                                  'BLADERF_FPGA_115KLE',    115);
+enuminfo.bladerf_format=struct('BLADERF_FORMAT_SC16_Q11',       0, ...
+                               'BLADERF_FORMAT_SC16_Q11_META',  1);
 
 enuminfo.bladerf_xb200_filter=struct('BLADERF_XB200_50M',       0, ...
                                      'BLADERF_XB200_144M',      1, ...
@@ -543,6 +504,30 @@ enuminfo.bladerf_xb200_filter=struct('BLADERF_XB200_50M',       0, ...
                                      'BLADERF_XB200_CUSTOM',    3, ...
                                      'BLADERF_XB200_AUTO_1DB',  4, ...
                                      'BLADERF_XB200_AUTO_3DB',  5);
+
+enuminfo.bladerf_fpga_size=struct('BLADERF_FPGA_UNKNOWN',   0,  ...
+                                  'BLADERF_FPGA_40KLE',     40, ...
+                                  'BLADERF_FPGA_115KLE',    115);
+
+enuminfo.bladerf_rx_mux=struct('BLADERF_RX_MUX_INVALID',            -1, ...
+                               'BLADERF_RX_MUX_BASEBAND_LMS',        0, ...
+                               'BLADERF_RX_MUX_12BIT_COUNTER',       1, ...
+                               'BLADERF_RX_MUX_32BIT_COUNTER',       2, ...
+                               'BLADERF_RX_MUX_DIGITAL_LOOPBACK',    4);
+                               % Value 3 is reserved for future use
+
+enuminfo.bladerf_dev_speed=struct('BLADERF_DEVICE_SPEED_UNKNOWN',   0, ...
+                                  'BLADERF_DEVICE_SPEED_HIGH',      1, ...
+                                  'BLADERF_DEVICE_SPEED_SUPER',     2);
+
+enuminfo.bladerf_tuning_mode=struct('BLADERF_TUNING_MODE_INVALID', -1, ...
+                                    'BLADERF_TUNING_MODE_HOST',     0, ...
+                                    'BLADERF_TUNING_MODE_FPGA',     1);
+
+enuminfo.bladerf_cal_module=struct('BLADERF_DC_CAL_LPF_TUNING', 0, ...
+                                   'BLADERF_DC_CAL_TX_LPF',     1, ...
+                                   'BLADERF_DC_CAL_RX_LPF',     2, ...
+                                   'BLADERF_DC_CAL_RXVGA2',     3);
 
 enuminfo.bladerf_image_type=struct('BLADERF_IMAGE_TYPE_INVALID',       -1, ...
                                    'BLADERF_IMAGE_TYPE_RAW',            0, ...
@@ -555,12 +540,28 @@ enuminfo.bladerf_image_type=struct('BLADERF_IMAGE_TYPE_INVALID',       -1, ...
                                    'BLADERF_IMAGE_TYPE_RX_IQ_CAL',      7, ...
                                    'BLADERF_IMAGE_TYPE_TX_IQ_CAL',      8);
 
-enuminfo.bladerf_rx_mux=struct('BLADERF_RX_MUX_INVALID',            -1, ...
-                               'BLADERF_RX_MUX_BASEBAND_LMS',        0, ...
-                               'BLADERF_RX_MUX_12BIT_COUNTER',       1, ...
-                               'BLADERF_RX_MUX_32BIT_COUNTER',       2, ...
-                               'BLADERF_RX_MUX_DIGITAL_LOOPBACK',    4);
-                               % Value 3 is reserved for future use
+enuminfo.bladerf_backend=struct('BLADERF_BACKEND_ANY',      0, ...
+                                'BLADERF_BACKEND_LINUX',    1, ...
+                                'BLADERF_BACKEND_LIBUSB',   2, ...
+                                'BLADERF_BACKEND_CYPRESS',  3, ...
+                                'BLADERF_BACKEND_DUMMY',    100);
+
+enuminfo.bladerf_module=struct('BLADERF_MODULE_RX', 0, ...
+                               'BLADERF_MODULE_TX', 1);
+
+enuminfo.bladerf_correction=struct('BLADERF_CORR_LMS_DCOFF_I',  0, ...
+                                   'BLADERF_CORR_LMS_DCOFF_Q',  1, ...
+                                   'BLADERF_CORR_FPGA_PHASE',   2, ...
+                                   'BLADERF_CORR_FPGA_GAIN',    3);
+
+enuminfo.bladerf_xb200_path=struct('BLADERF_XB200_BYPASS',  0, ...
+                                   'BLADERF_XB200_MIX',     1);
+
+enuminfo.bladerf_lna_gain=struct('BLADERF_LNA_GAIN_UNKNOWN',    0, ...
+                                 'BLADERF_LNA_GAIN_BYPASS',     1, ...
+                                 'BLADERF_LNA_GAIN_MID',        2, ...
+                                 'BLADERF_LNA_GAIN_MAX',        3);
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Output

--- a/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
+++ b/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
@@ -358,19 +358,24 @@ fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_get
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', [u64_type 'Ptr']};fcnNum=fcnNum+1;
 
 % int bladerf_init_stream ( struct bladerf_stream ** stream , struct bladerf * dev , bladerf_stream_cb callback , void *** buffers , size_t num_buffers , bladerf_format format , size_t samples_per_buffer , size_t num_transfers , void * user_data );
-fcns.thunkname{fcnNum}=['int32voidPtrvoidPtrvoidPtrvoidPtr' u64_type 'bladerf_format' u64_type u64_type 'voidPtrThunk'];fcns.name{fcnNum}='bladerf_init_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtrPtr', 'bladerfPtr', 'FcnPtr', 'voidPtrPtrPtr', u64_type, 'bladerf_format', u64_type, u64_type, 'voidPtr'};fcnNum=fcnNum+1;
+% NOTE: Matlab does not support FcnPtr or voidPtrPtrPtr (last checked: R2017b)
+%fcns.thunkname{fcnNum}=['int32voidPtrvoidPtrvoidPtrvoidPtr' u64_type 'bladerf_format' u64_type u64_type 'voidPtrThunk'];fcns.name{fcnNum}='bladerf_init_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtrPtr', 'bladerfPtr', 'FcnPtr', 'voidPtrPtrPtr', u64_type, 'bladerf_format', u64_type, u64_type, 'voidPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_stream ( struct bladerf_stream * stream , bladerf_module module );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleThunk';fcns.name{fcnNum}='bladerf_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'bladerf_module'};fcnNum=fcnNum+1;
+% NOTE: cannot bladerf_init_stream, so this function is unusable
+%fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleThunk';fcns.name{fcnNum}='bladerf_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'bladerf_module'};fcnNum=fcnNum+1;
 
 % int bladerf_submit_stream_buffer ( struct bladerf_stream * stream , void * buffer , unsigned int timeout_ms );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32Thunk';fcns.name{fcnNum}='bladerf_submit_stream_buffer'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'voidPtr', 'uint32'};fcnNum=fcnNum+1;
+% NOTE: cannot bladerf_init_stream, so this function is unusable
+%fcns.thunkname{fcnNum}='int32voidPtrvoidPtruint32Thunk';fcns.name{fcnNum}='bladerf_submit_stream_buffer'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'voidPtr', 'uint32'};fcnNum=fcnNum+1;
 
 % int bladerf_submit_stream_buffer_nb ( struct bladerf_stream * stream , void * buffer );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_submit_stream_buffer_nb'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'voidPtr'};fcnNum=fcnNum+1;
+% NOTE: cannot bladerf_init_stream, so this function is unusable
+%fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_submit_stream_buffer_nb'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'voidPtr'};fcnNum=fcnNum+1;
 
 % void bladerf_deinit_stream ( struct bladerf_stream * stream );
-fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_deinit_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_streamPtr'};fcnNum=fcnNum+1;
+% NOTE: cannot bladerf_init_stream, so this function is unusable
+%fcns.thunkname{fcnNum}='voidvoidPtrThunk';fcns.name{fcnNum}='bladerf_deinit_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}=[]; fcns.RHS{fcnNum}={'bladerf_streamPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_set_stream_timeout ( struct bladerf * dev , bladerf_module module , unsigned int timeout );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}='bladerf_set_stream_timeout'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32'};fcnNum=fcnNum+1;
@@ -500,7 +505,7 @@ structs.bladerf_quick_tune.members=struct('freqsel', 'uint8', ...
                                           'vcocap',  'uint8', ...
                                           'nint',    'uint16', ...
                                           'nfrac',   'uint32', ...
-                                          'flags', 'uint8');
+                                          'flags',   'uint8');
 
 structs.bladerf_trigger.members=struct('module',    'bladerf_module', ...
                                        'role',      'bladerf_trigger_role', ...
@@ -513,7 +518,8 @@ structs.bladerf_metadata.members=struct('timestamp',     u64_type, ...
                                         'actual_count', 'uint32', ...
                                         'reserved',     'uint8#32');
 
-structs.bladerf_stream.members=struct('');
+% NOTE: cannot bladerf_init_stream, so this struct is unusable
+%structs.bladerf_stream.members=struct('');
 
 structs.bladerf_image.members=struct('magic',     'int8#8', ...
                                      'checksum',  'uint8#32', ...

--- a/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
+++ b/host/libraries/libbladeRF_bindings/matlab/libbladeRF_proto.m
@@ -20,6 +20,10 @@
 % THE SOFTWARE.
 %
 
+% Background info:
+% https://www.mathworks.com/help/matlab/matlab_external/passing-arguments-to-shared-library-functions.html#f44412
+% https://ofekshilon.com/2016/07/15/on-matlabs-loadlibrary-proto-file-and-pcwin64-thunk/
+
 function [methodinfo,structs,enuminfo,ThunkLibName]=libbladeRF_proto
 %LIBBLADERF_PROTO Create structures to define interfaces found in libbladeRF.
 
@@ -27,30 +31,34 @@ function [methodinfo,structs,enuminfo,ThunkLibName]=libbladeRF_proto
 % Setup
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-ival={cell(1, 105)};
+ival={cell(1, 0)};
 structs=[];
 enuminfo=[];
 fcnNum=1;
-fcns=struct('name',ival,'calltype',ival,'LHS',ival,'RHS',ival,'alias',ival,'thunkname', ival);
+fcns=struct('name',         ival, ...
+            'calltype',     ival, ...
+            'LHS',          ival, ...
+            'RHS',          ival, ...
+            'alias',        ival, ...
+            'thunkname',    ival);
 
 arch = computer('arch');
 switch arch
     case 'glnxa64'
         libname   = 'libbladeRF_thunk_glnxa64';
         libsuffix = '.so';
-        pathsep   = ':';
         u64_type  = 'ulong';
 
     case 'win64'
         libname   = 'libbladeRF_thunk_pcwin64';
         libsuffix = '.dll';
         u64_type  = 'uint64';
-        pathsep   = ';';
 
     case 'imac64'
-        % Additionaly type changes for this may be required for OSX support
+        % Additional type changes for this may be required for OSX support
+        libname   = 'libbladeRF_thunk_imac64';
         libsuffix = '.dylib';
-        pathsep   = ':';
+        u64_type  = 'ulong';
 
     otherwise
         error(['Unsupported architecture: ' arch]);
@@ -215,7 +223,7 @@ fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint32Thunk';fcns.name{fcnNum}='bladerf_set_frequency'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint32'};fcnNum=fcnNum+1;
 
 % int bladerf_schedule_retune ( struct bladerf * dev , bladerf_module module , uint64_t timestamp , unsigned int frequency , struct bladerf_quick_tune * quick_tune );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleuint64uint32voidPtrThunk';fcns.name{fcnNum}='bladerf_schedule_retune'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint64', 'uint32', 'bladerf_quick_tunePtr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}=['int32voidPtrbladerf_module' u64_type 'uint32voidPtrThunk'];fcns.name{fcnNum}='bladerf_schedule_retune'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', u64_type, 'uint32', 'bladerf_quick_tunePtr'};fcnNum=fcnNum+1;
 
 % int bladerf_cancel_scheduled_retunes ( struct bladerf * dev , bladerf_module module );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleThunk';fcns.name{fcnNum}='bladerf_cancel_scheduled_retunes'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module'};fcnNum=fcnNum+1;
@@ -257,13 +265,13 @@ fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_get
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_trigger_signalvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_init'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_trigger_signal', 'bladerf_triggerPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_trigger_arm ( struct bladerf * dev , const struct bladerf_trigger * trigger , _Bool arm , uint64_t resv1 , uint64_t resv2 );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtr_Booluint64uint64Thunk';fcns.name{fcnNum}='bladerf_trigger_arm'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr', 'bool', 'uint64', 'uint64'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}=['int32voidPtrvoidPtr_Bool' u64_type u64_type 'Thunk'];fcns.name{fcnNum}='bladerf_trigger_arm'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr', 'bool', u64_type, u64_type};fcnNum=fcnNum+1;
 
 % int bladerf_trigger_fire ( struct bladerf * dev , const struct bladerf_trigger * trigger );
 fcns.thunkname{fcnNum}='int32voidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_fire'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_trigger_state ( struct bladerf * dev , const struct bladerf_trigger * trigger , _Bool * is_armed , _Bool * has_fired , _Bool * fire_requested , uint64_t * resv1 , uint64_t * resv2 );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrvoidPtrvoidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_state'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr', 'boolPtr', 'boolPtr', 'boolPtr', 'uint64Ptr', 'uint64Ptr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrvoidPtrvoidPtrvoidPtrvoidPtrThunk';fcns.name{fcnNum}='bladerf_trigger_state'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_triggerPtr', 'boolPtr', 'boolPtr', 'boolPtr', [u64_type 'Ptr'], [u64_type 'Ptr']};fcnNum=fcnNum+1;
 
 % int bladerf_set_correction ( struct bladerf * dev , bladerf_module module , bladerf_correction corr , int16_t value );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulebladerf_correctionint16Thunk';fcns.name{fcnNum}='bladerf_set_correction'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'bladerf_correction', 'int16'};fcnNum=fcnNum+1;
@@ -347,10 +355,10 @@ fcns.thunkname{fcnNum}='voidbladerf_log_levelThunk';fcns.name{fcnNum}='bladerf_l
 fcns.thunkname{fcnNum}='int32voidPtrcstringThunk';fcns.name{fcnNum}='bladerf_get_fw_log'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'cstring'};fcnNum=fcnNum+1;
 
 % int bladerf_get_timestamp ( struct bladerf * dev , bladerf_module mod , uint64_t * value );
-fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', 'uint64Ptr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}='int32voidPtrbladerf_modulevoidPtrThunk';fcns.name{fcnNum}='bladerf_get_timestamp'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerfPtr', 'bladerf_module', [u64_type 'Ptr']};fcnNum=fcnNum+1;
 
 % int bladerf_init_stream ( struct bladerf_stream ** stream , struct bladerf * dev , bladerf_stream_cb callback , void *** buffers , size_t num_buffers , bladerf_format format , size_t samples_per_buffer , size_t num_transfers , void * user_data );
-fcns.thunkname{fcnNum}='int32voidPtrvoidPtrvoidPtrvoidPtruint64bladerf_formatuint64uint64voidPtrThunk';fcns.name{fcnNum}='bladerf_init_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtrPtr', 'bladerfPtr', 'FcnPtr', 'voidPtrPtrPtr', 'uint64', 'bladerf_format', 'uint64', 'uint64', 'voidPtr'};fcnNum=fcnNum+1;
+fcns.thunkname{fcnNum}=['int32voidPtrvoidPtrvoidPtrvoidPtr' u64_type 'bladerf_format' u64_type u64_type 'voidPtrThunk'];fcns.name{fcnNum}='bladerf_init_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtrPtr', 'bladerfPtr', 'FcnPtr', 'voidPtrPtrPtr', u64_type, 'bladerf_format', u64_type, u64_type, 'voidPtr'};fcnNum=fcnNum+1;
 
 % int bladerf_stream ( struct bladerf_stream * stream , bladerf_module module );
 fcns.thunkname{fcnNum}='int32voidPtrbladerf_moduleThunk';fcns.name{fcnNum}='bladerf_stream'; fcns.calltype{fcnNum}='Thunk'; fcns.LHS{fcnNum}='int32'; fcns.RHS{fcnNum}={'bladerf_streamPtr', 'bladerf_module'};fcnNum=fcnNum+1;
@@ -497,7 +505,7 @@ structs.bladerf_quick_tune.members=struct('freqsel', 'uint8', ...
 structs.bladerf_trigger.members=struct('module',    'bladerf_module', ...
                                        'role',      'bladerf_trigger_role', ...
                                        'signal',    'bladerf_trigger_signal', ...
-                                       'options',   'uint64');
+                                       'options',   u64_type);
 
 structs.bladerf_metadata.members=struct('timestamp',     u64_type, ...
                                         'flags',        'uint32', ...


### PR DESCRIPTION
Updates the libbladeRF_proto.m file to have library calls added since it was first generated, and rearranges the order to make future edits easier.

Fixes #543 