### PR TITLE
Identify the last source (SPI or USB) which programmed the FPGA

### DIFF
--- a/firmware_common/bladeRF.h
+++ b/firmware_common/bladeRF.h
@@ -30,6 +30,7 @@
 #define BLADE_USB_CMD_RF_TX                     5
 #define BLADE_USB_CMD_QUERY_DEVICE_READY        6
 #define BLADE_USB_CMD_QUERY_FLASH_ID            7
+#define BLADE_USB_CMD_QUERY_FPGA_SOURCE         8
 #define BLADE_USB_CMD_FLASH_READ              100
 #define BLADE_USB_CMD_FLASH_WRITE             101
 #define BLADE_USB_CMD_FLASH_ERASE             102
@@ -87,6 +88,18 @@ struct bladeRF_sector {
     unsigned int len;
     unsigned char *ptr;
 };
+
+/**
+ * FPGA configuration source
+ * 
+ * Note: the numbering of this enum must match bladerf_fpga_source in
+ * libbladeRF.h
+ */
+typedef enum {
+    NUAND_FPGA_CONFIG_SOURCE_INVALID = 0, /**< Uninitialized/invalid */
+    NUAND_FPGA_CONFIG_SOURCE_FLASH   = 1, /**< Last FPGA load was from flash */
+    NUAND_FPGA_CONFIG_SOURCE_HOST    = 2  /**< Last FPGA load was from host */
+} NuandFpgaConfigSource;
 
 #define USB_CYPRESS_VENDOR_ID   0x04b4
 #define USB_FX3_PRODUCT_ID      0x00f3

--- a/fx3_firmware/CMakeLists.txt
+++ b/fx3_firmware/CMakeLists.txt
@@ -4,7 +4,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(bladeRF_fw C)
 
-
 ################################################################################
 # Project configuration
 ################################################################################
@@ -35,7 +34,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../host/cmake/modules)
 # Update these definitions when updating the firmware version
 set(VERSION_INFO_MAJOR 2)
 set(VERSION_INFO_MINOR 3)
-set(VERSION_INFO_PATCH 0)
+set(VERSION_INFO_PATCH 1)
 
 if(NOT DEFINED VERSION_INFO_EXTRA)
     set(VERSION_INFO_EXTRA "git")

--- a/fx3_firmware/src/bladeRF.c
+++ b/fx3_firmware/src/bladeRF.c
@@ -435,6 +435,9 @@ CyBool_t NuandHandleVendorRequest(
 
     case BLADE_USB_CMD_BEGIN_PROG:
         retStatus = FpgaBeginProgram();
+        if(0 == retStatus) {
+            NuandSetFpgaConfigSource(NUAND_FPGA_CONFIG_SOURCE_HOST);
+        }
         CyU3PUsbSendRetCode(retStatus);
     break;
 
@@ -458,6 +461,10 @@ CyBool_t NuandHandleVendorRequest(
         ret = (NuandGetSPIManufacturer() << 8) | NuandGetSPIDeviceID();
         CyU3PUsbSendRetCode(ret);
     break;
+
+    case BLADE_USB_CMD_QUERY_FPGA_SOURCE:
+        ret = (unsigned int)NuandGetFpgaConfigSource();
+        CyU3PUsbSendRetCode(ret);
 
     case BLADE_USB_CMD_SET_LOOPBACK:
         NuandRFLinkLoopBack(wValue);

--- a/fx3_firmware/src/fpga.h
+++ b/fx3_firmware/src/fpga.h
@@ -28,5 +28,7 @@ void NuandFpgaConfigSwInit(void);
 extern const struct NuandApplication NuandFpgaConfig;
 int FpgaBeginProgram(void);
 CyBool_t NuandLoadFromFlash(int fpga_len);
+NuandFpgaConfigSource NuandGetFpgaConfigSource(void);
+void NuandSetFpgaConfigSource(NuandFpgaConfigSource src);
 
 #endif /* _FPGA_H_ */

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -415,6 +415,18 @@ typedef enum {
 } bladerf_dev_speed;
 
 /**
+ * FPGA configuration source
+ *
+ * Note: the numbering of this enum must match NuandFpgaConfigSource in
+ * firmware_common/bladeRF.h
+ */
+typedef enum {
+    BLADERF_FPGA_SOURCE_UNKNOWN = 0, /**< Uninitialized/invalid */
+    BLADERF_FPGA_SOURCE_FLASH   = 1, /**< Last FPGA load was from flash */
+    BLADERF_FPGA_SOURCE_HOST    = 2  /**< Last FPGA load was from host */
+} bladerf_fpga_source;
+
+/**
  * Query a device's serial number (deprecated)
  *
  * @param       dev     Device handle
@@ -484,7 +496,8 @@ int CALL_CONV bladerf_get_fpga_size(struct bladerf *dev,
  * @return 0 on success, value from \ref RETCODES list on failure
  */
 API_EXPORT
-int CALL_CONV bladerf_get_flash_size(struct bladerf *dev, uint32_t *size,
+int CALL_CONV bladerf_get_flash_size(struct bladerf *dev,
+                                     uint32_t *size,
                                      bool *is_guess);
 
 /**
@@ -522,6 +535,24 @@ int CALL_CONV bladerf_is_fpga_configured(struct bladerf *dev);
 API_EXPORT
 int CALL_CONV bladerf_fpga_version(struct bladerf *dev,
                                    struct bladerf_version *version);
+
+/**
+ * Query FPGA configuration source
+ *
+ * Determine whether the FPGA image was loaded from flash, or if it was
+ * loaded from the host, by asking the firmware for the last-known FPGA
+ * configuration source.
+ *
+ * @param       dev     Device handle
+ * @param[out]  source  Source of the configuration
+ *
+ * @return 0 on success, ::BLADERF_ERR_UNSUPPORTED if the
+ * BLADERF_CAP_FW_FPGA_SOURCE capability is not present, value from \ref
+ * RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_fpga_source(struct bladerf *dev,
+                                      bladerf_fpga_source *source);
 
 /**
  * Obtain the bus speed at which the device is operating

--- a/host/libraries/libbladeRF/src/backend/backend.h
+++ b/host/libraries/libbladeRF/src/backend/backend.h
@@ -100,6 +100,7 @@ struct backend_fns {
                      const uint8_t *image,
                      size_t image_size);
     int (*is_fpga_configured)(struct bladerf *dev);
+    bladerf_fpga_source (*get_fpga_source)(struct bladerf *dev);
 
     /* Version checking */
     int (*get_fw_version)(struct bladerf *dev, struct bladerf_version *version);

--- a/host/libraries/libbladeRF/src/backend/usb/usb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/usb.c
@@ -159,6 +159,26 @@ static int usb_set_fpga_protocol(struct bladerf *dev, backend_fpga_protocol fpga
     return 0;
 }
 
+static bladerf_fpga_source usb_get_fpga_source(struct bladerf *dev)
+{
+    int result = -1;
+    int status;
+
+    status = vendor_cmd_int(dev, BLADE_USB_CMD_QUERY_FPGA_SOURCE,
+                            USB_DIR_DEVICE_TO_HOST, &result);
+
+    if (status < 0) {
+        log_debug("%s: vendor_cmd_int returned %s\n", __FUNCTION__,
+                  bladerf_strerror(status));
+        return BLADERF_FPGA_SOURCE_UNKNOWN;
+    } else if (0 == result || 1 == result || 2 == result) {
+        return (bladerf_fpga_source)result;
+    } else {
+        log_debug("Unexpected result from FPGA source query: %d\n", result);
+        return BLADERF_FPGA_SOURCE_UNKNOWN;
+    }
+}
+
 /* After performing a flash operation, switch back to either RF_LINK or the
  * FPGA loader.
  */
@@ -1134,6 +1154,7 @@ const struct backend_fns backend_fns_usb_legacy = {
 
     FIELD_INIT(.load_fpga, usb_load_fpga),
     FIELD_INIT(.is_fpga_configured, usb_is_fpga_configured),
+    FIELD_INIT(.get_fpga_source, usb_get_fpga_source),
 
     FIELD_INIT(.get_fw_version, usb_get_fw_version),
     FIELD_INIT(.get_fpga_version, usb_get_fpga_version),
@@ -1236,6 +1257,7 @@ const struct backend_fns backend_fns_usb = {
 
     FIELD_INIT(.load_fpga, usb_load_fpga),
     FIELD_INIT(.is_fpga_configured, usb_is_fpga_configured),
+    FIELD_INIT(.get_fpga_source, usb_get_fpga_source),
 
     FIELD_INIT(.get_fw_version, usb_get_fw_version),
     FIELD_INIT(.get_fpga_version, usb_get_fpga_version),

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -391,6 +391,17 @@ int bladerf_is_fpga_configured(struct bladerf *dev)
     return status;
 }
 
+int bladerf_get_fpga_source(struct bladerf *dev, bladerf_fpga_source *source)
+{
+    int status;
+    MUTEX_LOCK(&dev->lock);
+
+    status = dev->board->get_fpga_source(dev, source);
+
+    MUTEX_UNLOCK(&dev->lock);
+    return status;
+}
+
 const char *bladerf_get_board_name(struct bladerf *dev)
 {
     return dev->board->name;

--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -1235,6 +1235,24 @@ static int bladerf1_is_fpga_configured(struct bladerf *dev)
     return dev->backend->is_fpga_configured(dev);
 }
 
+static int bladerf1_get_fpga_source(struct bladerf *dev,
+                                    bladerf_fpga_source *source)
+{
+    CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
+
+    struct bladerf1_board_data *board_data = dev->board_data;
+
+    if (!have_cap(board_data->capabilities, BLADERF_CAP_FW_FPGA_SOURCE)) {
+        log_debug("%s: not supported by firmware\n", __FUNCTION__);
+        *source = BLADERF_FPGA_SOURCE_UNKNOWN;
+        return BLADERF_ERR_UNSUPPORTED;
+    }
+
+    *source = dev->backend->get_fpga_source(dev);
+
+    return 0;
+}
+
 static uint64_t bladerf1_get_capabilities(struct bladerf *dev)
 {
     struct bladerf1_board_data *board_data = dev->board_data;
@@ -3420,6 +3438,7 @@ const struct board_fns bladerf1_board_fns = {
     FIELD_INIT(.get_fpga_size, bladerf1_get_fpga_size),
     FIELD_INIT(.get_flash_size, bladerf1_get_flash_size),
     FIELD_INIT(.is_fpga_configured, bladerf1_is_fpga_configured),
+    FIELD_INIT(.get_fpga_source, bladerf1_get_fpga_source),
     FIELD_INIT(.get_capabilities, bladerf1_get_capabilities),
     FIELD_INIT(.get_channel_count, bladerf1_get_channel_count),
     FIELD_INIT(.get_fpga_version, bladerf1_get_fpga_version),

--- a/host/libraries/libbladeRF/src/board/bladerf1/capabilities.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/capabilities.c
@@ -46,6 +46,10 @@ uint64_t bladerf1_get_fw_capabilities(const struct bladerf_version *fw_version)
         capabilities |= BLADERF_CAP_FW_FLASH_ID;
     }
 
+    if (version_fields_greater_or_equal(fw_version, 2, 3, 1)) {
+        capabilities |= BLADERF_CAP_FW_FPGA_SOURCE;
+    }
+
     return capabilities;
 }
 

--- a/host/libraries/libbladeRF/src/board/bladerf1/compatibility.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/compatibility.c
@@ -13,6 +13,7 @@
 
 static const struct compat fw_compat[] = {
     /*   Firmware       requires  >=        FPGA */
+    { VERSION(2, 3, 1),                 VERSION(0, 0, 2) },
     { VERSION(2, 3, 0),                 VERSION(0, 0, 2) },
     { VERSION(2, 2, 0),                 VERSION(0, 0, 2) },
     { VERSION(2, 1, 1),                 VERSION(0, 0, 2) },

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1660,6 +1660,24 @@ static int bladerf2_is_fpga_configured(struct bladerf *dev)
     return dev->backend->is_fpga_configured(dev);
 }
 
+static int bladerf2_get_fpga_source(struct bladerf *dev,
+                                    bladerf_fpga_source *source)
+{
+    CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
+
+    struct bladerf2_board_data *board_data = dev->board_data;
+
+    if (!have_cap(board_data->capabilities, BLADERF_CAP_FW_FPGA_SOURCE)) {
+        log_debug("%s: not supported by firmware\n", __FUNCTION__);
+        *source = BLADERF_FPGA_SOURCE_UNKNOWN;
+        return BLADERF_ERR_UNSUPPORTED;
+    }
+
+    *source = dev->backend->get_fpga_source(dev);
+
+    return 0;
+}
+
 static uint64_t bladerf2_get_capabilities(struct bladerf *dev)
 {
     struct bladerf2_board_data *board_data;
@@ -4450,6 +4468,7 @@ const struct board_fns bladerf2_board_fns = {
     FIELD_INIT(.get_fpga_size, bladerf2_get_fpga_size),
     FIELD_INIT(.get_flash_size, bladerf2_get_flash_size),
     FIELD_INIT(.is_fpga_configured, bladerf2_is_fpga_configured),
+    FIELD_INIT(.get_fpga_source, bladerf2_get_fpga_source),
     FIELD_INIT(.get_capabilities, bladerf2_get_capabilities),
     FIELD_INIT(.get_channel_count, bladerf2_get_channel_count),
     FIELD_INIT(.get_fpga_version, bladerf2_get_fpga_version),

--- a/host/libraries/libbladeRF/src/board/bladerf2/capabilities.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/capabilities.c
@@ -50,6 +50,10 @@ uint64_t bladerf2_get_fw_capabilities(const struct bladerf_version *fw_version)
         capabilities |= BLADERF_CAP_FW_FLASH_ID;
     }
 
+    if (version_fields_greater_or_equal(fw_version, 2, 3, 1)) {
+        capabilities |= BLADERF_CAP_FW_FPGA_SOURCE;
+    }
+
     return capabilities;
 }
 

--- a/host/libraries/libbladeRF/src/board/bladerf2/compatibility.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/compatibility.c
@@ -13,6 +13,7 @@
 
 static const struct compat fw_compat[] = {
     /*   Firmware       requires  >=        FPGA */
+    { VERSION(2, 3, 1),                 VERSION(0, 6, 0) },
     { VERSION(2, 3, 0),                 VERSION(0, 6, 0) },
     { VERSION(2, 2, 0),                 VERSION(0, 6, 0) },
     { VERSION(2, 1, 1),                 VERSION(0, 6, 0) },

--- a/host/libraries/libbladeRF/src/board/board.h
+++ b/host/libraries/libbladeRF/src/board/board.h
@@ -138,6 +138,12 @@
  */
 #define BLADERF_CAP_FW_FLASH_ID (((uint64_t)1) << 36)
 
+/**
+ * FX3 firmware v2.3.1 introduced support for querying the source of the
+ * currently-configured FPGA (e.g. flash autoload, host, etc)
+ */
+#define BLADERF_CAP_FW_FPGA_SOURCE (((uint64_t)1) << 37)
+
 struct bladerf {
     /* Handle lock - to ensure atomic access to control and configuration
      * operations */
@@ -182,6 +188,7 @@ struct board_fns {
     int (*get_fpga_size)(struct bladerf *dev, bladerf_fpga_size *size);
     int (*get_flash_size)(struct bladerf *dev, uint32_t *size, bool *is_guess);
     int (*is_fpga_configured)(struct bladerf *dev);
+    int (*get_fpga_source)(struct bladerf *dev, bladerf_fpga_source *source);
     uint64_t (*get_capabilities)(struct bladerf *dev);
     size_t (*get_channel_count)(struct bladerf *dev, bladerf_direction dir);
 
@@ -437,18 +444,15 @@ struct board_fns {
 
 /* Information about the (SPI) flash architecture */
 struct bladerf_flash_arch {
-    enum {
-        STATUS_UNINITIALIZED,
-        STATUS_SUCCESS,
-        STATUS_ASSUMED
-    } status;
-    uint8_t  manufacturer_id;        /**< Raw manufacturer ID */
-    uint8_t  device_id;              /**< Raw device ID */
-    uint32_t tsize_bytes;            /**< Total size of flash, in bytes */
-    uint32_t psize_bytes;            /**< Flash page size, in bytes */
-    uint32_t ebsize_bytes;           /**< Flash erase block size, in bytes */
-    uint32_t num_pages;              /**< Size of flash, in pages */
-    uint32_t num_ebs;                /**< Size of flash, in erase blocks */
+    enum { STATUS_UNINITIALIZED, STATUS_SUCCESS, STATUS_ASSUMED } status;
+
+    uint8_t manufacturer_id; /**< Raw manufacturer ID */
+    uint8_t device_id;       /**< Raw device ID */
+    uint32_t tsize_bytes;    /**< Total size of flash, in bytes */
+    uint32_t psize_bytes;    /**< Flash page size, in bytes */
+    uint32_t ebsize_bytes;   /**< Flash erase block size, in bytes */
+    uint32_t num_pages;      /**< Size of flash, in pages */
+    uint32_t num_ebs;        /**< Size of flash, in erase blocks */
 };
 
 /* Boards */


### PR DESCRIPTION
In a case where multiple FPGA images may be in play (e.g. host autoloading vs SPI flash autoloading), it is desirable to have more information about the source of the currently-active FPGA bitstream.

This PR adds the following features:

- fx3_firmware v2.3.1
  - when an FPGA bitstream is loaded, set a global indicating whether it was programmed by SPI flash or USB host
  - adds a BLADE_USB_CMD_QUERY_FPGA_SOURCE command

- libbladeRF
  - add bladerf_get_fpga_source() API function
  - add bladerf_fpga_source enum
  - add capability BLADERF_CAP_FW_FPGA_SOURCE, which is active when firmware version >= 2.3.1

- bladeRF-cli
  - identify the source of the currently-running FPGA image, if known, in response to the 'version' command

Fixes #646 
