### PR TITLE
bladerf2: Support sample rates down to 0.521 Msps (#581)

### DIFF
--- a/host/libraries/libbladeRF/include/bladeRF2.h
+++ b/host/libraries/libbladeRF/include/bladeRF2.h
@@ -167,6 +167,80 @@ int CALL_CONV bladerf_get_rfic_rssi(struct bladerf *dev,
 API_EXPORT
 int CALL_CONV bladerf_get_rfic_ctrl_out(struct bladerf *dev, uint8_t *ctrl_out);
 
+/**
+ * RFIC RX FIR filter choices
+ */
+typedef enum {
+    BLADERF_RFIC_RXFIR_BYPASS, /**< No filter */
+    BLADERF_RFIC_RXFIR_CUSTOM, /**< Custom FIR filter (currently unused) */
+    BLADERF_RFIC_RXFIR_DEC1,   /**< Decimate by 1 (default) */
+    BLADERF_RFIC_RXFIR_DEC2,   /**< Decimate by 2 */
+    BLADERF_RFIC_RXFIR_DEC4,   /**< Decimate by 4 */
+} bladerf_rfic_rxfir;
+
+#define BLADERF_RFIC_RXFIR_DEFAULT BLADERF_RFIC_RXFIR_DEC1
+
+/**
+ * RFIC TX FIR filter choices
+ */
+typedef enum {
+    BLADERF_RFIC_TXFIR_BYPASS, /**< No filter (default) */
+    BLADERF_RFIC_TXFIR_CUSTOM, /**< Custom FIR filter (currently unused) */
+    BLADERF_RFIC_TXFIR_INT1,   /**< Interpolate by 1 */
+    BLADERF_RFIC_TXFIR_INT2,   /**< Interpolate by 2 */
+    BLADERF_RFIC_TXFIR_INT4,   /**< Interpolate by 4 */
+} bladerf_rfic_txfir;
+
+#define BLADERF_RFIC_TXFIR_DEFAULT BLADERF_RFIC_TXFIR_BYPASS
+
+/**
+ * Get the current status of the RX FIR filter on the RFIC.
+ *
+ * @param   dev     Device handle
+ * @param   rxfir   RX FIR selection
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_rfic_rx_fir(struct bladerf *dev,
+                                      bladerf_rfic_rxfir *rxfir);
+
+/**
+ * Set the RX FIR filter on the RFIC.
+ *
+ * @param   dev     Device handle
+ * @param   rxfir   RX FIR selection
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_set_rfic_rx_fir(struct bladerf *dev,
+                                      bladerf_rfic_rxfir rxfir);
+
+/**
+ * Get the current status of the TX FIR filter on the RFIC.
+ *
+ * @param   dev     Device handle
+ * @param   txfir   TX FIR selection
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_rfic_tx_fir(struct bladerf *dev,
+                                      bladerf_rfic_txfir *txfir);
+
+/**
+ * Set the TX FIR filter on the RFIC.
+ *
+ * @param   dev     Device handle
+ * @param   txfir   TX FIR selection
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_set_rfic_tx_fir(struct bladerf *dev,
+                                      bladerf_rfic_txfir txfir);
+
 /** @} (End of FN_BLADERF2_LOW_LEVEL_RFIC) */
 
 /**

--- a/host/libraries/libbladeRF/src/board/bladerf2/params.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/params.c
@@ -584,4 +584,132 @@ AD9361_TXFIRConfig ad9361_init_tx_fir_config_int2 = {
     0                   // tx_bandwidth
 };
 
+AD9361_RXFIRConfig ad9361_init_rx_fir_config_dec4 = {
+    3,  // rx (RX1 = 1, RX2 = 2, both = 3)
+    -6, // rx_gain (-12, -6, 0, or 6 dB)
+    4,  // rx_dec (decimate by 1, 2, or 4)
+
+    /**
+     * RX FIR Filter
+     * Built using https://github.com/analogdevicesinc/libad9361-iio
+     * Branch: filter_generation
+     * Commit: f749cef974f687f696226455dc7684277886cf3b
+     *
+     * This filter is intended to allow sample rates down to 520834 sps.
+     *
+     * It is a 128-tap, decimate-by-4 filter. Note that you MUST use a
+     * interpolate-by-4 filter on TX if you are using this filter.
+     *
+     * Design parameters:
+     *
+     * fdp.Rdata = 520834;
+     * fdp.RxTx = "Rx";
+     * fdp.Type = "Lowpass";
+     * fdp.DAC_div = 1;
+     * fdp.HB3 = 3;
+     * fdp.HB2 = 2;
+     * fdp.HB1 = 2;
+     * fdp.FIR = 4;
+     * fdp.PLL_mult = 32;
+     * fdp.converter_rate = 25000000;
+     * fdp.PLL_rate = 800000000;
+     * fdp.Fpass = fdp.Rdata*0.375;
+     * fdp.Fstop = fdp.Rdata*0.50;
+     * fdp.Fcenter = 0;
+     * fdp.Apass = 0.125;
+     * fdp.Astop = 85;
+     * fdp.phEQ = 217;
+     * fdp.wnom = 347220;
+     * fdp.caldiv = 309;
+     * fdp.RFbw = 433256;
+     * fdp.FIRdBmin = 0;
+     * fdp.int_FIR = 1;
+     */
+    {
+        -30,    -24,    -46,    -54,    -28,     -6,     50,     82,
+        108,     84,     28,    -60,   -136,   -172,   -132,    -24,
+        122,    244,    280,    192,     -2,   -238,   -410,   -428,
+       -250,     80,    436,    656,    614,    276,   -252,   -760,
+      -1006,   -830,   -234,    580,   1272,   1494,   1060,     48,
+      -1178,  -2086,  -2192,  -1284,    420,   2296,   3504,   3324,
+       1502,  -1544,  -4746,  -6664,  -5978,  -1984,   5054,  13852,
+      22416,  28606,  30790,  28370,  21974,  13264,   4422,  -2522,
+      -6282,  -6630,  -4358,   -892,   2236,   3914,   3762,   2144,
+        -80,  -1948,  -2774,  -2376,  -1078,    486,   1652,   2008,
+       1510,    466,   -640,  -1352,  -1434,   -928,   -110,    652,
+       1060,    990,    532,    -82,   -586,   -792,   -654,   -274,
+        164,    480,    562,    410,    118,   -178,   -362,   -378,
+       -244,    -34,    154,    256,    240,    136,     -4,   -116,
+       -168,   -144,    -74,     14,     74,    102,     76,     38,
+        -28,    -54,    -96,    -68,    -82,    -26,    -34,     -2,
+    },                  // rx_coef[128]
+    128,                // rx_coef_size
+    {0, 0, 0, 0, 0, 0}, // rx_path_clks[6]
+    0                   // rx_bandwidth
+};
+
+AD9361_TXFIRConfig ad9361_init_tx_fir_config_int4 = {
+    3,  // tx (TX1 = 1, TX2 = 2, both = 3)
+    0,  // tx_gain (-6 or 0 dB)
+    4,  // tx_int (interpolate by 1, 2, or 4)
+
+    /**
+     * TX FIR Filter
+     * Built using https://github.com/analogdevicesinc/libad9361-iio
+     * Branch: filter_generation
+     * Commit: f749cef974f687f696226455dc7684277886cf3b
+     *
+     * This filter is intended to allow sample rates down to 520834 sps.
+     *
+     * It is a 128-tap, interpolate-by-4 filter. Note that you MUST use a
+     * decimate-by-4 filter on RX if you are using this filter.
+     *
+     * Design parameters:
+     *
+     * fdp.Rdata = 520834;
+     * fdp.RxTx = "Tx";
+     * fdp.Type = "Lowpass";
+     * fdp.DAC_div = 1;
+     * fdp.HB3 = 3;
+     * fdp.HB2 = 2;
+     * fdp.HB1 = 2;
+     * fdp.FIR = 4;
+     * fdp.PLL_mult = 32;
+     * fdp.converter_rate = 25000000;
+     * fdp.PLL_rate = 800000000;
+     * fdp.Fpass = fdp.Rdata*0.375;
+     * fdp.Fstop = fdp.Rdata*0.50;
+     * fdp.Fcenter = 0;
+     * fdp.Apass = 0.125;
+     * fdp.Astop = 85;
+     * fdp.phEQ = 217;
+     * fdp.wnom = 347220;
+     * fdp.caldiv = 309;
+     * fdp.RFbw = 1253611;
+     * fdp.FIRdBmin = 0;
+     * fdp.int_FIR = 1;
+     */
+    {
+        -18,      2,    -14,     16,     34,     76,    104,    124,
+        108,     62,    -12,    -86,   -136,   -128,    -58,     58,
+        174,    242,    214,     84,   -110,   -294,   -382,   -310,
+        -84,    226,    494,    586,    426,     40,   -434,   -796,
+       -860,   -538,     92,    792,   1258,   1226,    622,   -386,
+      -1406,  -1972,  -1730,   -628,   1002,   2522,   3200,   2526,
+        466,  -2400,  -4986,  -6012,  -4444,     90,   7064,  15112,
+      22370,  27018,  27836,  24590,  18120,  10072,   2400,  -3220,
+      -5868,  -5578,  -3214,   -106,   2446,   3584,   3126,   1508,
+       -464,  -1970,  -2484,  -1940,   -696,    666,   1590,   1764,
+       1212,    244,   -706,  -1258,  -1242,   -732,     10,    656,
+        964,    850,    412,   -134,   -560,   -710,   -560,   -208,
+        178,    444,    500,    352,     88,   -172,   -330,   -336,
+       -212,    -24,    144,    230,    218,    124,      2,   -100,
+       -146,   -126,    -62,     18,     82,    110,     98,     60,
+         12,    -28,    -52,    -56,    -50,    -32,    -18,     -8,
+    },                  // tx_coef[128]
+    128,                // tx_coef_size
+    {0, 0, 0, 0, 0, 0}, // tx_path_clks[6]
+    0                   // tx_bandwidth
+};
+
 const float ina219_r_shunt = 0.001F;

--- a/host/utilities/bladeRF-cli/src/cmd/printset_hardware.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset_hardware.c
@@ -28,12 +28,50 @@
 #endif
 
 /* hardware */
+const char *_rxfir_to_str(bladerf_rfic_rxfir rxfir)
+{
+    switch (rxfir) {
+        case BLADERF_RFIC_RXFIR_BYPASS:
+            return "bypass";
+        case BLADERF_RFIC_RXFIR_CUSTOM:
+            return "custom";
+        case BLADERF_RFIC_RXFIR_DEC1:
+            return "normal";
+        case BLADERF_RFIC_RXFIR_DEC2:
+            return "2x decimation";
+        case BLADERF_RFIC_RXFIR_DEC4:
+            return "4x decimation";
+    }
+
+    return "unknown";
+}
+
+const char *_txfir_to_str(bladerf_rfic_txfir txfir)
+{
+    switch (txfir) {
+        case BLADERF_RFIC_TXFIR_BYPASS:
+            return "bypass";
+        case BLADERF_RFIC_TXFIR_CUSTOM:
+            return "custom";
+        case BLADERF_RFIC_TXFIR_INT1:
+            return "normal";
+        case BLADERF_RFIC_TXFIR_INT2:
+            return "2x interpolation";
+        case BLADERF_RFIC_TXFIR_INT4:
+            return "4x interpolation";
+    }
+
+    return "unknown";
+}
+
 static void _print_rfic(struct cli_state *state)
 {
     int status;
 
     float temperature;
     uint8_t ctrlout, reg35, reg36;
+    bladerf_rfic_rxfir rxfir;
+    bladerf_rfic_txfir txfir;
 
     /* Temperature */
     status = bladerf_get_rfic_temperature(state->dev, &temperature);
@@ -59,10 +97,23 @@ static void _print_rfic(struct cli_state *state)
         return;
     }
 
+    /* FIR filters */
+    status = bladerf_get_rfic_rx_fir(state->dev, &rxfir);
+    if (status < 0) {
+        return;
+    }
+
+    status = bladerf_get_rfic_tx_fir(state->dev, &txfir);
+    if (status < 0) {
+        return;
+    }
+
     printf("    RFIC status:\n");
     printf("      Temperature:  %4.1f °C\n", temperature);
     printf("      CTRL_OUT:     0x%02x (0x035=0x%02x, 0x036=0x%02x)\n", ctrlout,
            reg35, reg36);
+    printf("      RX FIR:       %s\n", _rxfir_to_str(rxfir));
+    printf("      TX FIR:       %s\n", _txfir_to_str(txfir));
 }
 
 static void _print_power_source_bladerf2(struct cli_state *state)


### PR DESCRIPTION
To support sample rates below ~2.1 Msps, interpolation/decimation must be enabled on the RFIC's FIR filter.  We do this by checking to see if we can achieve the current sample rate with the currently-enabled filter, and if not, we enable a 4x filter.

This PR adds:
- LPF taps for the RX and TX FIR filters
- API functions to get/set the filters
- enums for the available filters
- an entry in the RFIC status print from bladeRF-cli

Fixes #581 