### PR TITLE
 host: misc: add Dockerfiles for multi-distro test builds

### DIFF
--- a/host/misc/docker/README.md
+++ b/host/misc/docker/README.md
@@ -1,0 +1,54 @@
+# Dockerfiles for various OS environments #
+
+This directory contains Dockerfiles for building libbladeRF and associated
+utilities under various operating systems, primarily as a means to ensure it
+builds properly across a variety of OSes.
+
+Currently, the following operating systems are supported:
+
+ * Linux
+  * Arch Linux
+  * CentOS
+    * 7
+  * Debian
+    * Jessie (8.x)
+    * Stretch (9.x)
+  * Fedora
+  * Ubuntu
+    * Trusty (14.04)
+    * Xenial (16.04)
+    * Artful (17.10)
+    * Bionic (18.04)
+
+## Building ##
+
+Build a Docker image from the root of the Nuand/bladeRF checkout:
+
+```
+docker build -f host/misc/docker/archlinux.Dockerfile .
+```
+
+Optionally, add a -t option to tag the image:
+
+```
+docker build -f host/misc/docker/archlinux.Dockerfile \
+             -t nuand/bladerf-buildenv:archlinux .
+```
+
+## Running ##
+
+For a quick test to ensure the build was successful, try:
+
+```
+docker run --rm -t nuand/bladerf-buildenv:archlinux bladeRF-cli --version
+```
+
+At this time, actually using a bladeRF device is not supported, although it
+would be really useful.
+
+## Future goals ##
+
+ * More distribution support
+ * FreeBSD
+ * clang builds
+ * Hardware access

--- a/host/misc/docker/archlinux.Dockerfile
+++ b/host/misc/docker/archlinux.Dockerfile
@@ -1,0 +1,54 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM archlinux/base
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Arch Linux)"
+
+# Install things
+RUN pacman -Syuq --noconfirm \
+    base-devel \
+    cmake \
+    doxygen \
+    git \
+    help2man \
+    libtecla \
+    libusb \
+ && echo "/usr/local/lib" > /etc/ld.so.conf.d/locallib.conf \
+ && pacman -Scc --noconfirm
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/build.bash
+++ b/host/misc/docker/build.bash
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# assuming the script is 3 levels in (host/misc/docker)
+dfdir=$(dirname "${0}")
+basedir=${dfdir}/../../..
+
+success=""
+failure=""
+
+rels=""
+
+if [ $# -gt 0 ]; then
+    rels=$*
+else
+    for dff in $(ls ${dfdir}/*.Dockerfile); do
+        rels="${rels} $(basename -s ".Dockerfile" ${dff})"
+    done
+fi
+
+if [ -z "${rels}" ]; then
+    echo "could not find any Dockerfiles to build!"
+    exit 1
+fi
+
+echo "*** $0: build goals: ${rels}"
+
+for df in ${rels}; do
+    rel=$(basename -s ".Dockerfile" ${df})
+    echo "*** ${rel}: building"
+    cd ${basedir}
+
+    echo -e '\033]2;'${rel} - building'\007'
+
+    docker build -f host/misc/docker/${rel}.Dockerfile \
+                 -t nuand/bladerf-buildenv:${rel} \
+                 .
+    status=$?
+
+    if [ $status -ne 0 ]; then
+        echo "*** ${rel}: BUILD FAILED"
+        failure="${failure} ${rel}"
+        continue
+    else
+        echo "*** ${rel}: build successful"
+    fi
+
+    echo -e '\033]2;'${rel} - testing'\007'
+
+    docker run --rm -t nuand/bladerf-buildenv:${rel} bladeRF-cli --version
+    status=$?
+
+    if [ $status -ne 0 ]; then
+        echo "*** ${rel}: TEST FAILED"
+        failure="${failure} ${rel}"
+        continue
+    else
+        echo "*** ${rel}: test successful"
+    fi
+
+    echo "*** ${rel}: PASSED"
+    success="${success} ${rel}"
+done
+
+echo "RESULTS:"
+echo "Successful builds: ${success}"
+echo "Failed builds: ${failure}"

--- a/host/misc/docker/centos-7.Dockerfile
+++ b/host/misc/docker/centos-7.Dockerfile
@@ -40,9 +40,14 @@ RUN yum groupinstall -y "Development Tools" \
     wget \
  && yum clean all
 
+# CentOS does not look in /usr/local/lib* for libraries, so we must add
+# this manually.
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/locallib.conf \
+ && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/locallib.conf
+
 WORKDIR /root
 
-# CentOS and Fedora lack libtecla packages, so download and build.
+# CentOS lacks libtecla packages, so download and build.
 RUN (curl http://www.astro.caltech.edu/~mcs/tecla/libtecla.tar.gz | tar xzf -) \
  && cd libtecla \
  && CC=gcc ./configure \

--- a/host/misc/docker/centos-7.Dockerfile
+++ b/host/misc/docker/centos-7.Dockerfile
@@ -1,0 +1,64 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM centos:7
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (CentOS 7)"
+
+# Install things
+RUN yum groupinstall -y "Development Tools" \
+ && yum install -y \
+    cmake \
+    doxygen \
+    gcc-c++ \
+    help2man \
+    libusbx \
+    libusbx-devel \
+    pandoc \
+    wget \
+ && yum clean all
+
+WORKDIR /root
+
+# CentOS and Fedora lack libtecla packages, so download and build.
+RUN (curl http://www.astro.caltech.edu/~mcs/tecla/libtecla.tar.gz | tar xzf -) \
+ && cd libtecla \
+ && CC=gcc ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libtecla
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/debian-jessie.Dockerfile
+++ b/host/misc/docker/debian-jessie.Dockerfile
@@ -1,0 +1,57 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM debian:jessie
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Debian Jessie)"
+
+# Install things
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        doxygen \
+        git \
+        help2man \
+        libtecla-dev \
+        libusb-1.0-0-dev \
+        pandoc \
+        pkg-config \
+ && apt-get clean
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/debian-stretch.Dockerfile
+++ b/host/misc/docker/debian-stretch.Dockerfile
@@ -1,0 +1,57 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM debian:stretch
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Debian Stretch)"
+
+# Install things
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        doxygen \
+        git \
+        help2man \
+        libtecla-dev \
+        libusb-1.0-0-dev \
+        pandoc \
+        pkg-config \
+ && apt-get clean
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/fedora-latest.Dockerfile
+++ b/host/misc/docker/fedora-latest.Dockerfile
@@ -1,0 +1,70 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM fedora:latest
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Fedora Latest)"
+
+# Install things
+RUN yum groupinstall -y "Development Tools" \
+ && yum install -y \
+    cmake \
+    doxygen \
+    gcc-c++ \
+    help2man \
+    hostname \
+    libusbx \
+    libusbx-devel \
+    pandoc \
+    wget \
+ && yum clean all
+
+# Fedora does not look in /usr/local/lib* for libraries, so we must add
+# this manually.
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/locallib.conf \
+ && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/locallib.conf
+
+WORKDIR /root
+
+# CentOS and Fedora lack libtecla packages, so download and build.
+RUN (curl http://www.astro.caltech.edu/~mcs/tecla/libtecla.tar.gz | tar xzf -) \
+ && cd libtecla \
+ && CC=gcc ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libtecla
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/fedora-latest.Dockerfile
+++ b/host/misc/docker/fedora-latest.Dockerfile
@@ -48,7 +48,7 @@ RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/locallib.conf \
 
 WORKDIR /root
 
-# CentOS and Fedora lack libtecla packages, so download and build.
+# Fedora lacks libtecla packages, so download and build.
 RUN (curl http://www.astro.caltech.edu/~mcs/tecla/libtecla.tar.gz | tar xzf -) \
  && cd libtecla \
  && CC=gcc ./configure \

--- a/host/misc/docker/ubuntu-artful.Dockerfile
+++ b/host/misc/docker/ubuntu-artful.Dockerfile
@@ -1,0 +1,57 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM ubuntu:artful
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Ubuntu Artful)"
+
+# Install things
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        doxygen \
+        git \
+        help2man \
+        libtecla-dev \
+        libusb-1.0-0-dev \
+        pandoc \
+        pkg-config \
+ && apt-get clean
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/ubuntu-bionic.Dockerfile
+++ b/host/misc/docker/ubuntu-bionic.Dockerfile
@@ -1,0 +1,57 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM ubuntu:bionic
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Ubuntu Bionic)"
+
+# Install things
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        doxygen \
+        git \
+        help2man \
+        libtecla-dev \
+        libusb-1.0-0-dev \
+        pandoc \
+        pkg-config \
+ && apt-get clean
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/ubuntu-trusty.Dockerfile
+++ b/host/misc/docker/ubuntu-trusty.Dockerfile
@@ -1,0 +1,57 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM ubuntu:trusty
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Ubuntu Trusty)"
+
+# Install things
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        doxygen \
+        git \
+        help2man \
+        libtecla-dev \
+        libusb-1.0-0-dev \
+        pandoc \
+        pkg-config \
+ && apt-get clean
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig

--- a/host/misc/docker/ubuntu-xenial.Dockerfile
+++ b/host/misc/docker/ubuntu-xenial.Dockerfile
@@ -1,0 +1,57 @@
+# This file is part of the bladeRF project:
+#   http://www.github.com/nuand/bladeRF
+#
+# Copyright (c) 2018 Nuand LLC.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM ubuntu:xenial
+
+LABEL maintainer="Nuand LLC <bladeRF@nuand.com>"
+LABEL version="0.0.1"
+LABEL description="CI build environment for the bladeRF project (Ubuntu Xenial)"
+
+# Install things
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        doxygen \
+        git \
+        help2man \
+        libtecla-dev \
+        libusb-1.0-0-dev \
+        pandoc \
+        pkg-config \
+ && apt-get clean
+
+WORKDIR /root
+
+COPY . /root/bladeRF
+
+RUN test -d "/root/bladeRF/host/build" && rm -rf /root/bladeRF/host/build
+
+RUN cd bladeRF/host \
+ && mkdir -p build \
+ && cd build \
+ && cmake -DBUILD_DOCUMENTATION=ON ../ \
+ && make \
+ && make install \
+ && ldconfig


### PR DESCRIPTION
It is now possible to perform test builds automatically across various
releases of Arch, CentOS, Debian, Fedora, and Ubuntu with:

`bash host/mis/docker/build.bash`

This will hopefully improve the chances of catching build-breaking bugs, such as #551.