### PR TITLE
libbladeRF: add biastee_rx, biastee_tx config file options

### DIFF
--- a/host/libraries/libbladeRF/doc/doxygen/configfile.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/configfile.dox
@@ -171,6 +171,14 @@ will be applied more than once; e.g. specifying `frequency 2.4G` and then
         <strong>See ::bladerf_vctcxo_tamer_mode for important
         information.</strong>
 
+    <li><b>`biastee_rx <bool>`</b>, <b>`biastee_tx <bool>`</b></li>
+
+        Enables or disables the bias tee supply on the RX or TX ports
+        respectively, via bladerf_set_bias_tee().
+
+        A true value (e.g. `on`) turns the DC bias on, while a false value
+        (e.g. `off`) turns the DC bias off.
+
 </ul>
 
 <h3>Suffixes</h3>

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -57,14 +57,24 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
 
     status = BLADERF_ERR_INVAL;
 
-    if (!strcasecmp(opt.key, "rx_biastee_en")) {
+    if (!strcasecmp(opt.key, "tx_biastee_en")) {
+      if (!strcasecmp(opt.value, "1")) {
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_TX(0), 1);
+      } else {
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_TX(0), 0);
+      }
+      if (status < 0) {
+        log_warning("Unable to set %s", opt.key);
+        return status;
+      }
+    } else if (!strcasecmp(opt.key, "rx_biastee_en")) {
       if (!strcasecmp(opt.value, "1")) {
         status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(0), 1);
       } else {
-        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(1), 0);
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(0), 0);
       }
       if (status < 0) {
-        log_warning("Processed rx_biastee_en\n");
+        log_warning("Unable to set rx_biastee_en\n");
         return status; 
       }
     } else if (!strcasecmp(opt.key, "fpga")) {

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -57,26 +57,30 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
 
     status = BLADERF_ERR_INVAL;
 
-    if (!strcasecmp(opt.key, "tx_biastee_en")) {
-      if (!strcasecmp(opt.value, "1")) {
-        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_TX(0), 1);
-      } else {
-        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_TX(0), 0);
-      }
-      if (status < 0) {
-        log_warning("Unable to set %s", opt.key);
-        return status;
-      }
-    } else if (!strcasecmp(opt.key, "rx_biastee_en")) {
-      if (!strcasecmp(opt.value, "1")) {
-        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(0), 1);
-      } else {
-        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(0), 0);
-      }
-      if (status < 0) {
-        log_warning("Unable to set rx_biastee_en\n");
-        return status; 
-      }
+    if (!strcasecmp(opt.key, "biastee_tx")) {
+        bool enable = false;
+
+        status = str2bool(opt.value, &enable);
+        if (status < 0) {
+            return BLADERF_ERR_INVAL;
+        }
+
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_TX(0), enable);
+        if (status < 0) {
+            return status;
+        }
+    } else if (!strcasecmp(opt.key, "biastee_rx")) {
+        bool enable = false;
+
+        status = str2bool(opt.value, &enable);
+        if (status < 0) {
+            return BLADERF_ERR_INVAL;
+        }
+
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(0), enable);
+        if (status < 0) {
+            return status;
+        }
     } else if (!strcasecmp(opt.key, "fpga")) {
         status = bladerf_load_fpga(dev, opt.value);
         if (status < 0) {

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -57,7 +57,17 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
 
     status = BLADERF_ERR_INVAL;
 
-    if (!strcasecmp(opt.key, "fpga")) {
+    if (!strcasecmp(opt.key, "rx_biastee_en")) {
+      if (!strcasecmp(opt.value, "1")) {
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(0), 1);
+      } else {
+        status = bladerf_set_bias_tee(dev, BLADERF_CHANNEL_RX(1), 0);
+      }
+      if (status < 0) {
+        log_warning("Processed rx_biastee_en\n");
+        return status; 
+      }
+    } else if (!strcasecmp(opt.key, "fpga")) {
         status = bladerf_load_fpga(dev, opt.value);
         if (status < 0) {
             log_warning("Config line %d: could not load FPGA from `%s'\n",


### PR DESCRIPTION
Adds configuration file options for controlling the bias tee supplies.

This PR replaces and closes #650, originally by @mdtopham 