### PR TITLE
libbladeRF: polished release notes for v2.0

### DIFF
--- a/host/libraries/libbladeRF/doc/doxygen/mainpage.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/mainpage.dox
@@ -27,13 +27,13 @@ accessible knowledge base of common questions and answers to be developed.
 Bugs, both in libbladeRF and this documentation, may be reported on the
 <a class="el" href="https://www.github.com/Nuand/bladeRF/issues">GitHub issue tracker</a>
 
-@attention libbladeRF 2.0.0 introduces breaking changes to the parameter lists
+@attention libbladeRF 2.0 introduces breaking changes to the parameter lists
            for bladerf_get_frequency(), bladerf_stream(), and
            bladerf_sync_config().
 @attention Existing code using these functions @b must be updated to be
            compatible with this version. See the
-           \ref relnotes_2_0_0_api_freq_uint64 and
-           \ref relnotes_2_0_0_api_stream sections of the \ref relnotes_2_0_0
+           \ref relnotes_2_0_api_freq_uint64 and
+           \ref relnotes_2_0_api_stream sections of the \ref relnotes_2_0
            document for guidance.
 
 <hr>
@@ -85,7 +85,7 @@ libbladeRF provides the ability to:
 The <a class="el" href="modules.html">API Sections</a> page presents a complete list of of the libbladeRF API sections,
 including the aforementioned items.
 
-The \ref relnotes_2_0_0 page summarizes the new features and changes in
+The \ref relnotes_2_0 page summarizes the new features and changes in
 the second major release of libbladeRF.
 
 The following pages provide examples and more detailed usage information:

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0.dox
@@ -13,18 +13,17 @@
            bladerf_set_gain(), be aware that the gain range for these functions
            has shifted. See \ref relnotes_2_0_api_gain for guidance.
 
-This document describes many of the changes in libbladeRF 2.0, our first
-major release in more than three years. This release adds support for the
-bladeRF 2.0 "Micro," and improves the API for all bladeRF products. This
+This document describes many of the changes in libbladeRF 2.0, our latest major
+version increment that features significant changes. This release adds support
+for the bladeRF 2.0 Micro, and improves the API for all bladeRF products. This
 is also the first release with bindings for the Python programming language.
 
 We are very excited to release this library alongside the new bladeRF Micro.
-libbladeRF 2.0 began as a fork of the bladeRF codebase in February 2017.
-Across the FPGA, firmware, and host software trees, four engineers added
-105,000+ lines (and deleted 20,000+) to the bladeRF codebase, in more than 700
-commits.
+libbladeRF 2.0 began as a fork of the bladeRF codebase. Across the FPGA,
+firmware, and host software trees, we added 95,000+ lines (and deleted 18,000+)
+to the bladeRF codebase, in more than 600 commits.
 
-Inevitably, there will be bugs or missing features. Please use our issue
+In case you experience any bugs or missing features, please use our issue
 tracker at https://github.com/Nuand/bladeRF/issues to report any problems
 you encounter with this release. Also, visit our forums at
 https://nuand.com/forums/ to discuss this release with other bladeRF users.

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0.dox
@@ -1,25 +1,25 @@
 /**
 
-\page relnotes_2_0_0 libbladeRF 2.0.0 Release Notes
+\page relnotes_2_0 libbladeRF 2.0 Release Notes
 
-@attention libbladeRF 2.0.0 introduces breaking changes to the parameter lists
+@attention libbladeRF 2.0 introduces breaking changes to the parameter lists
            for bladerf_get_frequency(), bladerf_stream(), and
            bladerf_sync_config().
 @attention Existing code using these functions @b must be updated to be
            compatible with this version. See the
-           \ref relnotes_2_0_0_api_freq_uint64 and
-           \ref relnotes_2_0_0_api_stream sections for guidance.
+           \ref relnotes_2_0_api_freq_uint64 and
+           \ref relnotes_2_0_api_stream sections for guidance.
 @attention Additionally, if you use bladerf_get_gain() and/or
            bladerf_set_gain(), be aware that the gain range for these functions
-           has shifted. See \ref relnotes_2_0_0_api_gain for guidance.
+           has shifted. See \ref relnotes_2_0_api_gain for guidance.
 
-This document describes many of the changes in libbladeRF 2.0.0, our first
+This document describes many of the changes in libbladeRF 2.0, our first
 major release in more than three years. This release adds support for the
 bladeRF 2.0 "Micro," and improves the API for all bladeRF products. This
 is also the first release with bindings for the Python programming language.
 
 We are very excited to release this library alongside the new bladeRF Micro.
-libbladeRF 2.0.0 began as a fork of the bladeRF codebase in February 2017.
+libbladeRF 2.0 began as a fork of the bladeRF codebase in February 2017.
 Across the FPGA, firmware, and host software trees, four engineers added
 105,000+ lines (and deleted 20,000+) to the bladeRF codebase, in more than 700
 commits.
@@ -31,20 +31,20 @@ https://nuand.com/forums/ to discuss this release with other bladeRF users.
 
 \tableofcontents
 
-\section relnotes_2_0_0_api Significant changes to the libbladeRF API
+\section relnotes_2_0_api Significant changes to the libbladeRF API
 
 We attempted to minimize the changes required to make existing applications
-work with libbladeRF 2.x. However, the nature of this project required some
+work with libbladeRF 2.0. However, the nature of this project required some
 changes to the API. Many of the changes can be transparently handled by
 compilers. However, applications will generally need to be recompiled and
 relinked to work with this version.
 
 Each topic has a table describing the affected functions, the importance
 of this change, and the recommended action. Please see
-\ref relnotes_2_0_0_ref_nomenclature for definitions of the words used in the
+\ref relnotes_2_0_ref_nomenclature for definitions of the words used in the
 "Importance" column.
 
-\subsection relnotes_2_0_0_api_freq_uint64 RF frequencies are now uint64_t
+\subsection relnotes_2_0_api_freq_uint64 RF frequencies are now uint64_t
 
 In libbladeRF 1.x, RF frequencies were specified as 32-bit `unsigned int`. To
 support the wider frequency range of the bladeRF Micro, frequencies are now
@@ -93,7 +93,7 @@ specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 \li Do expect bladerf_get_frequency() to return values larger than `UINT32_MAX`.
 \li Do use the ::bladerf_frequency type when possible.
 
-\subsection relnotes_2_0_0_api_stream Streaming API changes for MIMO
+\subsection relnotes_2_0_api_stream Streaming API changes for MIMO
 
 The data transfer APIs were expanded to support MIMO (multiple-input,
 multiple-output). This capability is used to transmit or receive samples via
@@ -160,7 +160,7 @@ void configure_module_sync(bladerf_module module) {
     are convenience functions written for clarity and portability, not
     performance.
 
-\see \ref relnotes_2_0_0_ref_channels
+\see \ref relnotes_2_0_ref_channels
 \see \ref BLADERF_FORMAT_SC16_Q11 describes the sample interleaving format.
 \see bladerf_interleave_stream_buffer() - Interleaves contiguous blocks of
      samples in preparation for MIMO TX.
@@ -169,7 +169,7 @@ void configure_module_sync(bladerf_module module) {
 \see bladerf_get_channel_count() - Get the number of RX or TX channels
      supported by the given device.
 
-\subsection relnotes_2_0_0_api_channel bladerf_module replaced by bladerf_channel
+\subsection relnotes_2_0_api_channel bladerf_module replaced by bladerf_channel
 
 In libbladeRF 1.x, `bladerf_module` was an enum with two valid choices:
 `BLADERF_MODULE_RX` and `BLADERF_MODULE_TX`. To support MIMO, this enum has
@@ -184,7 +184,7 @@ respectively.
 
 Note that some `bladerf_module` instances have been replaced with
 \ref bladerf_direction and \ref bladerf_channel_layout depending on context.
-See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
+See the \ref relnotes_2_0_api_stream section elsewhere in this document.
 
 <table>
 <caption id="multi_row_2">Required actions</caption>
@@ -244,11 +244,11 @@ See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 \li Do use the BLADERF_CHANNEL_RX(channel) and BLADERF_CHANNEL_TX(channel)
     convenience macros.
 
-\see \ref relnotes_2_0_0_ref_channels
+\see \ref relnotes_2_0_ref_channels
 \see bladerf_get_channel_count() - Get the number of RX or TX channels
      supported by the given device.
 
-\subsection relnotes_2_0_0_api_range Defined BLADERF_*_{MAX,MIN,etc} constants replaced by bladerf_get_*_range functions
+\subsection relnotes_2_0_api_range Defined BLADERF_*_{MAX,MIN,etc} constants replaced by bladerf_get_*_range functions
 
 The precompiler constants for supported minimum/maximum values have been
 deprecated and replaced with a set of context-aware functions. The old
@@ -351,7 +351,7 @@ bool is_frequency_within_range(struct bladerf *dev, bladerf_channel channel, bla
 \see bladerf_set_gain() - Set overall system gain.
 \see bladerf_get_gain() - Get overall system gain.
 
-\subsection relnotes_2_0_0_api_gain bladerf_{get,set}_gain range standardization
+\subsection relnotes_2_0_api_gain bladerf_{get,set}_gain range standardization
 
 Previously, the ranges used by bladerf_get_gain() and bladerf_set_gain() were
 somewhat arbitrary, with a value of 0 being the minimum possible gain, and the
@@ -390,9 +390,9 @@ as the maximum available gain on RX, and roughly +0 dBm output power on TX.
       output ports on the same board. Applications requiring precise control
       of TX power should consider calibration.
 
-\see \ref relnotes_2_0_0_feats_gc_proportioning
+\see \ref relnotes_2_0_feats_gc_proportioning
 
-\subsection relnotes_2_0_0_api_typedefs Common parameter types now have typedefs
+\subsection relnotes_2_0_api_typedefs Common parameter types now have typedefs
 
 For semantic clarity, common parameter types now have typedefs.
 
@@ -419,7 +419,7 @@ For semantic clarity, common parameter types now have typedefs.
         \li ::bladerf_correction_value (correction value in arbitrary units;
             `int16_t`)
 
-        \see \ref relnotes_2_0_0_api_freq_uint64
+        \see \ref relnotes_2_0_api_freq_uint64
     </td>
 </tr>
 <tr><td>bladerf_get_frequency()</td></tr>
@@ -448,9 +448,9 @@ Using `printf()` with a ::bladerf_frequency or ::bladerf_timestamp currently
 require knowing that they are actually `uint64_t`, e.g.
 `printf("the frequency is %" PRIu64 " Hz\n", freq);`.
 
-\section relnotes_2_0_0_feats New features
+\section relnotes_2_0_feats New features
 
-\subsection relnotes_2_0_0_feats_platform Multiple platform support
+\subsection relnotes_2_0_feats_platform Multiple platform support
 
 We reorganized libbladeRF to easily support multiple hardware platforms.  You
 will find a new directory tree, `host/libraries/libbladeRF/src/board/`,
@@ -474,7 +474,7 @@ you'll also find `board/` (product-specific code), `driver/` (device drivers),
 `expansion/` (expansion board drivers), `helpers/` (helpful utility functions),
 and `streaming/` (sample streaming code).
 
-\subsection relnotes_2_0_0_feats_gc Gain control improvements
+\subsection relnotes_2_0_feats_gc Gain control improvements
 
 The original manual gain control functionality in libbladeRF was very low-level
 and hardware-specific, and requires significant knowledge of the underlying
@@ -489,7 +489,7 @@ to the API, and the following functions are now deprecated:
 
 Instead, applications should use one of approaches described below.
 
-\subsubsection relnotes_2_0_0_feats_gc_agc Automatic Gain Control (AGC)
+\subsubsection relnotes_2_0_feats_gc_agc Automatic Gain Control (AGC)
 
 Automatic gain control is available for RX channels, starting with
 <a class="el" href="https://github.com/Nuand/bladeRF/releases/tag/libbladeRF_v1.9.0">libbladeRF v1.9.0</a>
@@ -546,7 +546,7 @@ void agc_example(struct bladerf *dev, bladerf_channel channel)
 }
 \endcode
 
-\subsubsection relnotes_2_0_0_feats_gc_proportioning System gain proportioning
+\subsubsection relnotes_2_0_feats_gc_proportioning System gain proportioning
 
 In previous versions, setting the gain required careful proportioning of gain
 between LNAs and VGAs. To reduce the implementation burden, an overall gain may
@@ -561,7 +561,7 @@ The gain scales are defined such that a 60 dB gain on a TX channel is
 maximum available amplification.
 
 \note bladerf_set_gain() may be unavailable or may not operate as expected if
-      \ref relnotes_2_0_0_feats_gc_agc is enabled, or if the channel
+      \ref relnotes_2_0_feats_gc_agc is enabled, or if the channel
       is not currently enabled.
 
 \note The range returned by bladerf_get_gain_range() may vary depending on the
@@ -603,7 +603,7 @@ gain_example(dev, BLADERF_CHANNEL_RX(0), 60);  // set 60 dB RX gain (max)
 
 \see bladerf_get_rfic_rssi() - query received signal strength from the RFIC.
 
-\subsubsection relnotes_2_0_0_feats_gc_manual Individual gain stage control
+\subsubsection relnotes_2_0_feats_gc_manual Individual gain stage control
 
 Advanced implementations that need to directly configure the gain stages may
 use the following family of functions:
@@ -619,17 +619,17 @@ use the following family of functions:
       a particular channel.
 
 \note bladerf_set_gain_stage() may be unavailable or may not operate as
-      expected if \ref relnotes_2_0_0_feats_gc_agc is enabled, or if
+      expected if \ref relnotes_2_0_feats_gc_agc is enabled, or if
       the channel is not currently enabled.
 
 \note The range returned by bladerf_get_gain_stage_range() may vary depending
       on the selected center frequency.
 
-\subsection relnotes_2_0_0_feats_hw New hardware features
+\subsection relnotes_2_0_feats_hw New hardware features
 
 libbladeRF 2.0 includes support for new hardware features on the bladeRF Micro.
 
-\subsubsection relnotes_2_0_0_feats_hw_biastee Bias tees
+\subsubsection relnotes_2_0_feats_hw_biastee Bias tees
 
 The bias tees apply a +5 VDC bias to the SMA connectors, which may be used
 for powering active antennas or inline amplifiers.
@@ -641,7 +641,7 @@ for powering active antennas or inline amplifiers.
 
 \see bladerf_get_bias_tee() and bladerf_set_bias_tee()
 
-\subsubsection relnotes_2_0_0_feats_hw_clock Clock references and controls
+\subsubsection relnotes_2_0_feats_hw_clock Clock references and controls
 
 An external frequency reference may be connected to the J95 U.FL connector
 ("REFIN") to discipline the onboard VCTCXO. By default, this port expects
@@ -664,7 +664,7 @@ output.
 \see bladerf_get_clock_output(), bladerf_set_clock_output() - enable or disable
      clock output (J92)
 
-\subsubsection relnotes_2_0_0_feats_hw_power Power status
+\subsubsection relnotes_2_0_feats_hw_power Power status
 
 Functions are provided to determine how the board is currently being powered,
 what the bus voltage is, and what the system current and power draws are.
@@ -672,7 +672,7 @@ what the bus voltage is, and what the system current and power draws are.
 \see bladerf_get_power_source() - query how the board is currently powered
 \see bladerf_get_pmic_register() - get bus voltage, load current, load power
 
-\subsubsection relnotes_2_0_0_feats_hw_temperature RFIC temperature
+\subsubsection relnotes_2_0_feats_hw_temperature RFIC temperature
 
 The RFIC has an onboard temperature sensor, which may be useful for
 environmental monitoring, or for determining if the RFIC's synthesizers should
@@ -680,9 +680,9 @@ be retuned after a significant temperature shift.
 
 \see bladerf_get_rfic_temperature()
 
-\section relnotes_2_0_0_ref Further information
+\section relnotes_2_0_ref Further information
 
-\subsection relnotes_2_0_0_ref_channels What is a channel?
+\subsection relnotes_2_0_ref_channels What is a channel?
 
 In the bladeRF architecture, a channel is a single, unidirectional RF path.
 There is a 1:1 mapping between a ::bladerf_channel and a physical RF port.
@@ -722,14 +722,14 @@ interleaved in the sample buffers (currently 1 or 2).
 \li bladerf_sync_config()
 \li bladerf_stream()
 
-\subsection relnotes_2_0_0_ref_nomenclature Definitions for "Importance"
+\subsection relnotes_2_0_ref_nomenclature Definitions for "Importance"
 
 <table>
 <tr><th>Word</th><th>Meaning</th></tr>
 <tr>
     <td><b>Required</b></td>
     <td>
-        This change must be performed to build code against libbladeRF 2.x.
+        This change must be performed to build code against libbladeRF 2.0.
         Compile errors will result if you fail to do so.
     </td>
 </tr>

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0.dox
@@ -252,7 +252,7 @@ See the \ref relnotes_2_0_api_stream section elsewhere in this document.
 
 The precompiler constants for supported minimum/maximum values have been
 deprecated and replaced with a set of context-aware functions. The old
-constants will be removed in a later rleae.
+constants will be removed in a later release.
 
 <table>
 <caption id="multi_row_3">Required actions</caption>
@@ -676,7 +676,7 @@ what the bus voltage is, and what the system current and power draws are.
 
 The RFIC has an onboard temperature sensor, which may be useful for
 environmental monitoring, or for determining if the RFIC's synthesizers should
-be retuned after a significant temperature shift.
+be re-tuned after a significant temperature shift.
 
 \see bladerf_get_rfic_temperature()
 

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -39,7 +39,7 @@ changes to the API. Many of the changes can be transparently handled by
 compilers. However, applications will generally need to be recompiled and
 relinked to work with this version.
 
-\subsection relnotes_2_0_0_api_freq_uint64 Tuning frequencies are now uint64_t
+\subsection relnotes_2_0_0_api_freq_uint64 RF frequencies are now uint64_t
 
 In libbladeRF 1.x, RF frequencies were specified as 32-bit `unsigned int`. To
 support the wider frequency range of the bladeRF Micro, frequencies are now
@@ -60,7 +60,7 @@ specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 </tr>
 <tr>
     <td>bladerf_set_frequency()</td>
-    <td rowspan="3">Minor</td>
+    <td rowspan="3">Recommended</td>
     <td rowspan="3">
         The `frequency` parameter is now of type ::bladerf_frequency.
 
@@ -84,7 +84,7 @@ specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 \li Do expect bladerf_get_frequency() to return values larger than `UINT32_MAX`.
 \li Do use the ::bladerf_frequency type when possible.
 
-\subsection relnotes_2_0_0_api_stream MIMO support in streaming API
+\subsection relnotes_2_0_0_api_stream Streaming API changes for MIMO
 
 The data transfer APIs were expanded to support MIMO (multiple-input,
 multiple-output). This capability is used to transmit or receive samples via
@@ -160,7 +160,7 @@ void configure_module_sync(bladerf_module module) {
 \see bladerf_get_channel_count() - Get the number of RX or TX channels
      supported by the given device.
 
-\subsection relnotes_2_0_0_api_channel bladerf_channel replaces bladerf_module
+\subsection relnotes_2_0_0_api_channel bladerf_module replaced by bladerf_channel
 
 In libbladeRF 1.x, `bladerf_module` was an enum with two valid choices:
 `BLADERF_MODULE_RX` and `BLADERF_MODULE_TX`. To support MIMO, this enum has
@@ -182,7 +182,7 @@ See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>bladerf_enable_module()</td>
-    <td rowspan="27">Required for MIMO support, optional otherwise</td>
+    <td rowspan="27"><b>Required</b> for MIMO support, optional otherwise</td>
     <td rowspan="27">
         Replace `bladerf_module` with \ref bladerf_channel.
 
@@ -233,7 +233,7 @@ See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 \see bladerf_get_channel_count() - Get the number of RX or TX channels
      supported by the given device.
 
-\subsection relnotes_2_0_0_api_range bladerf_get_*_range functions replace #define'd constants
+\subsection relnotes_2_0_0_api_range Defined BLADERF_*_{MAX,MIN,etc} constants replaced by bladerf_get_*_range functions
 
 The precompiler constants for supported minimum/maximum values have been
 deprecated and replaced with a set of context-aware functions.
@@ -243,7 +243,10 @@ deprecated and replaced with a set of context-aware functions.
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>BLADERF_RXVGA1_GAIN_MIN</td>
-    <td rowspan="17">Required for complete bladeRF Micro compatibility</td>
+    <td rowspan="17">
+        <b>Required</b> for full compatibility. The old constants are
+        deprecated and will be removed in a future release.
+    </td>
     <td rowspan="10">
         Use bladerf_get_gain_stage_range() to retrieve the range of allowable
         gains for a specific gain stage. This should be called after setting
@@ -328,68 +331,35 @@ bool is_frequency_within_range(struct bladerf *dev, bladerf_channel channel, bla
 \see bladerf_set_gain() - Set overall system gain.
 \see bladerf_get_gain() - Get overall system gain.
 
-\subsection relnotes_2_0_0_api_typedefs New type definitions for parameters
-
-The following types are now defined:
-
-\li ::bladerf_gain (gain value in dB; `int`)
-\li ::bladerf_sample_rate (sample rate in samples per second; `unsigned int`)
-\li ::bladerf_bandwidth (bandwidth in Hz; `unsigned int`)
-\li ::bladerf_frequency (center frequency in Hz; `uint64_t`)
-\li ::bladerf_timestamp (timestamp in ticks; `uint64_t`)
-\li ::bladerf_correction_value (correction value in arbitrary units; `int16_t`)
-
-With the exception of ::bladerf_frequency, none of the underlying types changed
-from libbladeRF 1.x.x and no changes are strictly necessary. However, the
-declarations changed for the following functions:
-
-\li bladerf_set_gain()
-\li bladerf_get_gain()
-\li bladerf_set_gain_stage()
-\li bladerf_get_gain_stage()
-\li bladerf_set_sample_rate()
-\li bladerf_get_sample_rate()
-\li bladerf_set_bandwidth()
-\li bladerf_get_bandwidth()
-\li bladerf_select_band()
-\li bladerf_set_frequency()
-\li bladerf_get_frequency()
-\li bladerf_schedule_retune()
-\li bladerf_set_correction()
-\li bladerf_get_correction()
-\li bladerf_get_timestamp()
-
-As well as:
-
-\li struct bladerf_metadata
-
-\remarks
-\li Don't use the underlying types (e.g. `uint64_t` instead of
-    `bladerf_frequency`) if it can be avoided.
-\li Do use these typedefs whereever possible! They exist to make implementation
-    easier.
-
-\todo
-<a class="el" href="https://github.com/Nuand/bladeRF/issues/577">Issue #577</a>:
-Using `printf()` with a ::bladerf_frequency or ::bladerf_timestamp currently
-require knowing that they are actually `uint64_t`, e.g.
-`printf("the frequency is %" PRIu64 " Hz\n", freq);`.
-
-\subsection relnotes_2_0_0_api_gain bladerf_{get,set}_gain range shift
+\subsection relnotes_2_0_0_api_gain bladerf_{get,set}_gain range standardization
 
 Previously, the ranges used by bladerf_get_gain() and bladerf_set_gain() were
-somewhat arbitrary, with a value of 0 being the minimum possible gain, and
-the maximum possible gain being the sum of the max gain for all gain stages.
+somewhat arbitrary, with a value of 0 being the minimum possible gain, and the
+maximum possible gain being the sum of the max gain for all gain stages.
 
 To allow the same gain settings to produce similar results on all bladeRF
-models, we've standardized the gain ranges for these two functions as follows:
+models, we've adjusted the gain ranges for these two functions to define 60 dB
+as the maximum available gain on RX, and roughly +0 dBm output power on TX.
 
-\li RX Gain: 60 dB is the maximum available gain
-\li TX Gain: 60 dB is \em approximately +0 dBm CW output power
+<table>
+<caption id="multi_row">Required actions</caption>
+<tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
+<tr>
+    <td>bladerf_set_gain()</td>
+    <td rowspan="2">
+        <b>Required</b>
+    </td>
+    <td rowspan="2">
+        60 dB is now defined as:
+        \li Maximum RX Gain
+        \li +0 dBm TX power (CW, approximate)
+    </td>
+</tr>
+<tr><td>bladerf_get_gain()</td></tr>
+</table>
 
-This only affects bladerf_set_gain() and bladerf_get_gain(); individual gain
-stages (bladerf_set_gain_stage() and bladerf_get_gain_stage()) still expect
-raw hardware-specific values.
+\note Individual gain stages (bladerf_set_gain_stage() and
+      bladerf_get_gain_stage()) still expect raw hardware-specific values.
 
 \note The TX Gain is \em not calibrated, and the actual output power will vary
       from board to board, frequency to frequency, and even between different
@@ -397,6 +367,62 @@ raw hardware-specific values.
       of TX power should consider calibration.
 
 \see \ref relnotes_2_0_0_feats_gc_proportioning
+
+\subsection relnotes_2_0_0_api_typedefs Common parameter types now have typedefs
+
+For semantic clarity, common parameter types now have typedefs.
+
+<table>
+<caption id="multi_row">Required actions</caption>
+<tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
+<tr>
+    <td>bladerf_set_frequency()</td>
+    <td rowspan="4">
+        <b>Required</b> (see \ref relnotes_2_0_0_api_freq_uint64 elsewhere in
+        this document)
+    </td>
+    <td rowspan="16">
+        The declarations for these functions were changed to use defined
+        types. No changes are immediately necessary, with the exception of
+        ::bladerf_frequency (see \ref relnotes_2_0_0_api_freq_uint64).
+
+        The new types are:
+
+        \li ::bladerf_gain (gain value in dB; `int`)
+        \li ::bladerf_sample_rate (sample rate in samples per second;
+            `unsigned int`)
+        \li ::bladerf_bandwidth (bandwidth in Hz; `unsigned int`)
+        \li ::bladerf_frequency (center frequency in Hz; `uint64_t`)
+        \li ::bladerf_timestamp (timestamp in ticks; `uint64_t`)
+        \li ::bladerf_correction_value (correction value in arbitrary units;
+            `int16_t`)
+    </td>
+</tr>
+<tr><td>bladerf_get_frequency()</td></tr>
+<tr><td>bladerf_schedule_retune()</td></tr>
+<tr><td>bladerf_select_band()</td></tr>
+<tr>
+    <td>bladerf_set_gain()</td>
+    <td rowspan="12">Optional</td>
+</tr>
+<tr><td>bladerf_get_gain()</td></tr>
+<tr><td>bladerf_set_gain_stage()</td></tr>
+<tr><td>bladerf_get_gain_stage()</td></tr>
+<tr><td>bladerf_set_sample_rate()</td></tr>
+<tr><td>bladerf_get_sample_rate()</td></tr>
+<tr><td>bladerf_set_bandwidth()</td></tr>
+<tr><td>bladerf_get_bandwidth()</td></tr>
+<tr><td>bladerf_set_correction()</td></tr>
+<tr><td>bladerf_get_correction()</td></tr>
+<tr><td>bladerf_get_timestamp()</td></tr>
+<tr><td>struct bladerf_metadata</td></tr>
+</table>
+
+\todo
+<a class="el" href="https://github.com/Nuand/bladeRF/issues/577">Issue #577</a>:
+Using `printf()` with a ::bladerf_frequency or ::bladerf_timestamp currently
+require knowing that they are actually `uint64_t`, e.g.
+`printf("the frequency is %" PRIu64 " Hz\n", freq);`.
 
 \section relnotes_2_0_0_feats New features
 

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -148,6 +148,7 @@ void configure_module_sync(bladerf_module module) {
     are convenience functions written for clarity and portability, not
     performance.
 
+\see \ref relnotes_2_0_0_ref_channels
 \see \ref BLADERF_FORMAT_SC16_Q11 describes the sample interleaving format.
 \see bladerf_interleave_stream_buffer() - Interleaves contiguous blocks of
      samples in preparation for MIMO TX.
@@ -225,12 +226,13 @@ See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 \li DO use the BLADERF_CHANNEL_RX(channel) and BLADERF_CHANNEL_TX(channel)
     convenience macros.
 
+\see \ref relnotes_2_0_0_ref_channels
 \see bladerf_get_channel_count() - Get the number of RX or TX channels
      supported by the given device.
 
 \subsection relnotes_2_0_0_api_range bladerf_get_*_range functions replace #define'd constants
 
-The `#define`'d constants for supported minimum/maximum values have been
+The precompiler constants for supported minimum/maximum values have been
 deprecated and replaced with a set of context-aware functions.
 
 <table>
@@ -601,5 +603,47 @@ environmental monitoring, or for determining if the RFIC's synthesizers should
 be retuned after a significant temperature shift.
 
 \see bladerf_get_rfic_temperature()
+
+\subsection relnotes_2_0_0_ref Further information
+
+\subsubsection relnotes_2_0_0_ref_channels What is a channel?
+
+In the bladeRF architecture, a channel is a single, unidirectional RF path.
+There is generally a 1:1 mapping between a ::bladerf_channel and a physical
+RF port.
+
+On the original bladeRF, there are two channels available:
+
+\li BLADERF_CHANNEL_RX(0) == J53 "RX"
+\li BLADERF_CHANNEL_TX(0) == J54 "TX"
+
+On the bladeRF Micro, there are four channels available:
+
+\li BLADERF_CHANNEL_RX(0) == J1 "RX1"
+\li BLADERF_CHANNEL_RX(1) == J3 "RX2"
+
+\li BLADERF_CHANNEL_TX(0) == J2 "TX1"
+\li BLADERF_CHANNEL_TX(1) == J4 "TX2"
+
+Generally speaking, you will want to apply settings to a specific channel.
+Note that some groups of channels may share some settings on some hardware: for
+example, if you bladerf_set_frequency() on a bladeRF Micro's
+BLADERF_CHANNEL_RX(0), it will also change the frequency of
+BLADERF_CHANNEL_RX(1), because both RX ports share the same local oscillator.
+
+There are some functions which always apply to all the RX channels or all the
+TX channels. These accept a ::bladerf_direction argument:
+
+\li bladerf_get_channel_count()
+\li bladerf_get_timestamp()
+\li bladerf_set_stream_timeout()
+\li bladerf_get_stream_timeout()
+
+Finally, there are two functions which accept a ::bladerf_channel_layout.
+This specifies two things: the direction (RX vs TX), and the number of channels
+interleaved in the sample buffers (currently 1 or 2).
+
+\li bladerf_sync_config()
+\li bladerf_stream()
 
 */

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -39,6 +39,11 @@ changes to the API. Many of the changes can be transparently handled by
 compilers. However, applications will generally need to be recompiled and
 relinked to work with this version.
 
+Each topic has a table describing the affected functions, the importance
+of this change, and the recommended action. Please see
+\ref relnotes_2_0_0_ref_nomenclature for definitions of the words used in the
+"Importance" column.
+
 \subsection relnotes_2_0_0_api_freq_uint64 RF frequencies are now uint64_t
 
 In libbladeRF 1.x, RF frequencies were specified as 32-bit `unsigned int`. To
@@ -46,7 +51,7 @@ support the wider frequency range of the bladeRF Micro, frequencies are now
 specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 
 <table>
-<caption id="multi_row">Required actions</caption>
+<caption id="multi_row_0">Required actions</caption>
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>bladerf_get_frequency()</td>
@@ -60,7 +65,11 @@ specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 </tr>
 <tr>
     <td>bladerf_set_frequency()</td>
-    <td rowspan="3">Recommended</td>
+    <td rowspan="3">
+        <b>Required</b> for full compatibility
+
+        \note This action is required to use RF frequencies above ~4 GHz.
+    </td>
     <td rowspan="3">
         The `frequency` parameter is now of type ::bladerf_frequency.
 
@@ -91,7 +100,7 @@ multiple-output). This capability is used to transmit or receive samples via
 multiple RF ports simultaneously.
 
 <table>
-<caption id="multi_row">Required actions</caption>
+<caption id="multi_row_1">Required actions</caption>
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>bladerf_sync_config()</td>
@@ -120,7 +129,7 @@ void configure_module_sync(bladerf_module module) {
 <tr><td>bladerf_stream()</td></tr>
 <tr>
     <td>bladerf_get_timestamp()</td>
-    <td rowspan="4">Minor</td>
+    <td rowspan="3">Optional</td>
     <td rowspan="3">
         The `bladerf_module` argument has been replaced with
         \ref bladerf_direction.
@@ -136,6 +145,7 @@ void configure_module_sync(bladerf_module module) {
 <tr><td>bladerf_get_stream_timeout()</td></tr>
 <tr>
     <td>bladerf_sync_tx()</td>
+    <td rowspan="1">Informational</td>
     <td>
         The `samples` parameter is now a pointer to a `const`.
 
@@ -178,11 +188,17 @@ Note that some `bladerf_module` instances have been replaced with
 See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 
 <table>
-<caption id="multi_row">Required actions</caption>
+<caption id="multi_row_2">Required actions</caption>
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>bladerf_enable_module()</td>
-    <td rowspan="27"><b>Required</b> for MIMO support, optional otherwise</td>
+    <td rowspan="27">
+        <b>Required</b> for full compatibility
+
+        \note This action is required to fully support devices with multiple
+              channels. Without these changes, only the first channel will be
+              available for use.
+    </td>
     <td rowspan="27">
         Replace `bladerf_module` with \ref bladerf_channel.
 
@@ -236,21 +252,26 @@ See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 \subsection relnotes_2_0_0_api_range Defined BLADERF_*_{MAX,MIN,etc} constants replaced by bladerf_get_*_range functions
 
 The precompiler constants for supported minimum/maximum values have been
-deprecated and replaced with a set of context-aware functions.
+deprecated and replaced with a set of context-aware functions. The old
+constants will be removed in a later rleae.
 
 <table>
-<caption id="multi_row">Required actions</caption>
+<caption id="multi_row_3">Required actions</caption>
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>BLADERF_RXVGA1_GAIN_MIN</td>
     <td rowspan="17">
-        <b>Required</b> for full compatibility. The old constants are
-        deprecated and will be removed in a future release.
+        <b>Required</b> for full compatibility
+
+        \note This action is required for proper functioning of new bladeRF
+              models. The old constants are only valid for the original
+              bladeRF, and are not valid for other models.
     </td>
     <td rowspan="10">
         Use bladerf_get_gain_stage_range() to retrieve the range of allowable
-        gains for a specific gain stage. This should be called after setting
-        the frequency with bladerf_set_frequency().
+        gains for a specific gain stage. 
+
+        \see bladerf_get_gain() and bladerf_set_gain()
     </td>
 </tr>
 <tr><td>BLADERF_RXVGA1_GAIN_MAX</td></tr>
@@ -284,8 +305,8 @@ deprecated and replaced with a set of context-aware functions.
         Use bladerf_get_frequency_range() to retrieve the supported range of
         frequencies for a given channel.
 
-        \note This will vary depending on the particular hardware configuration
-              (such as if a XB-200 is attached).
+        \note The range will vary depending on the particular hardware
+              configuration, such as if a XB-200 is attached.
     </td>
 </tr>
 <tr><td>BLADERF_FREQUENCY_MIN</td></tr>
@@ -342,17 +363,21 @@ models, we've adjusted the gain ranges for these two functions to define 60 dB
 as the maximum available gain on RX, and roughly +0 dBm output power on TX.
 
 <table>
-<caption id="multi_row">Required actions</caption>
+<caption id="multi_row_4">Required actions</caption>
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>bladerf_set_gain()</td>
     <td rowspan="2">
-        <b>Required</b>
+        <b>Required</b> for full compatibility
+
+        \note This change affects the meaning of the values passed to/from
+              these functions, and the impact should be reviewed to avoid
+              unexpected results.
     </td>
     <td rowspan="2">
         60 dB is now defined as:
-        \li Maximum RX Gain
-        \li +0 dBm TX power (CW, approximate)
+        \li RX channels: Maximum RX Gain
+        \li TX channels: +0 dBm TX power (CW, approximate)
     </td>
 </tr>
 <tr><td>bladerf_get_gain()</td></tr>
@@ -373,18 +398,15 @@ as the maximum available gain on RX, and roughly +0 dBm output power on TX.
 For semantic clarity, common parameter types now have typedefs.
 
 <table>
-<caption id="multi_row">Required actions</caption>
+<caption id="multi_row_5">Required actions</caption>
 <tr><th>API Component</th><th>Importance</th><th>Action</th></tr>
 <tr>
     <td>bladerf_set_frequency()</td>
-    <td rowspan="4">
-        <b>Required</b> (see \ref relnotes_2_0_0_api_freq_uint64 elsewhere in
-        this document)
-    </td>
+    <td rowspan="4"><b>Required</b></td>
     <td rowspan="16">
         The declarations for these functions were changed to use defined
-        types. No changes are immediately necessary, with the exception of
-        ::bladerf_frequency (see \ref relnotes_2_0_0_api_freq_uint64).
+        types. No changes are immediately necessary, <i>with the exception of
+        ::bladerf_frequency</i>.
 
         The new types are:
 
@@ -392,10 +414,13 @@ For semantic clarity, common parameter types now have typedefs.
         \li ::bladerf_sample_rate (sample rate in samples per second;
             `unsigned int`)
         \li ::bladerf_bandwidth (bandwidth in Hz; `unsigned int`)
-        \li ::bladerf_frequency (center frequency in Hz; `uint64_t`)
+        \li ::bladerf_frequency (center frequency in Hz; now `uint64_t`,
+            was `uint32_t`)
         \li ::bladerf_timestamp (timestamp in ticks; `uint64_t`)
         \li ::bladerf_correction_value (correction value in arbitrary units;
             `int16_t`)
+
+        \see \ref relnotes_2_0_0_api_freq_uint64
     </td>
 </tr>
 <tr><td>bladerf_get_frequency()</td></tr>
@@ -697,5 +722,41 @@ interleaved in the sample buffers (currently 1 or 2).
 
 \li bladerf_sync_config()
 \li bladerf_stream()
+
+\subsection relnotes_2_0_0_ref_nomenclature Definitions for "Importance"
+
+<table>
+<tr><th>Word</th><th>Meaning</th></tr>
+<tr>
+    <td><b>Required</b></td>
+    <td>
+        This change must be performed to build code against libbladeRF 2.x.
+        Compile errors will result if you fail to do so.
+    </td>
+</tr>
+<tr>
+    <td><b>Required</b> for full compatibility</td>
+    <td>
+        This change is not required for building, but some functionality may
+        be missing or unavailable with some devices.
+
+        A Note will be included to describe the impact of not making this
+        change.
+    </td>
+</tr>
+<tr>
+    <td>Optional</td>
+    <td>
+        This change is optional, but recommended for clarity and/or future
+        compatibility.
+    </td>
+</tr>
+<tr>
+    <td>Informational</td>
+    <td>
+        This is an informational item, and no action is necessary or expected.
+    </td>
+</tr>
+</table>
 
 */

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -2,10 +2,10 @@
 
 \page relnotes_2_0_0 libbladeRF 2.0.0 Release Notes
 
-This page describes many of the changes in libbladeRF 2.0.0, our first major
-version increment in more than three years. This release adds support for the
-bladeRF Micro, and improves the API for all bladeRF products. This is also the
-first release with bindings for the Python programming language.
+This document describes many of the changes in libbladeRF 2.0.0, our first
+major version increment in more than three years. This release adds support for
+the bladeRF 2.0 "Micro," and improves the API for all bladeRF products. This
+is also the first release with bindings for the Python programming language.
 
 @attention libbladeRF 2.0.0 introduces breaking changes to the parameter lists
            for bladerf_get_frequency(), bladerf_stream(), and
@@ -32,17 +32,15 @@ https://nuand.com/forums/ to discuss this release with other bladeRF users.
 
 We attempted to minimize the changes required to make existing applications
 work with libbladeRF 2.x. However, the nature of this project required some
-changes to the API.
-
-Many of the changes can be transparently handled by compilers. However,
-applications will generally need to be recompiled and relinked to work with
-this version.
+changes to the API. Many of the changes can be transparently handled by
+compilers. However, applications will generally need to be recompiled and
+relinked to work with this version.
 
 \subsection relnotes_2_0_0_api_freq_uint64 Tuning frequencies are now uint64_t
 
 In libbladeRF 1.x, RF frequencies were specified as 32-bit `unsigned int`. To
 support the wider frequency range of the bladeRF Micro, frequencies are now
-specified as `uint64_t`, which is typedef'd as `bladerf_frequency`.
+specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 
 <table>
 <caption id="multi_row">Required actions</caption>
@@ -51,7 +49,7 @@ specified as `uint64_t`, which is typedef'd as `bladerf_frequency`.
     <td>bladerf_get_frequency()</td>
     <td><b>Required</b></td>
     <td>
-        The `frequency` parameter is now of type `bladerf_frequency*`.
+        The `frequency` parameter is now a pointer to a ::bladerf_frequency.
 
         \warning Applications using this function must be modified to pass in
                  the correct type.
@@ -61,15 +59,27 @@ specified as `uint64_t`, which is typedef'd as `bladerf_frequency`.
     <td>bladerf_set_frequency()</td>
     <td rowspan="3">Minor</td>
     <td rowspan="3">
-        The `frequency` parameter is now of type `bladerf_frequency`.
+        The `frequency` parameter is now of type ::bladerf_frequency.
 
         \note Compilers will generally implicitly cast `unsigned int` to
-              `bladerf_frequency`.
+              ::bladerf_frequency, but frequencies above `UINT32_MAX` will not
+              be available.
     </td>
 </tr>
 <tr><td>bladerf_select_band()</td></tr>
 <tr><td>bladerf_schedule_retune()</td></tr>
 </table>
+
+\remarks
+\li DO NOT be alarmed if there is a small discrepancy (a few Hz) in the value
+    returned by bladerf_get_frequency(), compared to what was requested by
+    bladerf_set_frequency().
+\li DO check bladerf_get_frequency_range() \em before using
+    bladerf_set_frequency() on a given device/channel.
+\li DO check bladerf_get_frequency() \em after doing bladerf_set_frequency(),
+    to verify that the expected frequency was achieved.
+\li DO expect bladerf_get_frequency() to return values larger than `UINT32_MAX`.
+\li DO use the ::bladerf_frequency type when possible.
 
 \subsection relnotes_2_0_0_api_stream MIMO support in streaming API
 
@@ -131,6 +141,13 @@ void configure_module_sync(bladerf_module module) {
 </tr>
 </table>
 
+\remarks
+\li DO NOT use the `BLADERF_MODULE_RX` and `BLADERF_MODULE_TX` values.
+\li DO feel free to re-implement bladerf_interleave_stream_buffer() and/or
+    bladerf_deinterleave_stream_buffer() in a more efficient fashion. These
+    are convenience functions written for clarity and portability, not
+    performance.
+
 \see \ref BLADERF_FORMAT_SC16_Q11 describes the sample interleaving format.
 \see bladerf_interleave_stream_buffer() - Interleaves contiguous blocks of
      samples in preparation for MIMO TX.
@@ -154,7 +171,7 @@ respectively.
 
 Note that some `bladerf_module` instances have been replaced with
 \ref bladerf_direction and \ref bladerf_channel_layout depending on context.
-See the \ref api_stream section elsewhere in this document.
+See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 
 <table>
 <caption id="multi_row">Required actions</caption>
@@ -165,11 +182,11 @@ See the \ref api_stream section elsewhere in this document.
     <td rowspan="27">
         Replace `bladerf_module` with \ref bladerf_channel.
 
-        Replace `BLADERF_MODULE_RX` with `BLADERF_CHANNEL_RX(0)`, or
-        generally, `BLADERF_CHANNEL_RX(channel_number)`
+        Replace `BLADERF_MODULE_RX` with BLADERF_CHANNEL_RX(0), or
+        generally, BLADERF_CHANNEL_RX(channel_number)
 
-        Replace `BLADERF_MODULE_TX` with `BLADERF_CHANNEL_TX(0)`, or
-        generally, `BLADERF_CHANNEL_TX(channel_number)`
+        Replace `BLADERF_MODULE_TX` with BLADERF_CHANNEL_TX(0), or
+        generally, BLADERF_CHANNEL_TX(channel_number)
     </td>
 </tr>
 <tr><td>bladerf_set_gain()</td></tr>
@@ -199,6 +216,14 @@ See the \ref api_stream section elsewhere in this document.
 <tr><td>bladerf_read_trigger()</td></tr>
 <tr><td>bladerf_write_trigger()</td></tr>
 </table>
+
+\remarks
+\li DO NOT use `BLADERF_MODULE_RX` or `BLADERF_MODULE_TX`.
+\li DO NOT assume the number of channels available.
+\li DO always check bladerf_get_channel_count() to determine how many channels
+    are available in a given direction.
+\li DO use the BLADERF_CHANNEL_RX(channel) and BLADERF_CHANNEL_TX(channel)
+    convenience macros.
 
 \see bladerf_get_channel_count() - Get the number of RX or TX channels
      supported by the given device.
@@ -276,6 +301,24 @@ bool is_frequency_within_range(struct bladerf *dev, bladerf_channel channel, bla
 }
 \endcode
 
+\remarks
+\li DO NOT use the legacy `BLADERF_*_{MIN,MAX}` defines or any hardcoded values
+    derived from them.
+\li DO NOT assume that the ranges will remain constant throughout operation,
+    or that they are the same for all channels.
+\li DO NOT hardcode ranges, or guess them based on the board model.
+\li DO remember that the ranges can change depending on configuration, e.g.
+    bladerf_get_gain_range() may return different values for an RX channel
+    depending on the configured center frequency.
+\li DO call `bladerf_get_*_range()` every time you need to know -- don't
+    cache it!
+\li DO test to ensure user-supplied values are valid before using them, when
+    possible.
+\li DO handle \ref BLADERF_ERR_RANGE errors when setting values, especially if
+    you don't check for validity first. The library will only return this if
+    it is not sensible to clamp the value to be within range, e.g. with
+    bladerf_set_sample_rate().
+
 \see bladerf_get_gain_stages() - Get a list of available gain stages.
 \see bladerf_set_gain() - Set overall system gain.
 \see bladerf_get_gain() - Get overall system gain.
@@ -315,6 +358,18 @@ As well as:
 
 \li struct bladerf_metadata
 
+\remarks
+\li DO NOT use the underlying types (e.g. `uint64_t` instead of
+    `bladerf_frequency`) if it can be avoided.
+\li DO use these typedefs whereever possible! They exist to make implementation
+    easier.
+
+\todo
+<a class="el" href="https://github.com/Nuand/bladeRF/issues/577">Issue #577</a>:
+Using `printf()` with a ::bladerf_frequency or ::bladerf_timestamp currently
+require knowing that they are actually `uint64_t`, e.g.
+`printf("the frequency is %" PRIu64 " Hz\n", freq);`.
+
 \section relnotes_2_0_0_feats New features
 
 \subsection relnotes_2_0_0_feats_platform Multiple platform support
@@ -343,7 +398,7 @@ and `streaming/` (sample streaming code).
 
 \subsection relnotes_2_0_0_feats_gc Gain control improvements
 
-The original manual gain control functionality in libbladeRF is very low-level
+The original manual gain control functionality in libbladeRF was very low-level
 and hardware-specific, and requires significant knowledge of the underlying
 RF module to adjust. As such, new gain control methods have been introduced
 to the API, and the following functions are now deprecated:
@@ -354,7 +409,7 @@ to the API, and the following functions are now deprecated:
 \li bladerf_set_txvga1() and bladerf_get_txvga1()
 \li bladerf_set_txvga2() and bladerf_get_txvga2()
 
-Instead, applications should use one of the following approaches:
+Instead, applications should use one of approaches described below.
 
 \subsubsection relnotes_2_0_0_feats_gc_agc Automatic Gain Control (AGC)
 
@@ -468,6 +523,8 @@ gain_example(dev, BLADERF_CHANNEL_TX(0), 60);  // set 60 dB TX gain (~ 0 dBm)
 gain_example(dev, BLADERF_CHANNEL_RX(0), 60);  // set 60 dB RX gain (max)
 \endcode
 
+\see bladerf_get_rfic_rssi() - query received signal strength from the RFIC.
+
 \subsubsection relnotes_2_0_0_feats_gc_manual Individual gain stage control
 
 Advanced implementations that need to directly configure the gain stages may
@@ -490,8 +547,59 @@ use the following family of functions:
 \note The range returned by bladerf_get_gain_stage_range() may vary depending
       on the selected center frequency.
 
-\subsection relnotes_2_0_0_feats_mimo MIMO
+\subsection relnotes_2_0_0_feats_hw New hardware features
 
-\subsection relnotes_2_0_0_feats_python Python bindings
+libbladeRF 2.0 includes support for new hardware features on the bladeRF Micro.
+
+\subsubsection relnotes_2_0_0_feats_hw_biastee Bias tees
+
+The bias tees apply a +5 VDC bias to the SMA connectors, which may be used
+for powering active antennas or inline amplifiers.
+
+\warning Enabling the bias tee on one channel enables it for all channels in
+         that direction; e.g. enabling RX1 will enable both RX1 and RX2
+         simultaneously. Use caution if there are multiple devices attached
+         to the bladeRF Micro.
+
+\see bladerf_get_bias_tee() and bladerf_set_bias_tee()
+
+\subsubsection relnotes_2_0_0_feats_hw_clock Clock references and controls
+
+An external frequency reference may be connected to the J95 U.FL connector
+("REFIN") to discipline the onboard VCTCXO. By default, this port expects
+10 MHz, but it can be configured for reference frequencies between 5 MHz and
+300 MHz.
+
+\see bladerf_get_pll_enable(), bladerf_set_pll_enable() - enabling the PLL
+\see bladerf_get_pll_lock_state() - verifying PLL lock
+\see bladerf_get_pll_refclk_range(), bladerf_get_pll_refclk(),
+     bladerf_set_pll_refclk() - configure reference clock frequency
+
+Alternatively, a 38.4 MHz clock may be provided into the CLKIN port.
+
+\see bladerf_get_clock_select(), bladerf_set_clock_select() - select between
+     internal and external (J93) clock
+
+There is also a CLKOUT port, which can provide a buffered 38.4 MHz system clock
+output.
+
+\see bladerf_get_clock_output(), bladerf_set_clock_output() - enable or disable
+     clock output (J92)
+
+\subsubsection relnotes_2_0_0_feats_hw_power Power status
+
+Functions are provided to determine how the board is currently being powered,
+what the bus voltage is, and what the system current and power draws are.
+
+\see bladerf_get_power_source() - query how the board is currently powered
+\see bladerf_get_pmic_register() - get bus voltage, load current, load power
+
+\subsubsection relnotes_2_0_0_feats_hw_temperature RFIC temperature
+
+The RFIC has an onboard temperature sensor, which may be useful for
+environmental monitoring, or for determining if the RFIC's synthesizers should
+be retuned after a significant temperature shift.
+
+\see bladerf_get_rfic_temperature()
 
 */

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -18,7 +18,7 @@ is also the first release with bindings for the Python programming language.
 We are very excited to release this library alongside the new bladeRF Micro.
 libbladeRF 2.0.0 began as a fork of the bladeRF codebase in February 2017.
 Across the FPGA, firmware, and host software trees, four engineers added
-95,000+ lines (and deleted 18,000+) to the bladeRF codebase, in more than 600
+105,000+ lines (and deleted 20,000+) to the bladeRF codebase, in more than 700
 commits.
 
 Inevitably, there will be bugs or missing features. Please use our issue
@@ -71,15 +71,15 @@ specified as `uint64_t`, which is typedef'd as ::bladerf_frequency.
 </table>
 
 \remarks
-\li DO NOT be alarmed if there is a small discrepancy (a few Hz) in the value
+\li Don't be alarmed if there is a small discrepancy (a few Hz) in the value
     returned by bladerf_get_frequency(), compared to what was requested by
     bladerf_set_frequency().
-\li DO check bladerf_get_frequency_range() \em before using
+\li Do check bladerf_get_frequency_range() \em before using
     bladerf_set_frequency() on a given device/channel.
-\li DO check bladerf_get_frequency() \em after doing bladerf_set_frequency(),
+\li Do check bladerf_get_frequency() \em after doing bladerf_set_frequency(),
     to verify that the expected frequency was achieved.
-\li DO expect bladerf_get_frequency() to return values larger than `UINT32_MAX`.
-\li DO use the ::bladerf_frequency type when possible.
+\li Do expect bladerf_get_frequency() to return values larger than `UINT32_MAX`.
+\li Do use the ::bladerf_frequency type when possible.
 
 \subsection relnotes_2_0_0_api_stream MIMO support in streaming API
 
@@ -142,8 +142,8 @@ void configure_module_sync(bladerf_module module) {
 </table>
 
 \remarks
-\li DO NOT use the `BLADERF_MODULE_RX` and `BLADERF_MODULE_TX` values.
-\li DO feel free to re-implement bladerf_interleave_stream_buffer() and/or
+\li Don't use the `BLADERF_MODULE_RX` and `BLADERF_MODULE_TX` values.
+\li Do feel free to re-implement bladerf_interleave_stream_buffer() and/or
     bladerf_deinterleave_stream_buffer() in a more efficient fashion. These
     are convenience functions written for clarity and portability, not
     performance.
@@ -219,11 +219,11 @@ See the \ref relnotes_2_0_0_api_stream section elsewhere in this document.
 </table>
 
 \remarks
-\li DO NOT use `BLADERF_MODULE_RX` or `BLADERF_MODULE_TX`.
-\li DO NOT assume the number of channels available.
-\li DO always check bladerf_get_channel_count() to determine how many channels
+\li Don't use `BLADERF_MODULE_RX` or `BLADERF_MODULE_TX`.
+\li Don't assume the number of channels available.
+\li Do always check bladerf_get_channel_count() to determine how many channels
     are available in a given direction.
-\li DO use the BLADERF_CHANNEL_RX(channel) and BLADERF_CHANNEL_TX(channel)
+\li Do use the BLADERF_CHANNEL_RX(channel) and BLADERF_CHANNEL_TX(channel)
     convenience macros.
 
 \see \ref relnotes_2_0_0_ref_channels
@@ -304,19 +304,19 @@ bool is_frequency_within_range(struct bladerf *dev, bladerf_channel channel, bla
 \endcode
 
 \remarks
-\li DO NOT use the legacy `BLADERF_*_{MIN,MAX}` defines or any hardcoded values
+\li Don't use the legacy `BLADERF_*_{MIN,MAX}` defines or any hardcoded values
     derived from them.
-\li DO NOT assume that the ranges will remain constant throughout operation,
+\li Don't assume that the ranges will remain constant throughout operation,
     or that they are the same for all channels.
-\li DO NOT hardcode ranges, or guess them based on the board model.
-\li DO remember that the ranges can change depending on configuration, e.g.
+\li Don't hardcode ranges, or guess them based on the board model.
+\li Do remember that the ranges can change depending on configuration, e.g.
     bladerf_get_gain_range() may return different values for an RX channel
     depending on the configured center frequency.
-\li DO call `bladerf_get_*_range()` every time you need to know -- don't
+\li Do call `bladerf_get_*_range()` every time you need to know -- don't
     cache it!
-\li DO test to ensure user-supplied values are valid before using them, when
+\li Do test to ensure user-supplied values are valid before using them, when
     possible.
-\li DO handle \ref BLADERF_ERR_RANGE errors when setting values, especially if
+\li Do handle \ref BLADERF_ERR_RANGE errors when setting values, especially if
     you don't check for validity first. The library will only return this if
     it is not sensible to clamp the value to be within range, e.g. with
     bladerf_set_sample_rate().
@@ -361,9 +361,9 @@ As well as:
 \li struct bladerf_metadata
 
 \remarks
-\li DO NOT use the underlying types (e.g. `uint64_t` instead of
+\li Don't use the underlying types (e.g. `uint64_t` instead of
     `bladerf_frequency`) if it can be avoided.
-\li DO use these typedefs whereever possible! They exist to make implementation
+\li Do use these typedefs whereever possible! They exist to make implementation
     easier.
 
 \todo
@@ -609,8 +609,7 @@ be retuned after a significant temperature shift.
 \subsubsection relnotes_2_0_0_ref_channels What is a channel?
 
 In the bladeRF architecture, a channel is a single, unidirectional RF path.
-There is generally a 1:1 mapping between a ::bladerf_channel and a physical
-RF port.
+There is a 1:1 mapping between a ::bladerf_channel and a physical RF port.
 
 On the original bladeRF, there are two channels available:
 
@@ -626,6 +625,7 @@ On the bladeRF Micro, there are four channels available:
 \li BLADERF_CHANNEL_TX(1) == J4 "TX2"
 
 Generally speaking, you will want to apply settings to a specific channel.
+
 Note that some groups of channels may share some settings on some hardware: for
 example, if you bladerf_set_frequency() on a bladeRF Micro's
 BLADERF_CHANNEL_RX(0), it will also change the frequency of

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -2,11 +2,6 @@
 
 \page relnotes_2_0_0 libbladeRF 2.0.0 Release Notes
 
-This document describes many of the changes in libbladeRF 2.0.0, our first
-major version increment in more than three years. This release adds support for
-the bladeRF 2.0 "Micro," and improves the API for all bladeRF products. This
-is also the first release with bindings for the Python programming language.
-
 @attention libbladeRF 2.0.0 introduces breaking changes to the parameter lists
            for bladerf_get_frequency(), bladerf_stream(), and
            bladerf_sync_config().
@@ -17,6 +12,11 @@ is also the first release with bindings for the Python programming language.
 @attention Additionally, if you use bladerf_get_gain() and/or
            bladerf_set_gain(), be aware that the gain range for these functions
            has shifted. See \ref relnotes_2_0_0_api_gain for guidance.
+
+This document describes many of the changes in libbladeRF 2.0.0, our first
+major release in more than three years. This release adds support for the
+bladeRF 2.0 "Micro," and improves the API for all bladeRF products. This
+is also the first release with bindings for the Python programming language.
 
 We are very excited to release this library alongside the new bladeRF Micro.
 libbladeRF 2.0.0 began as a fork of the bladeRF codebase in February 2017.
@@ -116,7 +116,7 @@ multiple RF ports simultaneously.
                  in the correct type.
 
         \note Existing `bladerf_module` values are valid for SISO applications,
-              but an explicit cast is required:
+              but an explicit cast is usually required:
 ```
 void configure_module_sync(bladerf_module module) {
     // ...
@@ -147,9 +147,8 @@ void configure_module_sync(bladerf_module module) {
     <td>bladerf_sync_tx()</td>
     <td rowspan="1">Informational</td>
     <td>
-        The `samples` parameter is now a pointer to a `const`.
-
-        This should not impact user code.
+        The `samples` parameter is now a pointer to a `const`, to enforce
+        safety. This should not impact user code.
     </td>
 </tr>
 </table>

--- a/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/relnotes_2_0_0.dox
@@ -14,6 +14,9 @@ is also the first release with bindings for the Python programming language.
            compatible with this version. See the
            \ref relnotes_2_0_0_api_freq_uint64 and
            \ref relnotes_2_0_0_api_stream sections for guidance.
+@attention Additionally, if you use bladerf_get_gain() and/or
+           bladerf_set_gain(), be aware that the gain range for these functions
+           has shifted. See \ref relnotes_2_0_0_api_gain for guidance.
 
 We are very excited to release this library alongside the new bladeRF Micro.
 libbladeRF 2.0.0 began as a fork of the bladeRF codebase in February 2017.
@@ -372,6 +375,29 @@ Using `printf()` with a ::bladerf_frequency or ::bladerf_timestamp currently
 require knowing that they are actually `uint64_t`, e.g.
 `printf("the frequency is %" PRIu64 " Hz\n", freq);`.
 
+\subsection relnotes_2_0_0_api_gain bladerf_{get,set}_gain range shift
+
+Previously, the ranges used by bladerf_get_gain() and bladerf_set_gain() were
+somewhat arbitrary, with a value of 0 being the minimum possible gain, and
+the maximum possible gain being the sum of the max gain for all gain stages.
+
+To allow the same gain settings to produce similar results on all bladeRF
+models, we've standardized the gain ranges for these two functions as follows:
+
+\li RX Gain: 60 dB is the maximum available gain
+\li TX Gain: 60 dB is \em approximately +0 dBm CW output power
+
+This only affects bladerf_set_gain() and bladerf_get_gain(); individual gain
+stages (bladerf_set_gain_stage() and bladerf_get_gain_stage()) still expect
+raw hardware-specific values.
+
+\note The TX Gain is \em not calibrated, and the actual output power will vary
+      from board to board, frequency to frequency, and even between different
+      output ports on the same board. Applications requiring precise control
+      of TX power should consider calibration.
+
+\see \ref relnotes_2_0_0_feats_gc_proportioning
+
 \section relnotes_2_0_0_feats New features
 
 \subsection relnotes_2_0_0_feats_platform Multiple platform support
@@ -470,7 +496,7 @@ void agc_example(struct bladerf *dev, bladerf_channel channel)
 }
 \endcode
 
-\subsubsection relnotes_2_0_0_feats_gc_auto System gain proportioning
+\subsubsection relnotes_2_0_0_feats_gc_proportioning System gain proportioning
 
 In previous versions, setting the gain required careful proportioning of gain
 between LNAs and VGAs. To reduce the implementation burden, an overall gain may
@@ -604,9 +630,9 @@ be retuned after a significant temperature shift.
 
 \see bladerf_get_rfic_temperature()
 
-\subsection relnotes_2_0_0_ref Further information
+\section relnotes_2_0_0_ref Further information
 
-\subsubsection relnotes_2_0_0_ref_channels What is a channel?
+\subsection relnotes_2_0_0_ref_channels What is a channel?
 
 In the bladeRF architecture, a channel is a single, unidirectional RF path.
 There is a 1:1 mapping between a ::bladerf_channel and a physical RF port.

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -2337,7 +2337,7 @@ int CALL_CONV bladerf_enable_module(struct bladerf *dev,
  *
  * @param       dev         Device handle
  * @param[in]   dir         Stream direction
- * @param[out]  value       Coarse timestamp value
+ * @param[out]  timestamp   Coarse timestamp value
  *
  * @return 0 on success, value from \ref RETCODES list on failure
  */


### PR DESCRIPTION
Updates the release notes for v2.0 to include more useful information, less useless information, and fewer typos.  More consistent and readable, hopefully.

Also fixes one error in the documentation in libbladeRF.h.