### PR TITLE
libbladeRF: add get_flash_id to usb_fns struct in usb drivers

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/cyapi.c
+++ b/host/libraries/libbladeRF/src/backend/usb/cyapi.c
@@ -809,6 +809,7 @@ extern "C" {
         FIELD_INIT(.open, cyapi_open),
         FIELD_INIT(.close, cyapi_close),
         FIELD_INIT(.get_vid_pid, cyapi_get_vid_pid),
+        FIELD_INIT(.get_flash_id, NULL),
         FIELD_INIT(.get_speed, cyapi_get_speed),
         FIELD_INIT(.change_setting, cyapi_change_setting),
         FIELD_INIT(.control_transfer, cyapi_control_transfer),

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1448,6 +1448,7 @@ static const struct usb_fns libusb_fns = {
     FIELD_INIT(.open, lusb_open),
     FIELD_INIT(.close, lusb_close),
     FIELD_INIT(.get_vid_pid, lusb_get_vid_pid),
+    FIELD_INIT(.get_flash_id, NULL),
     FIELD_INIT(.get_speed, lusb_get_speed),
     FIELD_INIT(.change_setting, lusb_change_setting),
     FIELD_INIT(.control_transfer, lusb_control_transfer),


### PR DESCRIPTION
MSVC is a stickler about how structs are populated, and
so we need to put something in libusb.c and cyapi.c even
though get_flash_id is actually handled in usb.c