### PR TITLE
host: bladerf1: skip init if BLADERF_FORCE_NO_FPGA_PRESENT

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -984,6 +984,13 @@ static int bladerf1_open(struct bladerf *dev, struct bladerf_devinfo *devinfo)
         }
     }
 
+    /* Skip further work if BLADERF_FORCE_NO_FPGA_PRESENT is set */
+    if (getenv("BLADERF_FORCE_NO_FPGA_PRESENT")) {
+        log_debug("Skipping FPGA configuration and initialization - "
+                  "BLADERF_FORCE_NO_FPGA_PRESENT is set.\n");
+        return 0;
+    }
+
     /* Check for possible mismatch between the USB device identification and
      * the board's own knowledge. We need this to be a non-fatal condition,
      * so that the problem can be fixed easily. */


### PR DESCRIPTION
On the bladerf2, we have a comparatively long initialization process,
and thus we skip the init if we're "just" loading an FPGA, e.g. with
the -l option to bladeRF-cli.

This adds the same bypass to bladerf1.