### PR TITLE
hdl: bladerf1: move AGC SPI driver into 80 MHz clock domain

### DIFF
--- a/hdl/fpga/ip/nuand/synthesis/lms6002d/vhdl/bladerf_agc_lms_drv.vhd
+++ b/hdl/fpga/ip/nuand/synthesis/lms6002d/vhdl/bladerf_agc_lms_drv.vhd
@@ -101,6 +101,10 @@ architecture arch of bladerf_agc_lms_drv is
         arbiter_req         :   std_logic ;
         arbiter_done        :   std_logic ;
 
+        gain_inc_req        :   std_logic ;
+        gain_dec_req        :   std_logic ;
+        gain_rst_req        :   std_logic ;
+
         -- Avalon-MM Interface
         mm_write            :   std_logic ;
         mm_addr             :   std_logic_vector(7 downto 0) ;
@@ -115,6 +119,9 @@ architecture arch of bladerf_agc_lms_drv is
         rv.initializing := '0' ;
         rv.arbiter_req  := '0' ;
         rv.arbiter_done := '0' ;
+        rv.gain_inc_req := '0' ;
+        rv.gain_dec_req := '0' ;
+        rv.gain_rst_req := '0' ;
         rv.gain_state   := UNSET_GAIN_STATE ;
         rv.mm_addr      := ( others => '0' ) ;
         rv.mm_din       := ( others => '0' ) ;
@@ -176,6 +183,10 @@ begin
         future.arbiter_done <= '0' ;
         future.arbiter_req  <= '0' ;
 
+        future.gain_inc_req <= gain_inc_req ;
+        future.gain_dec_req <= gain_dec_req ;
+        future.gain_rst_req <= gain_rst_req ;
+
         case current.fsm is
             when INIT =>
                 future.nack <= '1' ;
@@ -188,7 +199,7 @@ begin
                 end if ;
 
             when IDLE =>
-                if( gain_inc_req = '1' ) then
+                if( current.gain_inc_req = '1' ) then
                     if( current.gain_state = LOW_GAIN_STATE ) then
                         future.gain_state <= MID_GAIN_STATE ;
                         future.future_gain <= MID_GAIN ;
@@ -202,7 +213,7 @@ begin
                         -- we are already as high as can be
                     end if ;
                 end if ;
-                if( gain_dec_req = '1' ) then
+                if( current.gain_dec_req = '1' ) then
                     if( current.gain_state = MID_GAIN_STATE ) then
                         future.gain_state <= LOW_GAIN_STATE ;
                         future.future_gain <= LOW_GAIN ;
@@ -216,7 +227,7 @@ begin
                         -- we are already as low as can be
                     end if ;
                 end if ;
-                if( gain_rst_req = '1' ) then
+                if( current.gain_rst_req = '1' ) then
                     future.gain_state <= HIGH_GAIN_STATE ;
                     future.future_gain <= HIGH_GAIN ;
                 end if ;

--- a/hdl/fpga/ip/nuand/synthesis/lms6002d/vhdl/bladerf_agc_lms_drv.vhd
+++ b/hdl/fpga/ip/nuand/synthesis/lms6002d/vhdl/bladerf_agc_lms_drv.vhd
@@ -20,7 +20,7 @@ library ieee ;
 
 entity bladerf_agc_lms_drv is
   port (
-    -- 40MHz clock and async asserted, sync deasserted reset
+    -- 80 MHz clock and async asserted, sync deasserted reset
     clock           :   in  std_logic ;
     reset           :   in  std_logic ;
 
@@ -136,6 +136,9 @@ begin
     gain_nack <= current.nack ;
 
     U_spi_controller: entity work.lms6_spi_controller
+      generic map (
+        CLOCK_DIV       => 4
+      )
       port map (
         -- Physical Interface
         sclk            => sclk,

--- a/hdl/fpga/platforms/bladerf/constraints/bladerf.sdc
+++ b/hdl/fpga/platforms/bladerf/constraints/bladerf.sdc
@@ -65,8 +65,8 @@ create_generated_clock -name lms_sclk_pin -source [get_registers -no_duplicates 
 set_input_delay  -clock_fall -clock lms_sclk_pin -min  1.0 [get_ports {lms_sdo}]
 set_input_delay  -clock_fall -clock lms_sclk_pin -max  9.0 [get_ports {lms_sdo}] -add_delay
 
-set_output_delay -clock lms_sclk_pin -min  1.0 [get_ports {lms_sen lms_sdio}]
-set_output_delay -clock lms_sclk_pin -max  2.0 [get_ports {lms_sen lms_sdio}] -add_delay
+set_output_delay -clock lms_sclk_pin -min  1.0 [get_ports {lms_sen lms_sdio lms_sclk}]
+set_output_delay -clock lms_sclk_pin -max  2.0 [get_ports {lms_sen lms_sdio lms_sclk}] -add_delay
 
 set_multicycle_path -setup -start -from [get_clocks {U_pll*clk[0]}] -to [get_clocks lms_sclk_pin] 4
 set_multicycle_path -hold -start -from [get_clocks {U_pll*clk[0]}] -to [get_clocks lms_sclk_pin] 4

--- a/hdl/fpga/platforms/bladerf/constraints/bladerf.sdc
+++ b/hdl/fpga/platforms/bladerf/constraints/bladerf.sdc
@@ -68,10 +68,10 @@ set_input_delay  -clock_fall -clock lms_sclk_pin -max  9.0 [get_ports {lms_sdo}]
 set_output_delay -clock lms_sclk_pin -min  1.0 [get_ports {lms_sen lms_sdio}]
 set_output_delay -clock lms_sclk_pin -max  2.0 [get_ports {lms_sen lms_sdio}] -add_delay
 
-set_multicycle_path -setup -start -from [get_clocks {U_pll*clk[0]}] -to [get_clocks lms_sclk_pin] 2
-set_multicycle_path -hold -start -from [get_clocks {U_pll*clk[0]}] -to [get_clocks lms_sclk_pin] 2
-set_multicycle_path -setup -end -from [get_clocks lms_sclk_pin] -to [get_clocks {U_pll*clk[0]}] 2
-set_multicycle_path -hold -end -from [get_clocks lms_sclk_pin] -to [get_clocks {U_pll*clk[0]}] 2
+set_multicycle_path -setup -start -from [get_clocks {U_pll*clk[0]}] -to [get_clocks lms_sclk_pin] 4
+set_multicycle_path -hold -start -from [get_clocks {U_pll*clk[0]}] -to [get_clocks lms_sclk_pin] 4
+set_multicycle_path -setup -end -from [get_clocks lms_sclk_pin] -to [get_clocks {U_pll*clk[0]}] 4
+set_multicycle_path -hold -end -from [get_clocks lms_sclk_pin] -to [get_clocks {U_pll*clk[0]}] 4
 
 # Si5338 interface
 set_input_delay -clock [get_clocks U_pll*0*] -min  1.0 [get_ports {si_scl si_sda}]


### PR DESCRIPTION
This ensures that the SPI controllers have a consistent clock to work with, instead of rx_clock (which depends on the configured ADC sample rate). This ensures the SPI clock will always be 20 MHz, and that everything is passing between known clock domains.

Also registers the gain change request lines going into bladerf_agc_lms_drv to improve timing margin, and adds a set_output_delay timing constraint on lms_sclk.

Fixes #640 
