### PR TITLE
fx3: don't stop flash->fpga autoload on USB reset

### DIFF
--- a/fx3_firmware/src/bladeRF.c
+++ b/fx3_firmware/src/bladeRF.c
@@ -226,8 +226,11 @@ static void StopApplication()
 {
     if (glAppMode == MODE_RF_CONFIG) {
         NuandRFLink.stop();
-    } else if (glAppMode == MODE_FPGA_CONFIG){
-        NuandFpgaConfig.stop();
+    } else if (glAppMode == MODE_FPGA_CONFIG) {
+        /* if a flash autoload is in progress, don't stop it */
+        if (glDeviceReady || !glAutoLoadValid) {
+            NuandFpgaConfig.stop();
+        }
     }
 }
 


### PR DESCRIPTION
When libbladeRF is built with ENABLE_USB_DEV_RESET_ON_OPEN, a
USB port reset is performed on open, to work around some xHCI
controller bugs.

This hits the CyFxbladeRFApplnUSBEventCB() callback with an
event type of CY_U3P_USB_EVENT_RESET, which is then dispatched
to StopApplication(), which calls NuandRFLink.stop() or
NuandFpgaConfig.stop() or does nothing, depending on what the
glAppMode is.

Unfortunately, if the FX3 is loading an FPGA bitstream from the
SPI flash to the FPGA, NuandFpgaConfig.stop() also stops that
dead, and bladeRFAppThread_Entry() progresses forward and we end
up with an unconfigured FPGA. In that case, libbladeRF will then
go through the FPGA autoloading process.

This is essentially a race condition: which FPGA image is loaded,
if any, depends on the time between plugging in the bladeRF and
opening it. Kinda gross.

A reasonable workaround for this is implemented thus: if there's
a valid autoload image (glAutoLoadValid is true) and we haven't
yet made it through bladeRFAppThread_Entry() (glDeviceReady is
false), and we're in glAppMode == MODE_FPGA_CONFIG, then take no
action in StopApplication().

This seems to work OK with some limited power-cycle testing on
both an x40 and an xA4.

Fixes #661 
