### PR TITLE
host: libbladeRF: fix handle_serial strncpy warnings (#555)

### DIFF
--- a/host/libraries/libbladeRF/src/device_identifier.c
+++ b/host/libraries/libbladeRF/src/device_identifier.c
@@ -136,8 +136,8 @@ static int handle_serial(struct bladerf_devinfo *d, char *value)
         }
     }
 
-    memset(d->serial, 0, sizeof(d->serial));
-    strncpy(d->serial, value, len);
+    strncpy(d->serial, value, sizeof(d->serial));
+    d->serial[sizeof(d->serial) - 1] = '\0';
 
     if (len == (BLADERF_SERIAL_LENGTH - 1)) {
         log_verbose("Requested serial number: %s\n", d->serial);


### PR DESCRIPTION
Instead of using the length of the source string, use
sizeof(d->serial) to limit strncpy to the length of the destination
string.

Fixes #555