### PR TITLE
host: add nanosleep shim for Windows

### DIFF
--- a/host/common/include/windows/nanosleep.h
+++ b/host/common/include/windows/nanosleep.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #ifndef WIN32
-#   error "This file is intended for use with WIN32 systems only."
+#error "This file is intended for use with WIN32 systems only."
 #endif
 
 int nanosleep(const struct timespec *req, struct timespec *rem);

--- a/host/common/include/windows/nanosleep.h
+++ b/host/common/include/windows/nanosleep.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (c) 2018 Nuand LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef WIN_NANOSLEEP_H_
+#define WIN_NANOSLEEP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WIN32
+#   error "This file is intended for use with WIN32 systems only."
+#endif
+
+int nanosleep(const struct timespec *req, struct timespec *rem);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif

--- a/host/common/src/windows/nanosleep.c
+++ b/host/common/src/windows/nanosleep.c
@@ -23,17 +23,18 @@
  * THE SOFTWARE.
  */
 #ifndef WIN32
-#   error "This file is intended for use with WIN32 systems only."
+#error "This file is intended for use with WIN32 systems only."
 #endif
 
-#include <windows.h>
 #include "nanosleep.h"
+#include <pthread.h>
+#include <windows.h>
 
 int nanosleep(const struct timespec *req, struct timespec *rem)
 {
     DWORD sleep_ms;
 
-    sleep_ms = (req->tv_sec * 1e6) + (req->tv_nsec / 1e3);
+    sleep_ms = ((DWORD)req->tv_sec * 1000000) + ((DWORD)req->tv_nsec / 1000);
 
     Sleep(sleep_ms);
 

--- a/host/common/src/windows/nanosleep.c
+++ b/host/common/src/windows/nanosleep.c
@@ -34,7 +34,7 @@ int nanosleep(const struct timespec *req, struct timespec *rem)
 {
     DWORD sleep_ms;
 
-    sleep_ms = ((DWORD)req->tv_sec * 1000000) + ((DWORD)req->tv_nsec / 1000);
+    sleep_ms = ((DWORD)req->tv_sec * 1000) + ((DWORD)req->tv_nsec / 1000000);
 
     Sleep(sleep_ms);
 

--- a/host/common/src/windows/nanosleep.c
+++ b/host/common/src/windows/nanosleep.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (c) 2018 Nuand LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef WIN32
+#   error "This file is intended for use with WIN32 systems only."
+#endif
+
+#include <windows.h>
+#include "nanosleep.h"
+
+int nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    DWORD sleep_ms;
+
+    sleep_ms = (req->tv_sec * 1e6) + (req->tv_nsec / 1e3);
+
+    Sleep(sleep_ms);
+
+    return 0;
+}

--- a/host/utilities/bladeRF-cli/CMakeLists.txt
+++ b/host/utilities/bladeRF-cli/CMakeLists.txt
@@ -225,6 +225,7 @@ if(MSVC)
     set(BLADERF_CLI_SOURCE ${BLADERF_CLI_SOURCE}
             ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/getopt_long.c
             ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/clock_gettime.c
+            ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/nanosleep.c
             ${BLADERF_HOST_COMMON_SOURCE_DIR}/windows/setenv.c
     )
 endif()

--- a/host/utilities/bladeRF-cli/src/cmd/printset_hardware.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset_hardware.c
@@ -20,7 +20,12 @@
 #include "cmd.h"
 #include "printset.h"
 #include <inttypes.h>
+
+#if BLADERF_OS_WINDOWS
+#include "nanosleep.h"
+#else
 #include <time.h>
+#endif
 
 /* hardware */
 static void _print_rfic(struct cli_state *state)


### PR DESCRIPTION
Windows does not have nanosleep(), so this PR emulates it with a wrapper that calls Sleep().