### PR TITLE
host: common: include pthread.h in nanosleep.h (#669)

### DIFF
--- a/host/common/include/windows/nanosleep.h
+++ b/host/common/include/windows/nanosleep.h
@@ -25,6 +25,8 @@
 #ifndef WIN_NANOSLEEP_H_
 #define WIN_NANOSLEEP_H_
 
+#include <pthread.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,8 +34,6 @@ extern "C" {
 #ifndef WIN32
 #error "This file is intended for use with WIN32 systems only."
 #endif
-
-#include <pthread.h>
 
 int nanosleep(const struct timespec *req, struct timespec *rem);
 

--- a/host/common/include/windows/nanosleep.h
+++ b/host/common/include/windows/nanosleep.h
@@ -33,6 +33,8 @@ extern "C" {
 #error "This file is intended for use with WIN32 systems only."
 #endif
 
+#include <pthread.h>
+
 int nanosleep(const struct timespec *req, struct timespec *rem);
 
 #ifdef __cplusplus

--- a/host/common/src/windows/nanosleep.c
+++ b/host/common/src/windows/nanosleep.c
@@ -27,7 +27,6 @@
 #endif
 
 #include "nanosleep.h"
-#include <pthread.h>
 #include <windows.h>
 
 int nanosleep(const struct timespec *req, struct timespec *rem)


### PR DESCRIPTION
default header sort on nanosleep.c puts nanosleep.h above pthread.h, which creates an implicit definition of struct timespec.

Fixes #669