### PR TITLE
libbladeRF: fix bladerf2_trigger_arm typo

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -3356,7 +3356,7 @@ static int bladerf2_trigger_arm(struct bladerf *dev,
 {
     CHECK_BOARD_STATE(STATE_INITIALIZED);
 
-    return fpga_trigger_fire(dev, trigger);
+    return fpga_trigger_arm(dev, trigger, arm);
 }
 
 static int bladerf2_trigger_fire(struct bladerf *dev,


### PR DESCRIPTION
on the bladerf2, bladerf_trigger_arm was calling fpga_trigger_fire
instead of fpga_trigger_arm, creating a situation where the triggers
were not being armed.

Fixes #632