### PR TITLE
Fix mutex handling for Windows in libusb backend.

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -547,6 +547,7 @@ static int reset_and_reopen(libusb_context *context,
         libusb_close((*dev)->handle);
 #if 1 == BLADERF_OS_WINDOWS
         ReleaseMutex((*dev)->mutex);
+        CloseHandle((*dev)->mutex);
 #endif // BLADERF_OS_WINDOWS
 
         *dev = NULL;
@@ -651,6 +652,7 @@ static void lusb_close(void *driver)
     libusb_exit(lusb->context);
 #if 1 == BLADERF_OS_WINDOWS
     ReleaseMutex(lusb->mutex);
+    CloseHandle(lusb->mutex);
 #endif // BLADERF_OS_WINDOWS
     free(lusb);
 }
@@ -677,6 +679,7 @@ static void lusb_close_bootloader(void *driver)
 
 #if 1 == BLADERF_OS_WINDOWS
         ReleaseMutex(lusb->mutex);
+        CloseHandle(lusb->mutex);
 #endif // BLADERF_OS_WINDOWS
 
         free(lusb);


### PR DESCRIPTION
Calling ReleaseMutex without CloseHandle will let the mutex still exist until the process exists.
In such scenario, further calls to CreateMutex will succeed but GetLastError will return 183 (ERROR_ALREADY_EXISTS) causing libbladerf to fail opening the device. This can be assessed by running ```libbladeRF_test_open.exe -c 2 -v debug```.

Cypress backend is not affected as it systematically closes the handle after releasing the mutex.