### PR TITLE
hdl: bladerf-micro: weak pull-up on fx3_uart_rxd (#679)

### DIFF
--- a/hdl/fpga/platforms/bladerf-micro/constraints/pins.tcl
+++ b/hdl/fpga/platforms/bladerf-micro/constraints/pins.tcl
@@ -320,6 +320,7 @@ foreach pin ${ins} {
 }
 
 set_instance_assignment -name WEAK_PULL_UP_RESISTOR "ON" -to adf_muxout
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR "ON" -to fx3_uart_rxd
 
 
 ##########


### PR DESCRIPTION
Add a weak pull-up on fx3_uart_rxd

This is a bus used for both FPGA-to-FX3 UART data and FX3-to-Flash
SPI data, and without something driving it, it tends to float around
0.55 volts (which is very much a low/asserted signal for the UART).

When the FX3 SPI interface has the bus, it puts the FPGA into reset
via fx3_ctl(7), and fx3_uart_rxd goes high-Z accordingly.

I suspect what we're running into is a race condition between the FX3
reconfiguring the pin to UART mode and bringing the FPGA out of reset,
and the FPGA shifting from high-Z to high/idle, given:

- All of the "junk bytes" seen so far have been all ones followed by
  all zeroes, e.g. 0xF0, 0xFC, etc
- Being low for 5 clocks and then going high is indistinguishable from
  a start bit followed by 0xF0 followed by a stop bit.

Thus, by maintaining a constant weak pull-up on this bus, we can
ensure it's a logic high when idle.

There are possible side effects when the bus is in its SPI MOSI role,
but I believe they are minor. The FX3 is not expecting a pull-up/down
on this signal, and this is a critical pin for flash access. But,
C5's R_pu is 25 kohms, which means sinking 1.4 mA to pull it low, and
the FX3's absolute maximum output current is 20 mA, so I think we are
good here.

Fixes #679 