### PR TITLE
bladerf1: implement bladerf_{get,set}_rf_port[s]

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -1178,67 +1178,6 @@ int CALL_CONV bladerf_get_frequency_range(struct bladerf *dev,
 /** @} (End of FN_TUNING) */
 
 /**
- * @defgroup FN_RF_PORTS RF Ports
- *
- * These functions provide the ability to select various RF ports for RX and TX
- * channels.
- *
- * These functions are thread-safe.
- *
- * @{
- */
-
-/**
- * Set the RF port
- *
- * @param       dev         Device handle
- * @param[in]   ch          Channel
- * @param[in]   port        RF port name
- *
- * @return 0 on success, value from \ref RETCODES list on failure
- */
-API_EXPORT
-int CALL_CONV bladerf_set_rf_port(struct bladerf *dev,
-                                  bladerf_channel ch,
-                                  const char *port);
-
-/**
- * Get the RF port
- *
- * @param       dev         Device handle
- * @param[in]   ch          Channel
- * @param[out]  port        RF port name
- *
- * @return 0 on success, value from \ref RETCODES list on failure
- */
-API_EXPORT
-int CALL_CONV bladerf_get_rf_port(struct bladerf *dev,
-                                  bladerf_channel ch,
-                                  const char **port);
-
-/**
- * Get available RF ports
- *
- * This function may be called with `NULL` for `ports`, or 0 for `count`, to
- * determine the number of RF ports.
- *
- * @param       dev         Device handle
- * @param[in]   ch          Channel
- * @param[out]  ports       RF port names
- * @param[out]  count       Number to populate
- *
- * @return Number of RF ports on success, value from \ref RETCODES list on
- *         failure
- */
-API_EXPORT
-int CALL_CONV bladerf_get_rf_ports(struct bladerf *dev,
-                                   bladerf_channel ch,
-                                   const char **ports,
-                                   unsigned int count);
-
-/** @} (End of FN_RF_PORTS) */
-
-/**
  * @defgroup FN_LOOPBACK Internal loopback
  *
  * The bladeRF provides a variety of loopback modes to aid in development and
@@ -3582,6 +3521,67 @@ int CALL_CONV bladerf_write_flash(struct bladerf *dev,
                                   uint32_t count);
 
 /** @} (End of FN_SPI_FLASH) */
+
+/**
+ * @defgroup FN_RF_PORTS RF Ports
+ *
+ * These functions provide the ability to select various RF ports for RX and TX
+ * channels. This is normally handled automatically.
+ *
+ * These functions are thread-safe.
+ *
+ * @{
+ */
+
+/**
+ * Set the RF port
+ *
+ * @param       dev         Device handle
+ * @param[in]   ch          Channel
+ * @param[in]   port        RF port name
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_set_rf_port(struct bladerf *dev,
+                                  bladerf_channel ch,
+                                  const char *port);
+
+/**
+ * Get the RF port
+ *
+ * @param       dev         Device handle
+ * @param[in]   ch          Channel
+ * @param[out]  port        RF port name
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_rf_port(struct bladerf *dev,
+                                  bladerf_channel ch,
+                                  const char **port);
+
+/**
+ * Get available RF ports
+ *
+ * This function may be called with `NULL` for `ports`, or 0 for `count`, to
+ * determine the number of RF ports.
+ *
+ * @param       dev         Device handle
+ * @param[in]   ch          Channel
+ * @param[out]  ports       RF port names
+ * @param[out]  count       Number to populate
+ *
+ * @return Number of RF ports on success, value from \ref RETCODES list on
+ *         failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_rf_ports(struct bladerf *dev,
+                                   bladerf_channel ch,
+                                   const char **ports,
+                                   unsigned int count);
+
+/** @} (End of FN_RF_PORTS) */
 
 /** @} (End of FN_LOW_LEVEL) */
 

--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -323,6 +323,57 @@ static const struct bladerf_loopback_modes bladerf1_loopback_modes[] = {
     },
 };
 
+/* RF ports */
+
+struct bladerf_lms_port_name_map {
+    const char *name;
+    union {
+        lms_lna rx_lna;
+        lms_pa tx_pa;
+    };
+};
+
+static const struct bladerf_lms_port_name_map bladerf1_rx_port_map[] = {
+    {
+        FIELD_INIT(.name, "none"),
+        FIELD_INIT(.rx_lna, LNA_NONE),
+    },
+    {
+        FIELD_INIT(.name, "lna1"),
+        FIELD_INIT(.rx_lna, LNA_1),
+    },
+    {
+        FIELD_INIT(.name, "lna2"),
+        FIELD_INIT(.rx_lna, LNA_2),
+    },
+    {
+        FIELD_INIT(.name, "lna3"),
+        FIELD_INIT(.rx_lna, LNA_3),
+    },
+};
+
+static const struct bladerf_lms_port_name_map bladerf1_tx_port_map[] = {
+/* TODO: TX PA control is not implemented */
+#if 0
+    {
+        FIELD_INIT(.name, "aux"),
+        FIELD_INIT(.tx_pa, PA_AUX),
+    },
+    {
+        FIELD_INIT(.name, "pa1"),
+        FIELD_INIT(.tx_pa, PA_1),
+    },
+    {
+        FIELD_INIT(.name, "pa2"),
+        FIELD_INIT(.tx_pa, PA_2),
+    },
+    {
+        FIELD_INIT(.name, "none"),
+        FIELD_INIT(.tx_pa, PA_NONE),
+    },
+#endif  // 0
+};
+
 /******************************************************************************/
 /* Low-level Initialization */
 /******************************************************************************/
@@ -1946,19 +1997,173 @@ static int bladerf1_select_band(struct bladerf *dev, bladerf_channel ch, uint64_
 /* RF ports */
 /******************************************************************************/
 
-static int bladerf1_set_rf_port(struct bladerf *dev, bladerf_channel ch, const char *port)
+static int bladerf1_set_rf_port(struct bladerf *dev,
+                                bladerf_channel ch,
+                                const char *port)
 {
-    return BLADERF_ERR_UNSUPPORTED;
+    const struct bladerf_lms_port_name_map *port_map;
+    unsigned int port_map_len;
+    int status;
+    size_t i;
+
+    lms_lna rx_lna = LNA_NONE;
+    lms_pa tx_pa   = PA_NONE;
+    bool ok        = false;
+
+    CHECK_BOARD_STATE(STATE_INITIALIZED);
+
+    /* TODO: lms_pa_enable is not currently implemented */
+    if (BLADERF_CHANNEL_IS_TX(ch)) {
+        log_debug("%s: not implemented for TX channels, silently ignoring\n",
+                  __FUNCTION__);
+        return 0;
+    }
+
+    if (BLADERF_CHANNEL_IS_TX(ch)) {
+        port_map     = bladerf1_tx_port_map;
+        port_map_len = ARRAY_SIZE(bladerf1_tx_port_map);
+    } else {
+        port_map     = bladerf1_rx_port_map;
+        port_map_len = ARRAY_SIZE(bladerf1_rx_port_map);
+    }
+
+    for (i = 0; i < port_map_len; i++) {
+        if (strcmp(port_map[i].name, port) == 0) {
+            if (BLADERF_CHANNEL_IS_TX(ch)) {
+                tx_pa = port_map[i].tx_pa;
+            } else {
+                rx_lna = port_map[i].rx_lna;
+            }
+            ok = true;
+            break;
+        }
+    }
+
+    if (!ok) {
+        log_error("port '%s' not valid for channel %s\n", port,
+                  channel2str(ch));
+        return BLADERF_ERR_INVAL;
+    }
+
+    if (BLADERF_CHANNEL_IS_TX(ch)) {
+        for (i = 0; i < port_map_len; i++) {
+            bool enable = (port_map[i].tx_pa == tx_pa);
+#if 0
+            status = lms_pa_enable(dev, port_map[i].tx_pa, enable);
+#else
+            log_verbose("%s: would %s pa %d but this is not implemented\n",
+                        __FUNCTION__, enable ? "enable" : "disable", tx_pa);
+            status = 0;
+#endif  // 0
+            if (status < 0) {
+                break;
+            }
+        }
+    } else {
+        status = lms_select_lna(dev, rx_lna);
+    }
+
+    return status;
 }
 
-static int bladerf1_get_rf_port(struct bladerf *dev, bladerf_channel ch, const char **port)
+static int bladerf1_get_rf_port(struct bladerf *dev,
+                                bladerf_channel ch,
+                                const char **port)
 {
-    return BLADERF_ERR_UNSUPPORTED;
+    const struct bladerf_lms_port_name_map *port_map;
+    unsigned int port_map_len;
+    int status;
+    size_t i;
+
+    lms_lna rx_lna = LNA_NONE;
+    lms_pa tx_pa   = PA_NONE;
+    bool ok        = false;
+
+    CHECK_BOARD_STATE(STATE_INITIALIZED);
+
+    /* TODO: pa getter not currently implemented */
+    if (BLADERF_CHANNEL_IS_TX(ch)) {
+        log_debug("%s: not implemented for TX channels\n", __FUNCTION__);
+        if (port != NULL) {
+            *port = "auto";
+        }
+        return 0;
+    }
+
+    if (BLADERF_CHANNEL_IS_TX(ch)) {
+        port_map     = bladerf1_tx_port_map;
+        port_map_len = ARRAY_SIZE(bladerf1_tx_port_map);
+
+#if 0
+        status = lms_get_pa(dev, &tx_pa);
+#else
+        status = 0;
+#endif  // 0
+    } else {
+        port_map     = bladerf1_rx_port_map;
+        port_map_len = ARRAY_SIZE(bladerf1_rx_port_map);
+
+        status = lms_get_lna(dev, &rx_lna);
+    }
+
+    if (status < 0) {
+        return status;
+    }
+
+    if (port != NULL) {
+        for (i = 0; i < port_map_len; i++) {
+            if (BLADERF_CHANNEL_IS_TX(ch)) {
+                if (tx_pa == port_map[i].tx_pa) {
+                    *port = port_map[i].name;
+                    ok    = true;
+                    break;
+                }
+            } else {
+                if (rx_lna == port_map[i].rx_lna) {
+                    *port = port_map[i].name;
+                    ok    = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!ok) {
+        *port = "unknown";
+        log_error("%s: unexpected port id %d\n", __FUNCTION__,
+                  BLADERF_CHANNEL_IS_TX(ch) ? tx_pa : rx_lna);
+        return BLADERF_ERR_UNEXPECTED;
+    }
+
+    return 0;
 }
 
-static int bladerf1_get_rf_ports(struct bladerf *dev, bladerf_channel ch, const char **ports, unsigned int count)
+static int bladerf1_get_rf_ports(struct bladerf *dev,
+                                 bladerf_channel ch,
+                                 const char **ports,
+                                 unsigned int count)
 {
-    return BLADERF_ERR_UNSUPPORTED;
+    const struct bladerf_lms_port_name_map *port_map;
+    unsigned int port_map_len;
+    size_t i;
+
+    if (BLADERF_CHANNEL_IS_TX(ch)) {
+        port_map     = bladerf1_tx_port_map;
+        port_map_len = ARRAY_SIZE(bladerf1_tx_port_map);
+    } else {
+        port_map     = bladerf1_rx_port_map;
+        port_map_len = ARRAY_SIZE(bladerf1_rx_port_map);
+    }
+
+    if (ports != NULL) {
+        count = (port_map_len < count) ? port_map_len : count;
+
+        for (i = 0; i < count; i++) {
+            ports[i] = port_map[i].name;
+        }
+    }
+
+    return port_map_len;
 }
 
 /******************************************************************************/

--- a/host/utilities/bladeRF-cli/src/cmd/printset.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset.c
@@ -130,7 +130,7 @@ struct printset_entry printset_table[] = {
     PRINTSET_ENTRY(vctcxo_tamer, PRINTALL_OPTION_APPEND_NEWLINE, BOARD_BLADERF1),
     PRINTSET_ENTRY(xb_spi,       PRINTALL_OPTION_SKIP,           BOARD_BLADERF1),
     PRINTSET_ENTRY(xb_gpio,      PRINTALL_OPTION_NONE,           BOARD_BLADERF1),
-    PRINTSET_ENTRY(xb_gpio_dir,  PRINTALL_OPTION_NONE,           BOARD_BLADERF1),
+    PRINTSET_ENTRY(xb_gpio_dir,  PRINTALL_OPTION_APPEND_NEWLINE, BOARD_BLADERF1),
     READONLY_ENTRY(hardware,     PRINTALL_OPTION_NONE,           BOARD_ANY),
 
     /* End of table marked by entry with NULL/empty fields */

--- a/host/utilities/bladeRF-cli/src/cmd/printset_hardware.c
+++ b/host/utilities/bladeRF-cli/src/cmd/printset_hardware.c
@@ -167,6 +167,26 @@ static void _print_power_monitor_bladerf2(struct cli_state *state)
     printf("    Power monitor:  %g V, %g A, %g W\n", vbus, iload, pload);
 }
 
+static void _print_rfconfig_bladerf1(struct cli_state *state)
+{
+    int status;
+    char const *rx_config, *tx_config;
+
+    status = bladerf_get_rf_port(state->dev, BLADERF_CHANNEL_RX(0), &rx_config);
+    if (status < 0) {
+        return;
+    }
+
+    status = bladerf_get_rf_port(state->dev, BLADERF_CHANNEL_TX(0), &tx_config);
+    if (status < 0) {
+        return;
+    }
+
+    printf("    RF routing:\n");
+    printf("      TX: %s\n", tx_config);
+    printf("      RX: %s\n", rx_config);
+}
+
 static char const *_rfic_rx_portstr(uint32_t port)
 {
     const char *pstrs[] = { "A_BAL",  "B_BAL",   "C_BAL", "A_N", "A_P",
@@ -202,7 +222,7 @@ static char const *_rfswitch_portstr(uint32_t port)
     return pstrs[port];
 }
 
-static void _print_rfconfig(struct cli_state *state)
+static void _print_rfconfig_bladerf2(struct cli_state *state)
 {
     int status;
 
@@ -213,7 +233,7 @@ static void _print_rfconfig(struct cli_state *state)
         return;
     }
 
-    printf("    RF switch config:\n");
+    printf("    RF routing:\n");
     printf("      TX1: RFIC 0x%x (%-7s) => SW 0x%x (%-7s)\n",
            config.tx1_rfic_port, _rfic_tx_portstr(config.tx1_rfic_port),
            config.tx1_spdt_port, _rfswitch_portstr(config.tx1_spdt_port));
@@ -230,12 +250,17 @@ static void _print_rfconfig(struct cli_state *state)
 
 int print_hardware(struct cli_state *state, int argc, char **argv)
 {
+    printf("  Hardware status:\n");
+
+    if (ps_is_board(state->dev, BOARD_BLADERF1)) {
+        _print_rfconfig_bladerf1(state);
+    }
+
     if (ps_is_board(state->dev, BOARD_BLADERF2)) {
-        printf("  Hardware status:\n");
         _print_rfic(state);
         _print_power_source_bladerf2(state);
         _print_power_monitor_bladerf2(state);
-        _print_rfconfig(state);
+        _print_rfconfig_bladerf2(state);
     }
 
     return CLI_RET_OK;


### PR DESCRIPTION
Implements the RF port getters/setters for the bladeRF 1, moves these functions into the low-level functions section of libbladeRF.h, and implements reading of these settings in bladeRF-cli's 'print hardware' command.

Fixes #600 