### PR TITLE
libbladeRF: add format macros for frequency, timestamp

### DIFF
--- a/host/libraries/libbladeRF/include/bladeRF2.h
+++ b/host/libraries/libbladeRF/include/bladeRF2.h
@@ -178,6 +178,7 @@ typedef enum {
     BLADERF_RFIC_RXFIR_DEC4,   /**< Decimate by 4 */
 } bladerf_rfic_rxfir;
 
+/** Default RFIC RX FIR filter */
 #define BLADERF_RFIC_RXFIR_DEFAULT BLADERF_RFIC_RXFIR_DEC1
 
 /**
@@ -191,6 +192,7 @@ typedef enum {
     BLADERF_RFIC_TXFIR_INT4,   /**< Interpolate by 4 */
 } bladerf_rfic_txfir;
 
+/** Default RFIC TX FIR filter */
 #define BLADERF_RFIC_TXFIR_DEFAULT BLADERF_RFIC_TXFIR_BYPASS
 
 /**

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -734,7 +734,7 @@ int CALL_CONV bladerf_get_gain(struct bladerf *dev,
  *
  * The special value of ::BLADERF_GAIN_DEFAULT will return hardware AGC to
  * its default value at initialization.
- * 
+ *
  * @see bladerf_gain_mode for implementation guidance
  *
  * @param       dev         Device handle
@@ -774,7 +774,7 @@ int CALL_CONV bladerf_get_gain_mode(struct bladerf *dev,
  *
  * This function may be called with `NULL` for `modes` to determine the number
  * of gain modes supported.
- * 
+ *
  * @see bladerf_gain_mode for implementation guidance
  *
  * @param       dev         Device handle
@@ -1092,10 +1092,22 @@ int CALL_CONV bladerf_get_bandwidth_range(struct bladerf *dev,
 /**
  * RF center frequency, in hertz (Hz)
  *
- * @remark Prior to libbladeRF 2.x.x, frequencies were specified as
+ * @see Format macros for fprintf() and fscanf(): `BLADERF_PRIuFREQ`,
+ * `BLADERF_PRIxFREQ`, `BLADERF_SCNuFREQ`, `BLADERF_SCNxFREQ`
+ *
+ * @remark Prior to libbladeRF 2.0.0, frequencies were specified as
  *         `unsigned int`.
  */
 typedef uint64_t bladerf_frequency;
+
+/** printf format for frequencies in unsigned decimal */
+#define BLADERF_PRIuFREQ PRIu64
+/** printf format for frequencies in hexadecimal */
+#define BLADERF_PRIxFREQ PRIx64
+/** scanf format for frequencies in unsigned decimal */
+#define BLADERF_SCNuFREQ SCNu64
+/** scanf format for frequencies in hexadecimal */
+#define BLADERF_SCNxFREQ SCNx64
 
 /**
  * Select the appropriate band path given a frequency in Hz.
@@ -1666,6 +1678,9 @@ int CALL_CONV bladerf_get_rx_mux(struct bladerf *dev, bladerf_rx_mux *mode);
  * Timestamp, in ticks
  *
  * A channel's timestamp typically increments at the sample rate.
+ *
+ * @see Format macros for fprintf() and fscanf(): `BLADERF_PRIuTS`,
+ * `BLADERF_PRIxTS`, `BLADERF_SCNuTS`, `BLADERF_SCNxTS`
  */
 typedef uint64_t bladerf_timestamp;
 
@@ -1890,6 +1905,15 @@ int CALL_CONV bladerf_get_correction(struct bladerf *dev,
  *
  * @{
  */
+
+/** printf format for timestamps in unsigned decimal */
+#define BLADERF_PRIuTS PRIu64
+/** printf format for timestamps in hexadecimal */
+#define BLADERF_PRIxTS PRIx64
+/** scanf format for timestamps in unsigned decimal */
+#define BLADERF_SCNuTS SCNu64
+/** scanf format for timestamps in hexadecimal */
+#define BLADERF_SCNxTS SCNx64
 
 /**
  * @defgroup STREAMING_FORMAT Formats

--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -444,7 +444,8 @@ static int bladerf1_apply_lms_dc_cals(struct bladerf *dev)
     cals.rxvga2b_q  = -1;
 
     if (have_rx) {
-        const struct bladerf_lms_dc_cals *reg_vals = &board_data->cal.dc_rx->reg_vals;
+        const struct bladerf_lms_dc_cals *reg_vals =
+            &board_data->cal.dc_rx->reg_vals;
 
         cals.lpf_tuning = reg_vals->lpf_tuning;
         cals.rx_lpf_i   = reg_vals->rx_lpf_i;
@@ -459,7 +460,8 @@ static int bladerf1_apply_lms_dc_cals(struct bladerf *dev)
     }
 
     if (have_tx) {
-        const struct bladerf_lms_dc_cals *reg_vals = &board_data->cal.dc_tx->reg_vals;
+        const struct bladerf_lms_dc_cals *reg_vals =
+            &board_data->cal.dc_tx->reg_vals;
 
         cals.tx_lpf_i = reg_vals->tx_lpf_i;
         cals.tx_lpf_q = reg_vals->tx_lpf_q;
@@ -473,13 +475,13 @@ static int bladerf1_apply_lms_dc_cals(struct bladerf *dev)
         } else {
             /* Have TX cal but no RX cal -- use the RX values that came along
              * for the ride when the TX table was generated */
-            cals.rx_lpf_i   = reg_vals->rx_lpf_i;
-            cals.rx_lpf_q   = reg_vals->rx_lpf_q;
-            cals.dc_ref     = reg_vals->dc_ref;
-            cals.rxvga2a_i  = reg_vals->rxvga2a_i;
-            cals.rxvga2a_q  = reg_vals->rxvga2a_q;
-            cals.rxvga2b_i  = reg_vals->rxvga2b_i;
-            cals.rxvga2b_q  = reg_vals->rxvga2b_q;
+            cals.rx_lpf_i  = reg_vals->rx_lpf_i;
+            cals.rx_lpf_q  = reg_vals->rx_lpf_q;
+            cals.dc_ref    = reg_vals->dc_ref;
+            cals.rxvga2a_i = reg_vals->rxvga2a_i;
+            cals.rxvga2a_q = reg_vals->rxvga2a_q;
+            cals.rxvga2b_i = reg_vals->rxvga2b_i;
+            cals.rxvga2b_q = reg_vals->rxvga2b_q;
         }
 
         log_verbose("Fetched register values from TX DC cal table.\n");
@@ -488,10 +490,11 @@ static int bladerf1_apply_lms_dc_cals(struct bladerf *dev)
     /* No TX table was loaded, so load LMS TX register cals from the RX table,
      * if available */
     if (have_rx && !have_tx) {
-        const struct bladerf_lms_dc_cals *reg_vals = &board_data->cal.dc_rx->reg_vals;
+        const struct bladerf_lms_dc_cals *reg_vals =
+            &board_data->cal.dc_rx->reg_vals;
 
-        cals.tx_lpf_i   = reg_vals->tx_lpf_i;
-        cals.tx_lpf_q   = reg_vals->tx_lpf_q;
+        cals.tx_lpf_i = reg_vals->tx_lpf_i;
+        cals.tx_lpf_q = reg_vals->tx_lpf_q;
     }
 
     if (have_rx || have_tx) {
@@ -504,18 +507,22 @@ static int bladerf1_apply_lms_dc_cals(struct bladerf *dev)
             int tx_status = 0;
 
             if (have_rx) {
-                uint64_t rx_f;
-                rx_status = dev->board->get_frequency(dev, BLADERF_CHANNEL_RX(0), &rx_f);
+                bladerf_frequency rx_f;
+                rx_status = dev->board->get_frequency(
+                    dev, BLADERF_CHANNEL_RX(0), &rx_f);
                 if (rx_status == 0) {
-                    rx_status = dev->board->set_frequency(dev, BLADERF_CHANNEL_RX(0), rx_f);
+                    rx_status = dev->board->set_frequency(
+                        dev, BLADERF_CHANNEL_RX(0), rx_f);
                 }
             }
 
             if (have_tx) {
-                uint64_t rx_f;
-                rx_status = dev->board->get_frequency(dev, BLADERF_CHANNEL_RX(0), &rx_f);
+                bladerf_frequency rx_f;
+                rx_status = dev->board->get_frequency(
+                    dev, BLADERF_CHANNEL_RX(0), &rx_f);
                 if (rx_status == 0) {
-                    rx_status = dev->board->set_frequency(dev, BLADERF_CHANNEL_RX(0), rx_f);
+                    rx_status = dev->board->set_frequency(
+                        dev, BLADERF_CHANNEL_RX(0), rx_f);
                 }
             }
 
@@ -1784,7 +1791,10 @@ static int bladerf1_get_rational_sample_rate(struct bladerf *dev, bladerf_channe
 /* Bandwidth */
 /******************************************************************************/
 
-static int bladerf1_set_bandwidth(struct bladerf *dev, bladerf_channel ch, unsigned int bandwidth, unsigned int *actual)
+static int bladerf1_set_bandwidth(struct bladerf *dev,
+                                  bladerf_channel ch,
+                                  bladerf_bandwidth bandwidth,
+                                  bladerf_bandwidth *actual)
 {
     int status;
     lms_bw bw;
@@ -1793,10 +1803,10 @@ static int bladerf1_set_bandwidth(struct bladerf *dev, bladerf_channel ch, unsig
 
     if (bandwidth < BLADERF_BANDWIDTH_MIN) {
         bandwidth = BLADERF_BANDWIDTH_MIN;
-        log_info("Clamping bandwidth to %dHz\n", bandwidth);
+        log_info("Clamping bandwidth to %d Hz\n", bandwidth);
     } else if (bandwidth > BLADERF_BANDWIDTH_MAX) {
         bandwidth = BLADERF_BANDWIDTH_MAX;
-        log_info("Clamping bandwidth to %dHz\n", bandwidth);
+        log_info("Clamping bandwidth to %d Hz\n", bandwidth);
     }
 
     bw = lms_uint2bw(bandwidth);
@@ -1818,14 +1828,16 @@ static int bladerf1_set_bandwidth(struct bladerf *dev, bladerf_channel ch, unsig
     return status;
 }
 
-static int bladerf1_get_bandwidth(struct bladerf *dev, bladerf_channel ch, unsigned int *bandwidth)
+static int bladerf1_get_bandwidth(struct bladerf *dev,
+                                  bladerf_channel ch,
+                                  bladerf_bandwidth *bandwidth)
 {
     int status;
     lms_bw bw;
 
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 
-    status = lms_get_bandwidth( dev, ch, &bw);
+    status = lms_get_bandwidth(dev, ch, &bw);
     if (status == 0) {
         *bandwidth = lms_bw2uint(bw);
     } else {
@@ -1835,7 +1847,9 @@ static int bladerf1_get_bandwidth(struct bladerf *dev, bladerf_channel ch, unsig
     return status;
 }
 
-static int bladerf1_get_bandwidth_range(struct bladerf *dev, bladerf_channel ch, const struct bladerf_range **range)
+static int bladerf1_get_bandwidth_range(struct bladerf *dev,
+                                        bladerf_channel ch,
+                                        const struct bladerf_range **range)
 {
     *range = &bladerf1_bandwidth_range;
     return 0;
@@ -1845,19 +1859,23 @@ static int bladerf1_get_bandwidth_range(struct bladerf *dev, bladerf_channel ch,
 /* Frequency */
 /******************************************************************************/
 
-static int bladerf1_set_frequency(struct bladerf *dev, bladerf_channel ch, uint64_t frequency)
+static int bladerf1_set_frequency(struct bladerf *dev,
+                                  bladerf_channel ch,
+                                  bladerf_frequency frequency)
 {
     struct bladerf1_board_data *board_data = dev->board_data;
-    const bladerf_xb attached = dev->xb;
+    const bladerf_xb attached              = dev->xb;
     int status;
     int16_t dc_i, dc_q;
     struct dc_cal_entry entry;
-    const struct dc_cal_tbl *dc_cal =
-        (ch == BLADERF_CHANNEL_RX(0)) ? board_data->cal.dc_rx : board_data->cal.dc_tx;
+    const struct dc_cal_tbl *dc_cal = (ch == BLADERF_CHANNEL_RX(0))
+                                          ? board_data->cal.dc_rx
+                                          : board_data->cal.dc_tx;
 
     CHECK_BOARD_STATE(STATE_FPGA_LOADED);
 
-    log_debug("Setting %s frequency to %u\n", channel2str(ch), frequency);
+    log_debug("Setting %s frequency to %" BLADERF_PRIuFREQ "\n",
+              channel2str(ch), frequency);
 
     if (attached == BLADERF_XB_200) {
         if (frequency < BLADERF_FREQUENCY_MIN) {
@@ -1891,7 +1909,8 @@ static int bladerf1_set_frequency(struct bladerf *dev, bladerf_channel ch, uint6
             break;
 
         case BLADERF_TUNING_MODE_FPGA: {
-            status = dev->board->schedule_retune(dev, ch, BLADERF_RETUNE_NOW, frequency, NULL);
+            status = dev->board->schedule_retune(dev, ch, BLADERF_RETUNE_NOW,
+                                                 frequency, NULL);
             break;
         }
 
@@ -1922,20 +1941,17 @@ static int bladerf1_set_frequency(struct bladerf *dev, bladerf_channel ch, uint6
 
         if (ch == BLADERF_CHANNEL_RX(0) &&
             have_cap(board_data->capabilities, BLADERF_CAP_AGC_DC_LUT)) {
-
-            status = dev->backend->set_agc_dc_correction(dev,
-                            entry.max_dc_q, entry.max_dc_i,
-                            entry.mid_dc_q, entry.mid_dc_i,
-                            entry.min_dc_q, entry.min_dc_i);
+            status = dev->backend->set_agc_dc_correction(
+                dev, entry.max_dc_q, entry.max_dc_i, entry.mid_dc_q,
+                entry.mid_dc_i, entry.min_dc_q, entry.min_dc_i);
             if (status != 0) {
                 return status;
             }
 
             log_verbose("Set AGC DC offset cal (I, Q) to: Max (%d, %d) "
                         " Mid (%d, %d) Min (%d, %d)\n",
-                        entry.max_dc_q, entry.max_dc_i,
-                        entry.mid_dc_q, entry.mid_dc_i,
-                        entry.min_dc_q, entry.min_dc_i);
+                        entry.max_dc_q, entry.max_dc_i, entry.mid_dc_q,
+                        entry.mid_dc_i, entry.min_dc_q, entry.min_dc_i);
         }
 
         log_verbose("Set %s DC offset cal (I, Q) to: (%d, %d)\n",
@@ -1945,7 +1961,9 @@ static int bladerf1_set_frequency(struct bladerf *dev, bladerf_channel ch, uint6
     return 0;
 }
 
-static int bladerf1_get_frequency(struct bladerf *dev, bladerf_channel ch, uint64_t *frequency)
+static int bladerf1_get_frequency(struct bladerf *dev,
+                                  bladerf_channel ch,
+                                  bladerf_frequency *frequency)
 {
     bladerf_xb200_path path;
     struct lms_freq f;
@@ -1961,8 +1979,8 @@ static int bladerf1_get_frequency(struct bladerf *dev, bladerf_channel ch, uint6
     if (f.x == 0) {
         /* If we see this, it's most often an indication that communication
          * with the LMS6002D is not occuring correctly */
-        *frequency = 0 ;
-        status = BLADERF_ERR_IO;
+        *frequency = 0;
+        status     = BLADERF_ERR_IO;
     } else {
         *frequency = lms_frequency_to_hz(&f);
     }
@@ -1983,7 +2001,9 @@ static int bladerf1_get_frequency(struct bladerf *dev, bladerf_channel ch, uint6
     return 0;
 }
 
-static int bladerf1_get_frequency_range(struct bladerf *dev, bladerf_channel ch, const struct bladerf_range **range)
+static int bladerf1_get_frequency_range(struct bladerf *dev,
+                                        bladerf_channel ch,
+                                        const struct bladerf_range **range)
 {
     if (dev->xb == BLADERF_XB_200) {
         *range = &bladerf1_xb200_frequency_range;
@@ -1994,7 +2014,9 @@ static int bladerf1_get_frequency_range(struct bladerf *dev, bladerf_channel ch,
     return 0;
 }
 
-static int bladerf1_select_band(struct bladerf *dev, bladerf_channel ch, uint64_t frequency)
+static int bladerf1_select_band(struct bladerf *dev,
+                                bladerf_channel ch,
+                                bladerf_frequency frequency)
 {
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 
@@ -2178,14 +2200,20 @@ static int bladerf1_get_rf_ports(struct bladerf *dev,
 /* Scheduled Tuning */
 /******************************************************************************/
 
-static int bladerf1_get_quick_tune(struct bladerf *dev, bladerf_channel ch, struct bladerf_quick_tune *quick_tune)
+static int bladerf1_get_quick_tune(struct bladerf *dev,
+                                   bladerf_channel ch,
+                                   struct bladerf_quick_tune *quick_tune)
 {
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 
     return lms_get_quick_tune(dev, ch, quick_tune);
 }
 
-static int bladerf1_schedule_retune(struct bladerf *dev, bladerf_channel ch, uint64_t timestamp, uint64_t frequency, struct bladerf_quick_tune *quick_tune)
+static int bladerf1_schedule_retune(struct bladerf *dev,
+                                    bladerf_channel ch,
+                                    bladerf_timestamp timestamp,
+                                    bladerf_frequency frequency,
+                                    struct bladerf_quick_tune *quick_tune)
 
 {
     struct bladerf1_board_data *board_data = dev->board_data;
@@ -2196,8 +2224,10 @@ static int bladerf1_schedule_retune(struct bladerf *dev, bladerf_channel ch, uin
 
     if (!have_cap(board_data->capabilities, BLADERF_CAP_SCHEDULED_RETUNE)) {
         log_debug("This FPGA version (%u.%u.%u) does not support "
-                  "scheduled retunes.\n",  board_data->fpga_version.major,
-                  board_data->fpga_version.minor, board_data->fpga_version.patch);
+                  "scheduled retunes.\n",
+                  board_data->fpga_version.major,
+                  board_data->fpga_version.minor,
+                  board_data->fpga_version.patch);
 
         return BLADERF_ERR_UNSUPPORTED;
     }
@@ -2208,22 +2238,23 @@ static int bladerf1_schedule_retune(struct bladerf *dev, bladerf_channel ch, uin
             return status;
         }
     } else {
-        f.freqsel = quick_tune->freqsel;
-        f.vcocap  = quick_tune->vcocap;
-        f.nint    = quick_tune->nint;
-        f.nfrac   = quick_tune->nfrac;
-        f.flags   = quick_tune->flags;
-        f.x       = 0;
+        f.freqsel       = quick_tune->freqsel;
+        f.vcocap        = quick_tune->vcocap;
+        f.nint          = quick_tune->nint;
+        f.nfrac         = quick_tune->nfrac;
+        f.flags         = quick_tune->flags;
+        f.x             = 0;
         f.vcocap_result = 0;
     }
 
-    return dev->backend->retune(dev, ch, timestamp,
-                       f.nint, f.nfrac, f.freqsel, f.vcocap,
-                       (f.flags & LMS_FREQ_FLAGS_LOW_BAND) != 0,
-                       (f.flags & LMS_FREQ_FLAGS_FORCE_VCOCAP) != 0);
+    return dev->backend->retune(dev, ch, timestamp, f.nint, f.nfrac, f.freqsel,
+                                f.vcocap,
+                                (f.flags & LMS_FREQ_FLAGS_LOW_BAND) != 0,
+                                (f.flags & LMS_FREQ_FLAGS_FORCE_VCOCAP) != 0);
 }
 
-static int bladerf1_cancel_scheduled_retunes(struct bladerf *dev, bladerf_channel ch)
+static int bladerf1_cancel_scheduled_retunes(struct bladerf *dev,
+                                             bladerf_channel ch)
 {
     struct bladerf1_board_data *board_data = dev->board_data;
     int status;
@@ -2231,11 +2262,14 @@ static int bladerf1_cancel_scheduled_retunes(struct bladerf *dev, bladerf_channe
     CHECK_BOARD_STATE(STATE_FPGA_LOADED);
 
     if (have_cap(board_data->capabilities, BLADERF_CAP_SCHEDULED_RETUNE)) {
-        status = dev->backend->retune(dev, ch, NIOS_PKT_RETUNE_CLEAR_QUEUE, 0, 0, 0, 0, false, false);
+        status = dev->backend->retune(dev, ch, NIOS_PKT_RETUNE_CLEAR_QUEUE, 0,
+                                      0, 0, 0, false, false);
     } else {
         log_debug("This FPGA version (%u.%u.%u) does not support "
-                  "scheduled retunes.\n",  board_data->fpga_version.major,
-                  board_data->fpga_version.minor, board_data->fpga_version.patch);
+                  "scheduled retunes.\n",
+                  board_data->fpga_version.major,
+                  board_data->fpga_version.minor,
+                  board_data->fpga_version.patch);
 
         return BLADERF_ERR_UNSUPPORTED;
     }
@@ -2654,7 +2688,9 @@ static int bladerf1_sync_rx(struct bladerf *dev,
     return status;
 }
 
-static int bladerf1_get_timestamp(struct bladerf *dev, bladerf_direction dir, uint64_t *value)
+static int bladerf1_get_timestamp(struct bladerf *dev,
+                                  bladerf_direction dir,
+                                  bladerf_timestamp *value)
 {
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -230,8 +230,8 @@ struct band_port_map {
     uint32_t ad9361_port;
 };
 
-static const uint64_t BLADERF_VCTCXO_FREQUENCY = 38400000;
-static const uint64_t BLADERF_REFIN_DEFAULT    = 10000000;
+static const bladerf_frequency BLADERF_VCTCXO_FREQUENCY = 38400000;
+static const bladerf_frequency BLADERF_REFIN_DEFAULT    = 10000000;
 
 // clang-format off
 
@@ -633,10 +633,10 @@ static const struct bladerf_loopback_modes bladerf2_loopback_modes[] = {
 
 static int bladerf2_select_band(struct bladerf *dev,
                                 bladerf_channel ch,
-                                uint64_t frequency);
+                                bladerf_frequency frequency);
 static int bladerf2_get_frequency(struct bladerf *dev,
                                   bladerf_channel ch,
-                                  uint64_t *frequency);
+                                  bladerf_frequency *frequency);
 static int bladerf2_read_flash_vctcxo_trim(struct bladerf *dev, uint16_t *trim);
 
 
@@ -716,7 +716,7 @@ static int64_t _clamp_to_range(struct bladerf_range const *range, int64_t value)
 }
 
 static enum bladerf2_band _get_band_by_frequency(bladerf_channel ch,
-                                                 uint64_t frequency)
+                                                 bladerf_frequency frequency)
 {
     const struct range_band_map *band_map;
     size_t band_map_len;
@@ -740,14 +740,13 @@ static enum bladerf2_band _get_band_by_frequency(bladerf_channel ch,
     }
 
     /* Not a valid frequency */
-    log_warning("%s: frequency %" PRIu64 " not found in band map\n",
+    log_warning("%s: frequency %" BLADERF_PRIuFREQ " not found in band map\n",
                 __FUNCTION__, frequency);
     return BAND_SHUTDOWN;
 }
 
-static const struct band_port_map *_get_band_port_map(bladerf_channel ch,
-                                                      bool enabled,
-                                                      uint64_t frequency)
+static const struct band_port_map *_get_band_port_map(
+    bladerf_channel ch, bool enabled, bladerf_frequency frequency)
 {
     enum bladerf2_band band;
     const struct band_port_map *port_map;
@@ -779,7 +778,7 @@ static const struct band_port_map *_get_band_port_map(bladerf_channel ch,
     }
 
     /* Wasn't found, return a null ptr */
-    log_warning("%s: frequency %" PRIu64 " not found in port map\n",
+    log_warning("%s: frequency %" BLADERF_PRIuFREQ " not found in port map\n",
                 __FUNCTION__, frequency);
     return NULL;
 }
@@ -1834,7 +1833,7 @@ static int _get_gain_range(struct bladerf *dev,
 {
     struct bladerf_gain_range const *ranges = NULL;
     size_t ranges_len;
-    uint64_t frequency = 0;
+    bladerf_frequency frequency = 0;
     int status;
     size_t i;
 
@@ -2610,7 +2609,7 @@ static int bladerf2_get_frequency_range(struct bladerf *dev,
 
 static int bladerf2_select_band(struct bladerf *dev,
                                 bladerf_channel ch,
-                                uint64_t frequency)
+                                bladerf_frequency frequency)
 {
     int status;
     uint32_t reg;
@@ -2655,7 +2654,7 @@ static int bladerf2_select_band(struct bladerf *dev,
 
 static int bladerf2_set_frequency(struct bladerf *dev,
                                   bladerf_channel ch,
-                                  uint64_t frequency)
+                                  bladerf_frequency frequency)
 {
     struct bladerf2_board_data *board_data;
     const struct bladerf_range *range = NULL;
@@ -2698,11 +2697,11 @@ static int bladerf2_set_frequency(struct bladerf *dev,
 
 static int bladerf2_get_frequency(struct bladerf *dev,
                                   bladerf_channel ch,
-                                  uint64_t *frequency)
+                                  bladerf_frequency *frequency)
 {
     struct bladerf2_board_data *board_data;
     int status;
-    uint64_t lo_frequency;
+    bladerf_frequency lo_frequency;
 
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 
@@ -2875,8 +2874,8 @@ static int bladerf2_get_quick_tune(struct bladerf *dev,
 
 static int bladerf2_schedule_retune(struct bladerf *dev,
                                     bladerf_channel ch,
-                                    uint64_t timestamp,
-                                    uint64_t frequency,
+                                    bladerf_timestamp timestamp,
+                                    bladerf_frequency frequency,
                                     struct bladerf_quick_tune *quick_tune)
 
 {
@@ -3685,7 +3684,7 @@ static int bladerf2_sync_rx(struct bladerf *dev,
 
 static int bladerf2_get_timestamp(struct bladerf *dev,
                                   bladerf_direction dir,
-                                  uint64_t *value)
+                                  bladerf_timestamp *value)
 {
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 
@@ -5009,8 +5008,8 @@ static int bladerf_pll_configure(struct bladerf *dev, uint16_t R, uint16_t N)
     return 0;
 }
 
-static int bladerf_pll_calculate_ratio(uint64_t ref_freq,
-                                       uint64_t clock_freq,
+static int bladerf_pll_calculate_ratio(bladerf_frequency ref_freq,
+                                       bladerf_frequency clock_freq,
                                        uint16_t *R,
                                        uint16_t *N)
 {
@@ -5201,7 +5200,7 @@ int bladerf_get_pll_refclk_range(struct bladerf *dev,
     return 0;
 }
 
-int bladerf_get_pll_refclk(struct bladerf *dev, uint64_t *frequency)
+int bladerf_get_pll_refclk(struct bladerf *dev, bladerf_frequency *frequency)
 {
     int status;
     uint32_t reg;
@@ -5244,7 +5243,7 @@ int bladerf_get_pll_refclk(struct bladerf *dev, uint64_t *frequency)
     return 0;
 }
 
-int bladerf_set_pll_refclk(struct bladerf *dev, uint64_t frequency)
+int bladerf_set_pll_refclk(struct bladerf *dev, bladerf_frequency frequency)
 {
     int status;
     uint16_t R, N;


### PR DESCRIPTION
Adds new format macros for displaying bladerf_frequency and
bladerf_timestamp values to libbladeRF.h.

Transitions bladerf1.c and bladerf2.c to use these new macros,
and also cleans up a few more places where the typedefs aren't
currently used.

Also fixes a doxygen warning for undocumented #defines in
bladeRF2.h.

Fixes #577
Fixes #618
Fixes #620