### PR TITLE
"set loopback" help dialog aware of board type

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/printset_impl.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset_impl.c
@@ -758,20 +758,22 @@ int set_loopback(struct cli_state *state, int argc, char **argv)
         printf("Usage: %s %s <mode>, where <mode> is one of the following:\n",
                argv[0], argv[1]);
         printf("\n");
-        printf("  %-18s%s\n", "bb_txlpf_rxvga2",
-               "Baseband loopback: TXLPF output --> RXVGA2 input\n");
-        printf("  %-18s%s\n", "bb_txlpf_rxlpf",
-               "Baseband loopback: TXLPF output --> RXLPF input\n");
-        printf("  %-18s%s\n", "bb_txvga1_rxvga2",
-               "Baseband loopback: TXVGA1 output --> RXVGA2 input\n");
-        printf("  %-18s%s\n", "bb_txvga1_rxlpf",
-               "Baseband loopback: TXVGA1 output --> RXLPF input\n");
-        printf("  %-18s%s\n", "rf_lna1",
-               "RF loopback: TXMIX --> RXMIX via LNA1 path\n");
-        printf("  %-18s%s\n", "rf_lna2",
-               "RF loopback: TXMIX --> RXMIX via LNA2 path\n");
-        printf("  %-18s%s\n", "rf_lna3",
-               "RF loopback: TXMIX --> RXMIX via LNA3 path\n");
+        if (ps_is_board(state->dev, BOARD_BLADERF1)) {
+            printf("  %-18s%s\n", "bb_txlpf_rxvga2",
+                  "Baseband loopback: TXLPF output --> RXVGA2 input\n");
+            printf("  %-18s%s\n", "bb_txlpf_rxlpf",
+                  "Baseband loopback: TXLPF output --> RXLPF input\n");
+            printf("  %-18s%s\n", "bb_txvga1_rxvga2",
+                  "Baseband loopback: TXVGA1 output --> RXVGA2 input\n");
+            printf("  %-18s%s\n", "bb_txvga1_rxlpf",
+                  "Baseband loopback: TXVGA1 output --> RXLPF input\n");
+            printf("  %-18s%s\n", "rf_lna1",
+                  "RF loopback: TXMIX --> RXMIX via LNA1 path\n");
+            printf("  %-18s%s\n", "rf_lna2",
+                  "RF loopback: TXMIX --> RXMIX via LNA2 path\n");
+            printf("  %-18s%s\n", "rf_lna3",
+                  "RF loopback: TXMIX --> RXMIX via LNA3 path\n");
+        }
         printf("  %-18s%s\n", "firmware", "Firmware-based sample loopback\n");
         printf("  %-18s%s\n", "rfic_bist", "RFIC BIST loopback\n");
         printf("  %-18s%s\n", "none", "Loopback disabled - Normal operation\n");

--- a/host/utilities/bladeRF-cli/src/cmd/printset_impl.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset_impl.c
@@ -758,6 +758,7 @@ int set_loopback(struct cli_state *state, int argc, char **argv)
         printf("Usage: %s %s <mode>, where <mode> is one of the following:\n",
                argv[0], argv[1]);
         printf("\n");
+
         if (ps_is_board(state->dev, BOARD_BLADERF1)) {
             printf("  %-18s%s\n", "bb_txlpf_rxvga2",
                   "Baseband loopback: TXLPF output --> RXVGA2 input\n");
@@ -774,8 +775,12 @@ int set_loopback(struct cli_state *state, int argc, char **argv)
             printf("  %-18s%s\n", "rf_lna3",
                   "RF loopback: TXMIX --> RXMIX via LNA3 path\n");
         }
+
+        if (ps_is_board(state->dev, BOARD_BLADERF2)) {
+            printf("  %-18s%s\n", "rfic_bist", "RFIC BIST loopback\n");
+        }
+
         printf("  %-18s%s\n", "firmware", "Firmware-based sample loopback\n");
-        printf("  %-18s%s\n", "rfic_bist", "RFIC BIST loopback\n");
         printf("  %-18s%s\n", "none", "Loopback disabled - Normal operation\n");
 
         rv = CLI_RET_INVPARAM;


### PR DESCRIPTION
I was getting familiar with bladeRF-cli and testing my bladeRF2 and was getting errors when trying to set loopback modes:

```
radiodev@f838f94589fe:~$ bladeRF-cli -i
bladeRF> info

  Board:                    bladerf2
  Serial #:                 8a952f477f514a11a049743f0c98a38b
  VCTCXO DAC calibration:   0x1f6b
  FPGA size:                49 KLE
  FPGA loaded:              yes
  USB bus:                  2
  USB address:              6
  USB speed:                SuperSpeed
  Backend:                  libusb
  Instance:                 0

bladeRF> print loopback

  Loopback mode: none

bladeRF> set loopback

Usage: set loopback <mode>, where <mode> is one of the following:

  bb_txlpf_rxvga2   Baseband loopback: TXLPF output --> RXVGA2 input

  bb_txlpf_rxlpf    Baseband loopback: TXLPF output --> RXLPF input

  bb_txvga1_rxvga2  Baseband loopback: TXVGA1 output --> RXVGA2 input

  bb_txvga1_rxlpf   Baseband loopback: TXVGA1 output --> RXLPF input

  rf_lna1           RF loopback: TXMIX --> RXMIX via LNA1 path

  rf_lna2           RF loopback: TXMIX --> RXMIX via LNA2 path

  rf_lna3           RF loopback: TXMIX --> RXMIX via LNA3 path

  firmware          Firmware-based sample loopback

  rfic_bist         RFIC BIST loopback

  none              Loopback disabled - Normal operation


bladeRF> set loopback rf_lna1

[ERROR @ host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c:3858] bladerf2_set_loopback: unknown loopback mode (6)


  Error: An unexpected error occurred

bladeRF> set loopback bb_txlpf_rxvga2

[ERROR @ host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c:3858] bladerf2_set_loopback: unknown loopback mode (2)


  Error: An unexpected error occurred

bladeRF> set loopback rfic_bist

  Loopback mode: rfic_bist

bladeRF> print loopback

  Loopback mode: rfic_bist
```

I took a look in the library code and it seems that the only valid loopback modes are "none", "rfic_bist" and "firmware" for the bladeRF2:

https://github.com/Nuand/bladeRF/blob/master/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c#L3848-L3860

This is a quick fix that checks the board type before it displays the modes.

```
radiodev@9c3ca64e2af5:~$ bladeRF-cli -i
bladeRF> info

  Board:                    bladerf2
  Serial #:                 8a952f477f514a11a049743f0c98a38b
  VCTCXO DAC calibration:   0x1f6b
  FPGA size:                49 KLE
  FPGA loaded:              yes
  USB bus:                  2
  USB address:              6
  USB speed:                SuperSpeed
  Backend:                  libusb
  Instance:                 0

bladeRF> set loopback

Usage: set loopback <mode>, where <mode> is one of the following:

  firmware          Firmware-based sample loopback

  rfic_bist         RFIC BIST loopback

  none              Loopback disabled - Normal operation


bladeRF>
```

I don't have a bladeRF1 board to test with, would appreciate some help with testing.