### PR TITLE
libbladeRF: install doxygen docs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,18 @@ Description: Nuand bladeRF software-defined radio device (header files)
  This package contains the header files required for compiling bladeRF
  applications.
 
+Package: libbladerf-doc
+Section: doc
+Architecture: any
+Depends: ${misc:Depends}
+Description: Nuand bladeRF software-defined radio device (API documentation)
+ The Nuand bladeRF is an open-source software-defined radio (SDR) system,
+ comprised of an RF transceiver, a field-programmable gate array (FPGA),
+ a microcontroller driving a USB 3.0 interface, and a suite of host
+ libraries and drivers to facilitate interaction with the device.
+ .
+ This package contains libbladeRF API documentation.
+
 Package: libbladerf-udev
 Section: libs
 Architecture: any

--- a/debian/libbladerf-doc.docs
+++ b/debian/libbladerf-doc.docs
@@ -1,0 +1,4 @@
+COPYING
+CONTRIBUTORS
+README.md
+legal/*

--- a/debian/libbladerf-doc.install
+++ b/debian/libbladerf-doc.install
@@ -1,0 +1,1 @@
+usr/share/doc/libbladerf-doc/*

--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,7 @@ endif
 override_dh_auto_configure:
 	dh_auto_configure -- 	-DVERSION_INFO_OVERRIDE:STRING=$(VERSION_INFO_OVERRIDE) \
 							-DCMAKE_INSTALL_LIBDIR="lib/${DEB_HOST_MULTIARCH}" \
+							-DCMAKE_INSTALL_DOCDIR="share/doc/libbladerf-doc" \
 							-DENABLE_HOST_BUILD=ON \
 							-DENABLE_FX3_BUILD=OFF \
 							-DBUILD_DOCUMENTATION=ON \

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -35,6 +35,10 @@ if (NOT CMAKE_INSTALL_LIBDIR)
 include(GNUInstallDirs)
 endif (NOT CMAKE_INSTALL_LIBDIR)
 
+if (NOT CMAKE_INSTALL_DOCDIR)
+include(GNUInstallDirs)
+endif (NOT CMAKE_INSTALL_DOCDIR)
+
 # Fall back to just "lib" if the item provided by GNUInstallDirs doesn't exist
 # For example, on Ubuntu 13.10 with CMake 2.8.11.2,
 # /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE} doesn't exist.
@@ -535,6 +539,8 @@ if(BUILD_LIBBLADERF_DOCUMENTATION)
         )
 
     add_custom_target(libbladeRF-doxygen ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doc/doxygen/html/index.html)
+
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/doxygen/html/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/html)
 
     else(DOXYGEN_FOUND)
         message(FATAL_ERROR "Could not find Doxygen. Unable to build libbladeRF API documentation.")


### PR DESCRIPTION
Instead of leaving the deftly-assembled API documentation in the build/ dir, with the vast storehouse of knowledge and useful information treated as mere ephemera, this PR installs them with the rest of libbladeRF.

Also adds a debian package: libbladerf-doc