### PR TITLE
debian: update firmware pointer to v2.3.1

### DIFF
--- a/debian/bladerf-firmware-fx3.postinst
+++ b/debian/bladerf-firmware-fx3.postinst
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-UPSTREAM='https://www.nuand.com/fx3/bladeRF_fw_v2.2.0.img'
-CHECKSUM='e0ba76cf96ed12a37e73b4573337eaf6'
+UPSTREAM='https://www.nuand.com/fx3/bladeRF_fw_v2.3.1.img'
+CHECKSUM='4f873859f4a3cae49f9ecc95f8650d6f'
 DATAFILE='/usr/share/Nuand/bladeRF/bladeRF_fw.img'
 DESCRIPT='firmware'
 MYNAMEIS='bladerf-firmware-fx3'


### PR DESCRIPTION
Pending on https://www.nuand.com/fx3/bladeRF_fw_v2.3.1.img going live