### PR TITLE
host: libbladeRF/sync: extend transfer timeout to match stream timeout

### DIFF
--- a/host/libraries/libbladeRF/src/streaming/async.c
+++ b/host/libraries/libbladeRF/src/streaming/async.c
@@ -143,6 +143,26 @@ int async_init_stream(struct bladerf_stream **stream,
     return status;
 }
 
+int async_set_transfer_timeout(struct bladerf_stream *stream,
+                               unsigned int transfer_timeout_ms)
+{
+    MUTEX_LOCK(&stream->lock);
+    stream->transfer_timeout = transfer_timeout_ms;
+    MUTEX_UNLOCK(&stream->lock);
+
+    return 0;
+}
+
+int async_get_transfer_timeout(struct bladerf_stream *stream,
+                               unsigned int *transfer_timeout_ms)
+{
+    MUTEX_LOCK(&stream->lock);
+    *transfer_timeout_ms = stream->transfer_timeout;
+    MUTEX_UNLOCK(&stream->lock);
+
+    return 0;
+}
+
 int async_run_stream(struct bladerf_stream *stream, bladerf_channel_layout layout)
 {
     int status;

--- a/host/libraries/libbladeRF/src/streaming/async.h
+++ b/host/libraries/libbladeRF/src/streaming/async.h
@@ -79,6 +79,14 @@ int async_init_stream(struct bladerf_stream **stream,
                       size_t num_transfers,
                       void *user_data);
 
+/* Set the transfer timeout. This acquires stream->lock. */
+int async_set_transfer_timeout(struct bladerf_stream *stream,
+                               unsigned int transfer_timeout_ms);
+
+/* Get the transfer timeout. This acquires stream->lock. */
+int async_get_transfer_timeout(struct bladerf_stream *stream,
+                               unsigned int *transfer_timeout_ms);
+
 /* Backend code is responsible for acquiring stream->lock in their callbacks */
 int async_run_stream(struct bladerf_stream *stream,
                      bladerf_channel_layout layout);


### PR DESCRIPTION
In a case where we have a long stream timeout, e.g. when using
triggered receive, the long stream timeout is being rendered
ineffective by the per-transfer timeout, which defaults to
1000 ms.

This adds two functions to async, for setting and getting the
transfer timeout:

```
int async_set_transfer_timeout(struct bladerf_stream *stream,
                               unsigned int transfer_timeout_ms);
int async_get_transfer_timeout(struct bladerf_stream *stream,
                               unsigned int *transfer_timeout_ms);
```

This also calls `async_set_transfer_timeout` in `sync_worker_init`,
setting it to either the `BULK_TIMEOUT_MS` from usb.h (1000 ms)
or the `timeout_ms` for the stream (user-specified), whichever is
longer.

Fixes #655 