### PR TITLE
Memory deallocation fix

### DIFF
--- a/host/common/src/parse.c
+++ b/host/common/src/parse.c
@@ -214,9 +214,6 @@ static struct config_options *add_opt(
 
     rv[optc - 1].lineno = lineno;
 
-    //free(ptr1);
-    //free(ptr2);
-
     return rv;
 }
 

--- a/host/common/src/parse.c
+++ b/host/common/src/parse.c
@@ -214,8 +214,8 @@ static struct config_options *add_opt(
 
     rv[optc - 1].lineno = lineno;
 
-    free(ptr1);
-    free(ptr2);
+    //free(ptr1);
+    //free(ptr2);
 
     return rv;
 }


### PR DESCRIPTION
parse.c is releasing memory for strings, after it assigns the memory location to a struct. This results in the memory potentially being overwritten by subsequent allocations before it's referenced. 
 
Fixes #643 