### PR TITLE
libbladeRF: bladerf_load_fpga: release mutex on error (fixes #680)

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
+++ b/host/libraries/libbladeRF/src/board/bladerf1/bladerf1.c
@@ -2868,6 +2868,7 @@ static int bladerf1_load_fpga(struct bladerf *dev, const uint8_t *buf, size_t le
 
     status = dev->backend->load_fpga(dev, buf, length);
     if (status != 0) {
+        MUTEX_UNLOCK(&dev->lock);
         return status;
     }
 

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -3879,6 +3879,7 @@ static int bladerf2_load_fpga(struct bladerf *dev,
 
     status = dev->backend->load_fpga(dev, buf, length);
     if (status != 0) {
+        MUTEX_UNLOCK(&dev->lock);
         RETURN_ERROR_STATUS("load_fpga", status);
     }
 


### PR DESCRIPTION
In the event dev->backend->load_fpga fails, we need to unlock
the mutex or else we're gonna have a bad time tearing everything
down.