### PR TITLE
host: Add manufacturer/product strings to device information

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -117,6 +117,9 @@ typedef enum {
     BLADERF_BACKEND_DUMMY = 100, /**< Dummy used for development purposes */
 } bladerf_backend;
 
+/** Length of device description string, including NUL-terminator */
+#define BLADERF_DESCRIPTION_LENGTH 33
+
 /** Length of device serial number string, including NUL-terminator */
 #define BLADERF_SERIAL_LENGTH 33
 
@@ -130,6 +133,10 @@ struct bladerf_devinfo {
     uint8_t usb_bus;                    /**< Bus # device is attached to */
     uint8_t usb_addr;                   /**< Device address on bus */
     unsigned int instance;              /**< Device instance or ID */
+
+    /** Manufacturer description string */
+    char manufacturer[BLADERF_DESCRIPTION_LENGTH];
+    char product[BLADERF_DESCRIPTION_LENGTH]; /**< Product description string */
 };
 
 /**
@@ -734,7 +741,7 @@ int CALL_CONV bladerf_get_gain(struct bladerf *dev,
  *
  * The special value of ::BLADERF_GAIN_DEFAULT will return hardware AGC to
  * its default value at initialization.
- * 
+ *
  * @see bladerf_gain_mode for implementation guidance
  *
  * @param       dev         Device handle
@@ -774,7 +781,7 @@ int CALL_CONV bladerf_get_gain_mode(struct bladerf *dev,
  *
  * This function may be called with `NULL` for `modes` to determine the number
  * of gain modes supported.
- * 
+ *
  * @see bladerf_gain_mode for implementation guidance
  *
  * @param       dev         Device handle

--- a/host/libraries/libbladeRF/src/devinfo.c
+++ b/host/libraries/libbladeRF/src/devinfo.c
@@ -160,7 +160,7 @@ int bladerf_devinfo_list_add(struct bladerf_devinfo_list *list,
 
 void bladerf_init_devinfo(struct bladerf_devinfo *info)
 {
-    info->backend  = BLADERF_BACKEND_ANY;
+    info->backend = BLADERF_BACKEND_ANY;
 
     memset(info->serial, 0, BLADERF_SERIAL_LENGTH);
     strncpy(info->serial, DEVINFO_SERIAL_ANY, BLADERF_SERIAL_LENGTH - 1);
@@ -168,6 +168,12 @@ void bladerf_init_devinfo(struct bladerf_devinfo *info)
     info->usb_bus  = DEVINFO_BUS_ANY;
     info->usb_addr = DEVINFO_ADDR_ANY;
     info->instance = DEVINFO_INST_ANY;
+
+    memset(info->manufacturer, 0, BLADERF_DESCRIPTION_LENGTH);
+    strncpy(info->manufacturer, "<unknown>", BLADERF_DESCRIPTION_LENGTH - 1);
+
+    memset(info->product, 0, BLADERF_DESCRIPTION_LENGTH);
+    strncpy(info->product, "<unknown>", BLADERF_DESCRIPTION_LENGTH - 1);
 }
 
 bool bladerf_devinfo_matches(const struct bladerf_devinfo *a,

--- a/host/utilities/bladeRF-cli/src/cmd/info.c
+++ b/host/utilities/bladeRF-cli/src/cmd/info.c
@@ -17,9 +17,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <stdio.h>
 #include "cmd.h"
 #include "conversions.h"
+#include <stdio.h>
 
 int cmd_info(struct cli_state *state, int argc, char **argv)
 {
@@ -61,7 +61,8 @@ int cmd_info(struct cli_state *state, int argc, char **argv)
     usb_speed = bladerf_device_speed(state->dev);
 
     printf("\n");
-    printf("  Board:                    %s\n", bladerf_get_board_name(state->dev));
+    printf("  Board:                    %s %s (%s)\n", info.manufacturer,
+           info.product, bladerf_get_board_name(state->dev));
     printf("  Serial #:                 %s\n", info.serial);
     printf("  VCTCXO DAC calibration:   0x%.4x\n", dac_trim);
     if (fpga_size != 0) {

--- a/host/utilities/bladeRF-cli/src/cmd/probe.c
+++ b/host/utilities/bladeRF-cli/src/cmd/probe.c
@@ -17,9 +17,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <string.h>
-#include "rel_assert.h"
 #include "cmd.h"
+#include "rel_assert.h"
+#include <string.h>
 
 static inline const char *backend2str(bladerf_backend b)
 {
@@ -38,7 +38,7 @@ static inline const char *backend2str(bladerf_backend b)
 /* Todo move to cmd_probe.c */
 int cmd_probe(struct cli_state *s, int argc, char *argv[])
 {
-    bool error_on_no_dev = false;
+    bool error_on_no_dev            = false;
     struct bladerf_devinfo *devices = NULL;
     int n_devices, i;
 
@@ -72,6 +72,8 @@ int cmd_probe(struct cli_state *s, int argc, char *argv[])
 
     putchar('\n');
     for (i = 0; i < n_devices; i++) {
+        printf("  Description:    %s %s\n", devices[i].manufacturer,
+               devices[i].product);
         printf("  Backend:        %s\n", backend2str(devices[i].backend));
         printf("  Serial:         %s\n", devices[i].serial);
         printf("  USB Bus:        %d\n", devices[i].usb_bus);


### PR DESCRIPTION
Adds 'manufacturer' and 'product' members to the bladerf_devinfo struct, and ensures they are properly initialized and populated during enumeration.

These contain the human-readable manufacturer and product names from the USB device descriptor, and are displayed by bladeRF-cli during 'probe' and 'info' commands.

Note: This is a reimplementation of PR #611, which tried to be a little too clever.

Fixes #611 
Fixes #615 
Fixes #616 
Fixes #617 