### PR TITLE
bladeRF1: Fix nios_gpio assignment for AGC_EN

### DIFF
--- a/hdl/CHANGELOG
+++ b/hdl/CHANGELOG
@@ -6,6 +6,12 @@ hosted on GitHub: https://github.com/nuand/bladeRF
 ================================================================================
 
 --------------------------------
+v0.8.0 (2018-09-05)
+--------------------------------
+ * bladeRF: Fix nios_gpio assignment overlap for AGC_EN
+ * bladeRF: Fix bug in AGC band selection
+
+--------------------------------
 v0.7.3 (2018-08-07)
 --------------------------------
  * Initial release with bladeRF Micro support

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/fpga_version.h
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/fpga_version.h
@@ -7,8 +7,8 @@
 
 #define FPGA_VERSION_ID         0x7777
 #define FPGA_VERSION_MAJOR      0
-#define FPGA_VERSION_MINOR      7
-#define FPGA_VERSION_PATCH      3
+#define FPGA_VERSION_MINOR      8
+#define FPGA_VERSION_PATCH      0
 #define FPGA_VERSION ((uint32_t)( FPGA_VERSION_MAJOR        | \
                                  (FPGA_VERSION_MINOR << 8)  | \
                                  (FPGA_VERSION_PATCH << 16) ) )

--- a/hdl/fpga/platforms/bladerf/software/bladeRF_nios/src/fpga_version.h
+++ b/hdl/fpga/platforms/bladerf/software/bladeRF_nios/src/fpga_version.h
@@ -7,8 +7,8 @@
 
 #define FPGA_VERSION_ID         0x7777
 #define FPGA_VERSION_MAJOR      0
-#define FPGA_VERSION_MINOR      7
-#define FPGA_VERSION_PATCH      3
+#define FPGA_VERSION_MINOR      8
+#define FPGA_VERSION_PATCH      0
 #define FPGA_VERSION ((uint32_t)( FPGA_VERSION_MAJOR        | \
                                  (FPGA_VERSION_MINOR << 8)  | \
                                  (FPGA_VERSION_PATCH << 16) ) )

--- a/hdl/fpga/platforms/bladerf/vhdl/bladerf-hosted.vhd
+++ b/hdl/fpga/platforms/bladerf/vhdl/bladerf-hosted.vhd
@@ -456,7 +456,7 @@ begin
       ) port map (
         reset       =>  rx_reset,
         clock       =>  rx_clock,
-        async       =>  nios_gpio.o.agc_en,
+        async       =>  nios_gpio.o.agc_band_sel,
         sync        =>  agc_band_sel
       ) ;
 

--- a/hdl/fpga/platforms/bladerf/vhdl/bladerf_p.vhd
+++ b/hdl/fpga/platforms/bladerf/vhdl/bladerf_p.vhd
@@ -231,6 +231,7 @@ package bladerf_p is
         xb_mode         : std_logic_vector(1 downto 0);
         agc_en          : std_logic;
         agc_band_sel    : std_logic;
+        ts_div2         : std_logic;  -- Not used in FPGA versions >= 0.3.0
         meta_en         : std_logic;
         led_mode        : std_logic;
         leds            : std_logic_vector(3 downto 1);
@@ -298,8 +299,8 @@ package body bladerf_p is
         -- AVAILABLE: x(29 downto 23);
         -- RESERVED:  rv(22 downto 21) := x.xb_mode2;  -- Why? Is this even needed?
         -- RESERVED:  rv(20 downto 19) := x.nios_ss_n; -- Why? Is this even needed?
-        --rv(18)           := x.agc_en;
-        --rv(17)           := x.agc_band_sel;
+        rv(18)           := x.agc_en;
+        rv(17)           := x.ts_div2; -- Not used in FPGA versions >= 0.3.0
         rv(16)           := x.meta_en;
         rv(15)           := x.led_mode;
         rv(14 downto 12) := x.leds;
@@ -337,8 +338,8 @@ package body bladerf_p is
         -- AVAILABLE: x(29 downto 23);
         --rv.xb_mode2      := x(22 downto 21); -- Why? Is this even needed?
         --rv.nios_ss_n     := x(20 downto 19); -- Why? Is this even needed?
-        rv.agc_en          := x(12); -- FIXME: overlaps leds(1)     ... use x(18) instead?
-        rv.agc_band_sel    := x(5);  -- FIXME: overlaps lms_rx_v(1) ... use x(17) instead?
+        rv.agc_en          := x(18);
+        rv.ts_div2         := x(17); -- Not used in FPGA versions >= 0.3.0
         rv.meta_en         := x(16);
         rv.led_mode        := x(15);
         rv.leds            := x(14 downto 12);
@@ -346,6 +347,7 @@ package body bladerf_p is
         rv.rx_mux_sel      := x(10 downto 8);
         rv.usb_speed       := x(7);
         rv.lms_rx_v        := x(6 downto 5);
+        rv.agc_band_sel    := rv.lms_rx_v(rv.lms_rx_v'low);
         rv.lms_tx_v        := x(4 downto 3);
         rv.lms_tx_enable   := x(2);
         rv.lms_rx_enable   := x(1);

--- a/host/libraries/libbladeRF/include/bladeRF1.h
+++ b/host/libraries/libbladeRF/include/bladeRF1.h
@@ -1372,7 +1372,7 @@ int CALL_CONV bladerf_calibrate_dc(struct bladerf *dev,
  *
  * @note This is set using bladerf_set_gain_mode().
  */
-#define BLADERF_GPIO_AGC_ENABLE (1 << 12)
+#define BLADERF_GPIO_AGC_ENABLE (1 << 18)
 
 /**
  * Enable-bit for timestamp counter in the FPGA

--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -555,6 +555,18 @@ static int bladerf1_initialize(struct bladerf *dev)
 #endif
     }
 
+    /* Detect AGC FPGA bug and report warning */
+    if( have_cap(board_data->capabilities, BLADERF_CAP_AGC_DC_LUT) &&
+        version_fields_less_than(&board_data->fpga_version, 0, 8, 0) ) {
+        log_warning("AGC commands for FPGA v%u.%u.%u are incompatible with "
+                    "this version of libbladeRF. Please update to FPGA "
+                    "v%u.%u.%u or newer to use AGC.\n",
+                    board_data->fpga_version.major,
+                    board_data->fpga_version.minor,
+                    board_data->fpga_version.patch,
+                    0, 8, 0 );
+    }
+
     /* Set FPGA packet protocol */
     if (have_cap(board_data->capabilities, BLADERF_CAP_PKT_HANDLER_FMT)) {
         status = dev->backend->set_fpga_protocol(dev, BACKEND_FPGA_PROTOCOL_NIOSII);

--- a/host/libraries/libbladeRF/src/board/bladerf1/compatibility.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/compatibility.c
@@ -31,6 +31,7 @@ const struct version_compat_table bladerf1_fw_compat_table = {fw_compat, ARRAY_S
 
 static const struct compat fpga_compat[] = {
     /*    FPGA          requires >=        Firmware */
+    { VERSION(0, 8, 0),                 VERSION(1, 6, 1) },
     { VERSION(0, 7, 3),                 VERSION(1, 6, 1) },
     { VERSION(0, 7, 2),                 VERSION(1, 6, 1) },
     { VERSION(0, 7, 1),                 VERSION(1, 6, 1) },

--- a/host/libraries/libbladeRF/src/board/bladerf2/compatibility.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/compatibility.c
@@ -23,6 +23,7 @@ const struct version_compat_table bladerf2_fw_compat_table = {fw_compat, ARRAY_S
 
 static const struct compat fpga_compat[] = {
     /*    FPGA          requires >=        Firmware */
+    { VERSION(0, 8, 0),                 VERSION(2, 1, 0) },
     { VERSION(0, 7, 3),                 VERSION(2, 1, 0) },
     { VERSION(0, 7, 2),                 VERSION(2, 1, 0) },
     { VERSION(0, 7, 1),                 VERSION(2, 0, 0) },


### PR DESCRIPTION
Fixes #607

The nios_gpio bit assignment for AGC_EN was already being used for
led(1). This commit also fixes a bug in the agc_band_sel signal
assignment introduced in 3b670ca.