### PR TITLE
libbladeRF: adjust list of RX gain modes (#601)

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -175,16 +175,12 @@ static const struct bladerf_range bladerf1_tx_gain_range = {
 
 static const struct bladerf_gain_modes bladerf1_rx_gain_modes[] = {
     {
-        FIELD_INIT(.name, "default"),
+        FIELD_INIT(.name, "automatic"),
         FIELD_INIT(.mode, BLADERF_GAIN_DEFAULT)
     },
     {
         FIELD_INIT(.name, "manual"),
-        FIELD_INIT(.mode, BLADERF_GAIN_MANUAL)
-    },
-    {
-        FIELD_INIT(.name, "automatic"),
-        FIELD_INIT(.mode, BLADERF_GAIN_AUTOMATIC)
+        FIELD_INIT(.mode, BLADERF_GAIN_MGC)
     },
 };
 
@@ -1515,9 +1511,9 @@ static int bladerf1_get_gain_mode(struct bladerf *dev,
     }
 
     if (config_gpio & BLADERF_GPIO_AGC_ENABLE) {
-        *mode = BLADERF_GAIN_AUTOMATIC;
+        *mode = BLADERF_GAIN_DEFAULT;
     } else {
-        *mode = BLADERF_GAIN_MANUAL;
+        *mode = BLADERF_GAIN_MGC;
     }
 
     return status;

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -441,7 +441,7 @@ static const struct bladerf_gain_range bladerf2_tx_gain_ranges[] = {
 /* RX gain modes */
 static const struct bladerf_gain_modes bladerf2_rx_gain_modes[] = {
     {
-        FIELD_INIT(.name, "default"),
+        FIELD_INIT(.name, "automatic"),
         FIELD_INIT(.mode, BLADERF_GAIN_DEFAULT)
     },
     {


### PR DESCRIPTION
On the bladeRF 1, remove the redundant "automatic" setting
and rename "default" to "automatic". Also directly use
enum values instead of the reverse-compat #defines.

On the bladeRF 2, rename "default" to "automatic".

Intent: make it more clear whether the gain mode is automatic
or manual, without having to "know" that the default is automatic.

Fixes #601