### PR TITLE
bladeRF-cli: Add libedit support

### DIFF
--- a/host/cmake/modules/FindLibEdit.cmake
+++ b/host/cmake/modules/FindLibEdit.cmake
@@ -1,0 +1,36 @@
+if(DEFINED __INCLUDED_BLADERF_FINDLIBEDIT_CMAKE)
+    return()
+endif()
+set(__INCLUDED_BLADERF_FINDLIBEDIT_CMAKE TRUE)
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(LIBEDIT_PKG libedit QUIET)
+endif(PKG_CONFIG_FOUND)
+
+if(NOT LIBEDIT_FOUND)
+  find_path(LIBEDIT_INCLUDE_DIR NAMES histedit.h
+    PATHS
+    ${LIBEDIT_PKG_INCLUDE_DIRS}
+    /usr/include
+    /usr/local/include
+  )
+
+  find_library(LIBEDIT_LIBRARIES NAMES edit
+    PATHS
+    ${LIBEDIT_PKG_LIBRARY_DIRS}
+    /usr/lib
+    /usr/local/lib
+  )
+
+if(LIBEDIT_INCLUDE_DIR AND LIBEDIT_LIBRARIES)
+  set(LIBEDIT_FOUND TRUE CACHE INTERNAL "libedit found")
+  message(STATUS "Found libedit: ${LIBEDIT_INCLUDE_DIR}, ${LIBEDIT_LIBRARIES}")
+else(LIBEDIT_INCLUDE_DIR AND LIBEDIT_LIBRARIES)
+  set(LIBEDIT_FOUND FALSE CACHE INTERNAL "libedit found")
+  message(STATUS "libedit not found.")
+endif(LIBEDIT_INCLUDE_DIR AND LIBEDIT_LIBRARIES)
+
+mark_as_advanced(LIBEDIT_INCLUDE_DIR LIBEDIT_LIBRARIES)
+
+endif(NOT LIBEDIT_FOUND)

--- a/host/common/src/parse.c
+++ b/host/common/src/parse.c
@@ -159,6 +159,7 @@ int str2args(const char *line, char comment_char, char ***argv)
      * be closed */
     if (in_arg) {
         if (quote_char) {
+            free_args(argc, rv);
             return -2;
         } else {
             argc++;

--- a/host/utilities/bladeRF-cli/CMakeLists.txt
+++ b/host/utilities/bladeRF-cli/CMakeLists.txt
@@ -26,6 +26,7 @@ configure_file(
 # Build dependencies
 ################################################################################
 find_package(LibTecla)
+find_package(LibEdit)
 
 if(MSVC)
     find_package(LibPThreadsWin32 REQUIRED)
@@ -47,8 +48,10 @@ endif()
 ################################################################################
 
 option(ENABLE_LIBTECLA
-        "Enable the use of libtecla, if available."
-        ${LIBTECLA_FOUND})
+        "Enable the use of libtecla, if available.")
+
+option(ENABLE_LIBEDIT
+        "Enable the use of libtecla, if available.")
 
 option(BUILD_BLADERF_CLI_DOCUMENTATION
         "Build bladeRF-cli man page. Requires help2man."
@@ -72,8 +75,12 @@ if(ENABLE_LIBTECLA)
         message(FATAL_ERROR "ENABLE_LIBTECLA was forced ON, but libtecla "
                 "cannot be found!")
     endif()
-
-    message(STATUS "libtecla support enabled")
+endif()
+if(ENABLE_LIBEDIT)
+    if((NOT LIBEDIT_INCLUDE_DIR) OR (NOT LIBEDIT_LIBRARIES))
+        message(FATAL_ERROR "ENABLE_LIBEDIT was forced ON, but editline "
+                "cannot be found!")
+    endif()
 endif()
 
 ################################################################################
@@ -147,8 +154,16 @@ if(MSVC)
 endif()
 
 
-if(ENABLE_LIBTECLA)
+message(STATUS "libtecla ${ENABLE_LIBTECLA} ${LIBTECLA_FOUND}")
+message(STATUS "libedit ${ENABLE_LIBEDIT} ${LIBEDIT_FOUND}")
+if(ENABLE_LIBTECLA OR (LIBTECLA_FOUND AND NOT ENABLE_LIBEDIT))
+    message(STATUS "libtecla support enabled")
+    set(ENABLE_LIBTECLA ON)
     set(CLI_INCLUDE_DIRS ${CLI_INCLUDE_DIRS} ${LIBTECLA_INCLUDE_DIR})
+elseif(ENABLE_LIBEDIT OR LIBEDIT_FOUND)
+    message(STATUS "editline support enabled")
+    set(ENABLE_LIBEDIT ON)
+    set(CLI_INCLUDE_DIRS ${CLI_INCLUDE_DIRS} ${LIBEDIT_INCLUDE_DIR})
 endif()
 
 if(MSVC)
@@ -217,6 +232,8 @@ set(BLADERF_CLI_SOURCE
 # Select the input mode (and script handling) backend
 if(ENABLE_LIBTECLA)
     set(BLADERF_CLI_SOURCE ${BLADERF_CLI_SOURCE} src/input/tecla.c)
+elseif(ENABLE_LIBEDIT)
+    set(BLADERF_CLI_SOURCE ${BLADERF_CLI_SOURCE} src/input/editline.c)
 else()
     set(BLADERF_CLI_SOURCE ${BLADERF_CLI_SOURCE} src/input/fgets.c)
 endif()
@@ -258,7 +275,8 @@ if(ENABLE_LIBTECLA)
     if(CMAKE_HOST_APPLE)
         set(CLI_LINK_LIBRARIES ${CLI_LINK_LIBRARIES} ncurses)
     endif(CMAKE_HOST_APPLE)
-
+elseif(ENABLE_LIBEDIT)
+    set(CLI_LINK_LIBRARIES ${CLI_LINK_LIBRARIES} ${LIBEDIT_LIBRARIES})
 endif(ENABLE_LIBTECLA)
 
 if(LIBPTHREADSWIN32_FOUND)

--- a/host/utilities/bladeRF-cli/src/input/editline.c
+++ b/host/utilities/bladeRF-cli/src/input/editline.c
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the bladeRF project
+ *
+ * Copyright (C) 2013 Nuand LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <histedit.h>
+#include <editline/readline.h>
+#include <string.h>
+#include <errno.h>
+#include "input_impl.h"
+
+EditLine *el = NULL;
+History *hist = NULL;
+char *last_line = NULL;
+
+static char* bladerf_prompt(EditLine *el) {
+    static char prompt[] = CLI_DEFAULT_PROMPT;
+    return prompt;
+}
+
+int input_init()
+{
+    HistEvent ev;
+    input_deinit();
+    el = el_init("bladeRF-cli", stdin, stdout, stderr);
+    hist = history_init();
+    if (el && hist) {
+        if (history(hist, &ev, H_SETSIZE, CLI_MAX_HIST_LEN) < 0 ||
+            el_set(el, EL_PROMPT, bladerf_prompt) ||
+            el_set(el, EL_HIST, history, hist)) {
+            input_deinit();
+            return CLI_RET_UNKNOWN;
+        }
+        return 0;
+    } else {
+        input_deinit();
+        return CLI_RET_UNKNOWN;
+    }
+}
+
+void input_deinit()
+{
+    if (last_line) {
+        free(last_line);
+        last_line = NULL;
+    }
+    if (el) {
+        el_end(el);
+    }
+    if (hist) {
+        history_end(hist);
+    }
+}
+
+char * input_get_line(const char *prompt)
+{
+    int count;
+    const char *ret = NULL;
+    HistEvent ev;
+
+    if (last_line) {
+        free(last_line);
+    }
+
+    ret = el_gets(el, &count);
+
+    if (ret && count > 0 && count < CLI_MAX_LINE_LEN) {
+        if (history(hist, &ev, H_ENTER, ret) < 0) {
+            fprintf(stderr, "%d - %s\n", ev.num, ev.str);
+        }
+        last_line = strdup(ret);
+    } else {
+        last_line = NULL;
+    }
+
+    return last_line;
+}
+
+int input_set_input(FILE *file)
+{
+    if (el_set(el, EL_SETFP, 0, file)) {
+        return CLI_RET_UNKNOWN;
+    }
+    return 0;
+}
+
+char * input_expand_path(const char *path)
+{
+    return strdup(path);
+}
+
+void input_clear_terminal()
+{
+    fprintf(stderr, "editline backend does not currently support clear\n");
+}
+
+/* Nothing to do here, libedit handles the signal if we're in a call */
+void input_ctrlc(void)
+{
+}


### PR DESCRIPTION
 * Add libedit support to the bladeRF-cli utility
   * Add a libedit input backend
   * Allow the build system to be configured to link to libedit
     * Add FindLibEdit cmake module
     * Update bladeRF-cli build to use libedit if ENABLE_LIBEDIT is set or
       libedit is found and libtecla is not
 * Fix memory leak when a unterminated quoted string is given in
   interactive mode

Fixes: #319 