### PR TITLE
host: libbladerf/bladerf2: implement bladerf_{set,get}_stream_timeout

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -3653,14 +3653,26 @@ static int bladerf2_set_stream_timeout(struct bladerf *dev,
                                        bladerf_direction dir,
                                        unsigned int timeout)
 {
-    return BLADERF_ERR_UNSUPPORTED;
+    struct bladerf2_board_data *board_data = dev->board_data;
+
+    MUTEX_LOCK(&board_data->sync[dir].lock);
+    board_data->sync[dir].stream_config.timeout_ms = timeout;
+    MUTEX_UNLOCK(&board_data->sync[dir].lock);
+
+    return 0;
 }
 
 static int bladerf2_get_stream_timeout(struct bladerf *dev,
                                        bladerf_direction dir,
                                        unsigned int *timeout)
 {
-    return BLADERF_ERR_UNSUPPORTED;
+    struct bladerf2_board_data *board_data = dev->board_data;
+
+    MUTEX_LOCK(&board_data->sync[dir].lock);
+    *timeout = board_data->sync[dir].stream_config.timeout_ms;
+    MUTEX_UNLOCK(&board_data->sync[dir].lock);
+
+    return 0;
 }
 
 static int bladerf2_sync_config(struct bladerf *dev,


### PR DESCRIPTION
These were somehow not implemented, but were pretty easy copies from bladerf1.c