### PR TITLE
Probe flash ID and return its size

### DIFF
--- a/firmware_common/bladeRF.h
+++ b/firmware_common/bladeRF.h
@@ -29,6 +29,7 @@
 #define BLADE_USB_CMD_RF_RX                     4
 #define BLADE_USB_CMD_RF_TX                     5
 #define BLADE_USB_CMD_QUERY_DEVICE_READY        6
+#define BLADE_USB_CMD_QUERY_FLASH_ID            7
 #define BLADE_USB_CMD_FLASH_READ              100
 #define BLADE_USB_CMD_FLASH_WRITE             101
 #define BLADE_USB_CMD_FLASH_ERASE             102

--- a/fx3_firmware/CMakeLists.txt
+++ b/fx3_firmware/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../host/cmake/modules)
 
 # Update these definitions when updating the firmware version
 set(VERSION_INFO_MAJOR 2)
-set(VERSION_INFO_MINOR 2)
+set(VERSION_INFO_MINOR 3)
 set(VERSION_INFO_PATCH 0)
 
 if(NOT DEFINED VERSION_INFO_EXTRA)

--- a/fx3_firmware/src/bladeRF.c
+++ b/fx3_firmware/src/bladeRF.c
@@ -454,6 +454,11 @@ CyBool_t NuandHandleVendorRequest(
         CyU3PUsbSendRetCode(ret);
     break;
 
+    case BLADE_USB_CMD_QUERY_FLASH_ID:
+        ret = (NuandGetSPIManufacturer() << 8) | NuandGetSPIDeviceID();
+        CyU3PUsbSendRetCode(ret);
+    break;
+
     case BLADE_USB_CMD_SET_LOOPBACK:
         NuandRFLinkLoopBack(wValue);
         CyU3PUsbSendRetCode(wValue);

--- a/fx3_firmware/src/flash.c
+++ b/fx3_firmware/src/flash.c
@@ -164,6 +164,13 @@ uint8_t NuandGetSPIManufacturer() {
     return spi_mfn[0];
 }
 
+uint8_t NuandGetSPIDeviceID() {
+    if (!cached_spi_mfn) {
+        cacheSPIManufacturer();
+    }
+    return spi_mfn[1];
+}
+
 CyU3PReturnStatus_t NuandReadOtp(size_t offset, size_t size, void *buf) {
     CyU3PReturnStatus_t status;
 

--- a/fx3_firmware/src/flash.h
+++ b/fx3_firmware/src/flash.h
@@ -29,6 +29,7 @@ CyU3PReturnStatus_t NuandReadOtp(size_t offset, size_t size, void *buf);
 CyU3PReturnStatus_t NuandWriteOtp(size_t offset, size_t size, void *buf);
 CyU3PReturnStatus_t NuandLockOtp();
 uint8_t NuandGetSPIManufacturer();
+uint8_t NuandGetSPIDeviceID();
 void cacheSPIManufacturer();
 
 

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -404,7 +404,7 @@ typedef enum {
 typedef enum {
     BLADERF_DEVICE_SPEED_UNKNOWN,
     BLADERF_DEVICE_SPEED_HIGH,
-    BLADERF_DEVICE_SPEED_SUPER,
+    BLADERF_DEVICE_SPEED_SUPER
 } bladerf_dev_speed;
 
 /**

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -436,6 +436,23 @@ int CALL_CONV bladerf_get_fpga_size(struct bladerf *dev,
                                     bladerf_fpga_size *size);
 
 /**
+ * Query a device's Flash size
+ *
+ * @param       dev      Device handle
+ * @param[out]  size     Will be updated with the size of the onboard flash,
+ *                       in bytes. If an error occurs, no data will be written
+ *                       to this pointer.
+ * @param[out]  is_guess True if the flash size is a guess (using FPGA size).
+ *                       False if the flash ID was queried and its size
+ *                       was successfully decoded.
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_flash_size(struct bladerf *dev, uint32_t *size,
+                                     bool *is_guess);
+
+/**
  * Query firmware version
  *
  * @param       dev         Device handle

--- a/host/libraries/libbladeRF/src/backend/backend.h
+++ b/host/libraries/libbladeRF/src/backend/backend.h
@@ -79,6 +79,9 @@ struct backend_fns {
     /* Get VID and PID of the device */
     int (*get_vid_pid)(struct bladerf *dev, uint16_t *vid, uint16_t *pid);
 
+    /* Get flash manufacturer/device IDs */
+    int (*get_flash_id)(struct bladerf *dev, uint8_t *mid, uint8_t *did);
+
     /* Opening device based upon specified device info. */
     int (*open)(struct bladerf *dev, struct bladerf_devinfo *info);
 

--- a/host/libraries/libbladeRF/src/backend/dummy/dummy.c
+++ b/host/libraries/libbladeRF/src/backend/dummy/dummy.c
@@ -64,6 +64,11 @@ static int dummy_is_fw_ready(struct bladerf *dev)
     return 0;
 }
 
+static int dummy_get_flash_id(struct bladerf *dev, uint8_t *mid, uint8_t *did)
+{
+    return BLADERF_ERR_UNSUPPORTED;
+}
+
 static int dummy_load_fpga(struct bladerf *dev, const uint8_t *image, size_t image_size)
 {
     return 0;
@@ -387,6 +392,7 @@ const struct backend_fns backend_fns_dummy = {
     FIELD_INIT(.probe, dummy_probe),
 
     FIELD_INIT(.get_vid_pid, dummy_get_vid_pid),
+    FIELD_INIT(.get_flash_id, usb_get_flash_id),
     FIELD_INIT(.open, dummy_open),
     FIELD_INIT(.set_fpga_protocol, dummy_set_fpga_protocol),
     FIELD_INIT(.close, dummy_close),

--- a/host/libraries/libbladeRF/src/backend/usb/usb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/usb.c
@@ -344,6 +344,23 @@ static int usb_get_vid_pid(struct bladerf *dev, uint16_t *vid, uint16_t *pid)
     return usb->fn->get_vid_pid(usb->driver, vid, pid);
 }
 
+static int usb_get_flash_id(struct bladerf *dev, uint8_t *mid, uint8_t *did)
+{
+    int status;
+    int result;
+
+    status = vendor_cmd_int(dev, BLADE_USB_CMD_QUERY_FLASH_ID,
+                            USB_DIR_DEVICE_TO_HOST, &result);
+    if (status < 0) {
+        log_debug("Could not read flash manufacturer ID and/or device ID. %s.\n",
+                  bladerf_strerror(status));
+    } else {
+        *did = result & 0xFF;
+        *mid = (result >> 8) & 0xFF;
+    }
+    return status;
+}
+
 static int begin_fpga_programming(struct bladerf *dev)
 {
     int result;
@@ -1108,6 +1125,7 @@ const struct backend_fns backend_fns_usb_legacy = {
     FIELD_INIT(.probe, usb_probe),
 
     FIELD_INIT(.get_vid_pid, usb_get_vid_pid),
+    FIELD_INIT(.get_flash_id, usb_get_flash_id),
     FIELD_INIT(.open, usb_open),
     FIELD_INIT(.set_fpga_protocol, usb_set_fpga_protocol),
     FIELD_INIT(.close, usb_close),
@@ -1209,6 +1227,7 @@ const struct backend_fns backend_fns_usb = {
     FIELD_INIT(.probe, usb_probe),
 
     FIELD_INIT(.get_vid_pid, usb_get_vid_pid),
+    FIELD_INIT(.get_flash_id, usb_get_flash_id),
     FIELD_INIT(.open, usb_open),
     FIELD_INIT(.set_fpga_protocol, usb_set_fpga_protocol),
     FIELD_INIT(.close, usb_close),

--- a/host/libraries/libbladeRF/src/backend/usb/usb.h
+++ b/host/libraries/libbladeRF/src/backend/usb/usb.h
@@ -104,6 +104,8 @@ struct usb_fns {
 
     int (*get_vid_pid)(void *driver, uint16_t *vid, uint16_t *pid);
 
+    int (*get_flash_id)(void *driver, uint8_t *mid, uint8_t *did);
+
     int (*get_speed)(void *driver, bladerf_dev_speed *speed);
 
     int (*change_setting)(void *driver, uint8_t setting);

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -105,7 +105,7 @@ int bladerf_open_with_devinfo(struct bladerf **opened_device,
             break;
         }
     }
-    /* If no matching borad was found */
+    /* If no matching board was found */
     if (i == bladerf_boards_len) {
         dev->backend->close(dev);
         free(dev);

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -348,6 +348,17 @@ int bladerf_get_fpga_size(struct bladerf *dev, bladerf_fpga_size *size)
     return status;
 }
 
+int bladerf_get_flash_size(struct bladerf *dev, uint32_t *size, bool *is_guess)
+{
+    int status;
+    MUTEX_LOCK(&dev->lock);
+
+    status = dev->board->get_flash_size(dev, size, is_guess);
+
+    MUTEX_UNLOCK(&dev->lock);
+    return status;
+}
+
 int bladerf_is_fpga_configured(struct bladerf *dev)
 {
     int status;

--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -1208,6 +1208,16 @@ static int bladerf1_get_fpga_size(struct bladerf *dev, bladerf_fpga_size *size)
     return 0;
 }
 
+static int bladerf1_get_flash_size(struct bladerf *dev, uint32_t *size, bool *is_guess)
+{
+    CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
+
+    *size     = dev->flash_arch->tsize_bytes;
+    *is_guess = (dev->flash_arch->status != STATUS_SUCCESS);
+
+    return 0;
+}
+
 static int bladerf1_is_fpga_configured(struct bladerf *dev)
 {
     CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
@@ -3392,6 +3402,7 @@ const struct board_fns bladerf1_board_fns = {
     FIELD_INIT(.device_speed, bladerf1_device_speed),
     FIELD_INIT(.get_serial, bladerf1_get_serial),
     FIELD_INIT(.get_fpga_size, bladerf1_get_fpga_size),
+    FIELD_INIT(.get_flash_size, bladerf1_get_flash_size),
     FIELD_INIT(.is_fpga_configured, bladerf1_is_fpga_configured),
     FIELD_INIT(.get_capabilities, bladerf1_get_capabilities),
     FIELD_INIT(.get_channel_count, bladerf1_get_channel_count),

--- a/host/libraries/libbladeRF/src/board/bladerf1/capabilities.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/capabilities.c
@@ -42,6 +42,10 @@ uint64_t bladerf1_get_fw_capabilities(const struct bladerf_version *fw_version)
         capabilities |= BLADERF_CAP_READ_FW_LOG_ENTRY;
     }
 
+    if (version_fields_greater_or_equal(fw_version, 2, 3, 0)) {
+        capabilities |= BLADERF_CAP_FW_FLASH_ID;
+    }
+
     return capabilities;
 }
 

--- a/host/libraries/libbladeRF/src/board/bladerf1/compatibility.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/compatibility.c
@@ -13,6 +13,7 @@
 
 static const struct compat fw_compat[] = {
     /*   Firmware       requires  >=        FPGA */
+    { VERSION(2, 3, 0),                 VERSION(0, 0, 2) },
     { VERSION(2, 2, 0),                 VERSION(0, 0, 2) },
     { VERSION(2, 1, 1),                 VERSION(0, 0, 2) },
     { VERSION(2, 1, 0),                 VERSION(0, 0, 2) },

--- a/host/libraries/libbladeRF/src/board/bladerf1/flash.h
+++ b/host/libraries/libbladeRF/src/board/bladerf1/flash.h
@@ -106,6 +106,28 @@ int spi_flash_read_vctcxo_trim(struct bladerf *dev, uint16_t *dac_trim);
 int spi_flash_read_fpga_size(struct bladerf *dev, bladerf_fpga_size *fpga_size);
 
 /**
+ * Retrieve SPI flash manufacturer ID and device ID.
+ *
+ * @param       dev         Device handle.
+ * @param[out]  mid         Flash manufacturer ID
+ * @param[out]  did         Flash device ID
+ *
+ * @return 0 on success, BLADERF_ERR_* on failure
+ */
+int spi_flash_read_flash_id(struct bladerf *dev, uint8_t *mid, uint8_t *did);
+
+/**
+ * Decode SPI flash architecture given manufacturer and device IDs.
+ *
+ * @param       dev         Device handle.
+ * @param       fpga_size   FPGA size
+ *
+ * @return 0 on success, BLADERF_ERR_* on failure
+ */
+int spi_flash_decode_flash_architecture(struct bladerf *dev,
+                                        bladerf_fpga_size  *fpga_size);
+
+/**
  * Encode a binary key-value pair.
  *
  * @param[in]       ptr     Pointer to data buffer that will contain encoded

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1635,6 +1635,20 @@ static int bladerf2_get_fpga_size(struct bladerf *dev, bladerf_fpga_size *size)
     return 0;
 }
 
+static int bladerf2_get_flash_size(struct bladerf *dev, uint32_t *size, bool *is_guess)
+{
+    if (NULL == size) {
+        RETURN_INVAL("size", "is null");
+    }
+
+    CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
+
+    *size = dev->flash_arch->tsize_bytes;
+    *is_guess = (dev->flash_arch->status != STATUS_SUCCESS);
+
+    return 0;
+}
+
 static int bladerf2_is_fpga_configured(struct bladerf *dev)
 {
     CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
@@ -4430,6 +4444,7 @@ const struct board_fns bladerf2_board_fns = {
     FIELD_INIT(.device_speed, bladerf2_device_speed),
     FIELD_INIT(.get_serial, bladerf2_get_serial),
     FIELD_INIT(.get_fpga_size, bladerf2_get_fpga_size),
+    FIELD_INIT(.get_flash_size, bladerf2_get_flash_size),
     FIELD_INIT(.is_fpga_configured, bladerf2_is_fpga_configured),
     FIELD_INIT(.get_capabilities, bladerf2_get_capabilities),
     FIELD_INIT(.get_channel_count, bladerf2_get_channel_count),

--- a/host/libraries/libbladeRF/src/board/bladerf2/capabilities.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/capabilities.c
@@ -46,6 +46,10 @@ uint64_t bladerf2_get_fw_capabilities(const struct bladerf_version *fw_version)
         capabilities |= BLADERF_CAP_FW_SUPPORTS_BLADERF2;
     }
 
+    if (version_fields_greater_or_equal(fw_version, 2, 3, 0)) {
+        capabilities |= BLADERF_CAP_FW_FLASH_ID;
+    }
+
     return capabilities;
 }
 

--- a/host/libraries/libbladeRF/src/board/bladerf2/compatibility.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/compatibility.c
@@ -13,6 +13,7 @@
 
 static const struct compat fw_compat[] = {
     /*   Firmware       requires  >=        FPGA */
+    { VERSION(2, 3, 0),                 VERSION(0, 6, 0) },
     { VERSION(2, 2, 0),                 VERSION(0, 6, 0) },
     { VERSION(2, 1, 1),                 VERSION(0, 6, 0) },
     { VERSION(2, 1, 0),                 VERSION(0, 6, 0) },

--- a/host/libraries/libbladeRF/src/board/board.h
+++ b/host/libraries/libbladeRF/src/board/board.h
@@ -132,6 +132,12 @@
  */
 #define BLADERF_CAP_FW_SUPPORTS_BLADERF2 (((uint64_t)1) << 35)
 
+/**
+ * FX3 firmware v2.3.0 introduced support for reporting the SPI Flash
+ * manufacturer ID and device ID.
+ */
+#define BLADERF_CAP_FW_FLASH_ID (((uint64_t)1) << 36)
+
 struct bladerf {
     /* Handle lock - to ensure atomic access to control and configuration
      * operations */

--- a/host/libraries/libbladeRF/src/board/board.h
+++ b/host/libraries/libbladeRF/src/board/board.h
@@ -148,16 +148,22 @@ struct bladerf {
 
     /* Backend-specific implementations */
     const struct backend_fns *backend;
+
     /* Backend's private data */
     void *backend_data;
 
     /* Board-specific implementations */
     const struct board_fns *board;
+
+    /* Flash architecture */
+    struct bladerf_flash_arch *flash_arch;
+
     /* Board's private data */
     void *board_data;
 
     /* XB attached */
     bladerf_xb xb;
+
     /* XB's private data */
     void *xb_data;
 };
@@ -426,6 +432,22 @@ struct board_fns {
 
     /* Board name */
     const char *name;
+};
+
+/* Information about the (SPI) flash architecture */
+struct bladerf_flash_arch {
+    enum {
+        STATUS_UNINITIALIZED,
+        STATUS_SUCCESS,
+        STATUS_ASSUMED
+    } status;
+    uint8_t  manufacturer_id;        /**< Raw manufacturer ID */
+    uint8_t  device_id;              /**< Raw device ID */
+    uint32_t tsize_bytes;            /**< Total size of flash, in bytes */
+    uint32_t psize_bytes;            /**< Flash page size, in bytes */
+    uint32_t ebsize_bytes;           /**< Flash erase block size, in bytes */
+    uint32_t num_pages;              /**< Size of flash, in pages */
+    uint32_t num_ebs;                /**< Size of flash, in erase blocks */
 };
 
 /* Boards */

--- a/host/libraries/libbladeRF/src/board/board.h
+++ b/host/libraries/libbladeRF/src/board/board.h
@@ -180,6 +180,7 @@ struct board_fns {
     bladerf_dev_speed (*device_speed)(struct bladerf *dev);
     int (*get_serial)(struct bladerf *dev, char *serial);
     int (*get_fpga_size)(struct bladerf *dev, bladerf_fpga_size *size);
+    int (*get_flash_size)(struct bladerf *dev, uint32_t *size, bool *is_guess);
     int (*is_fpga_configured)(struct bladerf *dev);
     uint64_t (*get_capabilities)(struct bladerf *dev);
     size_t (*get_channel_count)(struct bladerf *dev, bladerf_direction dir);

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
@@ -512,6 +512,15 @@ class BladeRF:
 
     fpga_size = property(get_fpga_size, doc="FPGA size in kLE")
 
+    def get_flash_size(self):
+        flash_size = ffi.new("uint32_t *")
+        is_guess   = ffi.new("bool *")
+        ret = libbladeRF.bladerf_get_flash_size(self.dev[0], flash_size, is_guess)
+        _check_error(ret)
+        return (flash_size[0], is_guess[0])
+
+    flash_size = property(get_flash_size, doc="Flash size in bytes")
+
     def is_fpga_configured(self):
         ret = libbladeRF.bladerf_is_fpga_configured(self.dev[0])
         _check_error(ret)

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_cdef.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_cdef.py
@@ -69,6 +69,8 @@ header = """
   int bladerf_get_serial(struct bladerf *dev, char *serial);
   int bladerf_get_fpga_size(struct bladerf *dev, bladerf_fpga_size
     *size);
+  int bladerf_get_flash_size(struct bladerf *dev, uint32_t *size,
+    bool *is_guess);
   int bladerf_fw_version(struct bladerf *dev, struct bladerf_version
     *version);
   int bladerf_is_fpga_configured(struct bladerf *dev);

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_tool.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_tool.py
@@ -24,7 +24,7 @@ import argparse
 from bladerf import _bladerf
 
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 def _bool_to_onoff(val):
@@ -80,6 +80,9 @@ def _print_cmd_info(device=None, devinfo=None, verbose=False):
     b = _bladerf.BladeRF(device, devinfo)
 
     devinfo = b.get_devinfo()
+
+    flash_size, fs_guessed = b.flash_size
+
     if verbose:
         print("Object           ", repr(b))
     print("Board Name       ", b.board_name)
@@ -90,6 +93,8 @@ def _print_cmd_info(device=None, devinfo=None, verbose=False):
         print("FPGA Version     ", b.fpga_version)
     else:
         print("FPGA Version     ", "Not Configured")
+    print("Flash Size       ", (flash_size>>17), "Mbit",
+          "(assumed)" if fs_guessed else "")
     print("Firmware Version ", b.fw_version)
 
     if verbose:

--- a/host/libraries/libbladeRF_bindings/python/setup.py
+++ b/host/libraries/libbladeRF_bindings/python/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='bladerf',
-    version='1.0.1',
+    version='1.1.0',
     description='CFFI-based Python 3 binding to libbladeRF',
     long_description=long_description,
     url='https://github.com/Nuand/bladeRF',

--- a/host/utilities/bladeRF-cli/src/cmd/info.c
+++ b/host/utilities/bladeRF-cli/src/cmd/info.c
@@ -25,8 +25,10 @@ int cmd_info(struct cli_state *state, int argc, char **argv)
 {
     int status;
     bladerf_fpga_size fpga_size;
+    uint32_t flash_size;
     uint16_t dac_trim;
     bool fpga_loaded;
+    bool flash_size_guessed;
     struct bladerf_devinfo info;
     bladerf_dev_speed usb_speed;
     const char *backend_str;
@@ -52,6 +54,13 @@ int cmd_info(struct cli_state *state, int argc, char **argv)
         return CLI_RET_LIBBLADERF;
     }
 
+    status = bladerf_get_flash_size(state->dev, &flash_size,
+                                    &flash_size_guessed);
+    if (status < 0) {
+        state->last_lib_error = status;
+        return CLI_RET_LIBBLADERF;
+    }
+
     status = bladerf_get_vctcxo_trim(state->dev, &dac_trim);
     if (status < 0) {
         state->last_lib_error = status;
@@ -71,6 +80,12 @@ int cmd_info(struct cli_state *state, int argc, char **argv)
         printf("  FPGA size:                Unknown\n");
     }
     printf("  FPGA loaded:              %s\n", fpga_loaded ? "yes" : "no");
+    if (flash_size != 0) {
+        printf("  Flash size:               %u Mbit", (flash_size >> 17));
+        printf( flash_size_guessed ? " (assumed)\n" : "\n");
+    } else {
+        printf("  Flash size:               Unknown\n");
+    }
     printf("  USB bus:                  %d\n", info.usb_bus);
     printf("  USB address:              %d\n", info.usb_addr);
     printf("  USB speed:                %s\n", devspeed2str(usb_speed));


### PR DESCRIPTION
First "half" of fixing issue #571. Provides a mechanism to read out the manufacturer and device IDs from the SPI flash. This can be used to determine the density and architecture.