### PR TITLE
host: add a product description string to devinfo

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -117,6 +117,9 @@ typedef enum {
     BLADERF_BACKEND_DUMMY = 100, /**< Dummy used for development purposes */
 } bladerf_backend;
 
+/** Length of device description string, including NUL-terminator */
+#define BLADERF_PRODUCT_LENGTH 33
+
 /** Length of device serial number string, including NUL-terminator */
 #define BLADERF_SERIAL_LENGTH 33
 
@@ -124,12 +127,13 @@ typedef enum {
  * Information about a bladeRF attached to the system
  */
 struct bladerf_devinfo {
-    bladerf_backend backend;            /**< Backend to use when connecting to
-                                         *   device */
-    char serial[BLADERF_SERIAL_LENGTH]; /**< Device serial number string */
-    uint8_t usb_bus;                    /**< Bus # device is attached to */
-    uint8_t usb_addr;                   /**< Device address on bus */
-    unsigned int instance;              /**< Device instance or ID */
+    bladerf_backend backend;              /**< Backend to use when connecting to
+                                           *   device */
+    char product[BLADERF_PRODUCT_LENGTH]; /**< Product description string */
+    char serial[BLADERF_SERIAL_LENGTH];   /**< Device serial number string */
+    uint8_t usb_bus;                      /**< Bus # device is attached to */
+    uint8_t usb_addr;                     /**< Device address on bus */
+    unsigned int instance;                /**< Device instance or ID */
 };
 
 /**
@@ -734,7 +738,7 @@ int CALL_CONV bladerf_get_gain(struct bladerf *dev,
  *
  * The special value of ::BLADERF_GAIN_DEFAULT will return hardware AGC to
  * its default value at initialization.
- * 
+ *
  * @see bladerf_gain_mode for implementation guidance
  *
  * @param       dev         Device handle
@@ -774,7 +778,7 @@ int CALL_CONV bladerf_get_gain_mode(struct bladerf *dev,
  *
  * This function may be called with `NULL` for `modes` to determine the number
  * of gain modes supported.
- * 
+ *
  * @see bladerf_gain_mode for implementation guidance
  *
  * @param       dev         Device handle

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -142,37 +142,64 @@ static int get_devinfo(libusb_device *dev, struct bladerf_devinfo *info)
     int status = 0;
     libusb_device_handle *handle;
     struct libusb_device_descriptor desc;
+    char manu[BLADERF_PRODUCT_LENGTH];
+    char prod[BLADERF_PRODUCT_LENGTH];
+
+    bladerf_init_devinfo(info);
 
     status = libusb_open(dev, &handle);
 
     if (status == 0) {
         /* Populate device info */
-        info->backend = BLADERF_BACKEND_LIBUSB;
-        info->usb_bus = libusb_get_bus_number(dev);
+        info->backend  = BLADERF_BACKEND_LIBUSB;
+        info->usb_bus  = libusb_get_bus_number(dev);
         info->usb_addr = libusb_get_device_address(dev);
 
         status = libusb_get_device_descriptor(dev, &desc);
         if (status != 0) {
-            memset(info->serial, 0, BLADERF_SERIAL_LENGTH);
-        } else {
-            status = libusb_get_string_descriptor_ascii(
-                                        handle, desc.iSerialNumber,
-                                        (unsigned char *)&info->serial,
-                                        BLADERF_SERIAL_LENGTH);
-
-            /* Consider this to be non-fatal, otherwise firmware <= 1.1
-             * wouldn't be able to get far enough to upgrade */
-            if (status < 0) {
-                log_debug("Failed to retrieve serial number\n");
-                memset(info->serial, 0, BLADERF_SERIAL_LENGTH);
-            } else {
-                /* Adjust for > 0 return code */
-                status = 0;
-            }
-
+            goto out;
         }
 
-        libusb_close(handle);
+        status = libusb_get_string_descriptor_ascii(
+            handle, desc.iSerialNumber, (unsigned char *)&info->serial,
+            BLADERF_SERIAL_LENGTH);
+
+        /* Consider this to be non-fatal, otherwise firmware <= 1.1
+         * wouldn't be able to get far enough to upgrade */
+        if (status < 0) {
+            log_debug("Failed to retrieve serial number\n");
+            memset(info->serial, 0, BLADERF_SERIAL_LENGTH);
+            goto out;
+        }
+
+        status = libusb_get_string_descriptor_ascii(handle, desc.iManufacturer,
+                                                    (unsigned char *)&manu,
+                                                    BLADERF_PRODUCT_LENGTH);
+        if (status < 0) {
+            log_debug("Failed to retrieve manufacturer string\n");
+            goto out;
+        }
+
+        status = libusb_get_string_descriptor_ascii(handle, desc.iProduct,
+                                                    (unsigned char *)&prod,
+                                                    BLADERF_PRODUCT_LENGTH);
+        if (status < 0) {
+            log_debug("Failed to retrieve product string\n");
+            goto out;
+        }
+
+        snprintf(info->product, BLADERF_PRODUCT_LENGTH, "%s %s", manu, prod);
+
+        log_verbose("Bus %03d Device %03d: %s, serial %s\n", info->usb_bus,
+                    info->usb_addr, info->product, info->serial);
+    }
+
+out:
+    libusb_close(handle);
+
+    if (status > 0) {
+        /* Adjust for > 0 return code */
+        status = 0;
     }
 
     return status;

--- a/host/libraries/libbladeRF/src/devinfo.c
+++ b/host/libraries/libbladeRF/src/devinfo.c
@@ -161,13 +161,15 @@ int bladerf_devinfo_list_add(struct bladerf_devinfo_list *list,
 void bladerf_init_devinfo(struct bladerf_devinfo *info)
 {
     info->backend  = BLADERF_BACKEND_ANY;
-
-    memset(info->serial, 0, BLADERF_SERIAL_LENGTH);
-    strncpy(info->serial, DEVINFO_SERIAL_ANY, BLADERF_SERIAL_LENGTH - 1);
-
     info->usb_bus  = DEVINFO_BUS_ANY;
     info->usb_addr = DEVINFO_ADDR_ANY;
     info->instance = DEVINFO_INST_ANY;
+
+    memset(info->product, 0, BLADERF_PRODUCT_LENGTH);
+    snprintf(info->product, BLADERF_PRODUCT_LENGTH, "<unknown>");
+
+    memset(info->serial, 0, BLADERF_SERIAL_LENGTH);
+    strncpy(info->serial, DEVINFO_SERIAL_ANY, BLADERF_SERIAL_LENGTH - 1);
 }
 
 bool bladerf_devinfo_matches(const struct bladerf_devinfo *a,

--- a/host/utilities/bladeRF-cli/src/cmd/info.c
+++ b/host/utilities/bladeRF-cli/src/cmd/info.c
@@ -17,9 +17,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <stdio.h>
 #include "cmd.h"
 #include "conversions.h"
+#include <stdio.h>
 
 int cmd_info(struct cli_state *state, int argc, char **argv)
 {
@@ -61,7 +61,8 @@ int cmd_info(struct cli_state *state, int argc, char **argv)
     usb_speed = bladerf_device_speed(state->dev);
 
     printf("\n");
-    printf("  Board:                    %s\n", bladerf_get_board_name(state->dev));
+    printf("  Board:                    %s (%s)\n", info.product,
+           bladerf_get_board_name(state->dev));
     printf("  Serial #:                 %s\n", info.serial);
     printf("  VCTCXO DAC calibration:   0x%.4x\n", dac_trim);
     if (fpga_size != 0) {

--- a/host/utilities/bladeRF-cli/src/cmd/probe.c
+++ b/host/utilities/bladeRF-cli/src/cmd/probe.c
@@ -17,9 +17,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <string.h>
-#include "rel_assert.h"
 #include "cmd.h"
+#include "rel_assert.h"
+#include <string.h>
 
 static inline const char *backend2str(bladerf_backend b)
 {
@@ -38,7 +38,7 @@ static inline const char *backend2str(bladerf_backend b)
 /* Todo move to cmd_probe.c */
 int cmd_probe(struct cli_state *s, int argc, char *argv[])
 {
-    bool error_on_no_dev = false;
+    bool error_on_no_dev            = false;
     struct bladerf_devinfo *devices = NULL;
     int n_devices, i;
 
@@ -72,6 +72,7 @@ int cmd_probe(struct cli_state *s, int argc, char *argv[])
 
     putchar('\n');
     for (i = 0; i < n_devices; i++) {
+        printf("  Description:    %s\n", devices[i].product);
         printf("  Backend:        %s\n", backend2str(devices[i].backend));
         printf("  Serial:         %s\n", devices[i].serial);
         printf("  USB Bus:        %d\n", devices[i].usb_bus);


### PR DESCRIPTION
Displays a description for each device found during a bladeRF-cli --probe:

```
  Description:    Nuand bladeRF 2.0
  Backend:        libusb
  Serial:         <redacted>
  USB Bus:        4
  USB Address:    36
```

This is built from the USB device descriptor, piggy-backing on the same functionality that populates the serial number.

Currently libusb-only; on cyusb, it will likely display "<unknown>".