### PR TITLE
hdl: nios: parameterize nios2 RAM size by platform/size

### DIFF
--- a/hdl/fpga/platforms/bladerf-micro/build/platform.conf
+++ b/hdl/fpga/platforms/bladerf-micro/build/platform.conf
@@ -31,3 +31,17 @@ function get_device() {
 function get_device_family() {
     echo -n "Cyclone V"
 }
+
+# Parameters:
+#  $1  FPGA size
+# Prints string containing the amount of RAM to allocate to the common_system
+# RAM during Qsys generation
+function get_qsys_ram() {
+    if [ "${1}" == "A4" ] || [ "${1}" == "A9" ]; then
+        rams=131072
+    else
+        rams=32768
+    fi
+
+    echo -n "${rams}"
+}

--- a/hdl/fpga/platforms/bladerf/build/platform.conf
+++ b/hdl/fpga/platforms/bladerf/build/platform.conf
@@ -31,3 +31,12 @@ function get_device() {
 function get_device_family() {
     echo -n "Cyclone IV E"
 }
+
+# Parameters:
+#  $1  FPGA size
+# Prints string containing the amount of RAM to allocate to the common_system
+# RAM during Qsys generation
+function get_qsys_ram() {
+    echo -n "16384.0"
+}
+

--- a/hdl/fpga/platforms/common/bladerf/build/common_system.tcl
+++ b/hdl/fpga/platforms/common/bladerf/build/common_system.tcl
@@ -266,7 +266,7 @@ set_instance_parameter_value ram {enableDiffWidth} {0}
 set_instance_parameter_value ram {initMemContent} {1}
 set_instance_parameter_value ram {initializationFileName} {onchip_memory2_0}
 set_instance_parameter_value ram {instanceID} {MED}
-set_instance_parameter_value ram {memorySize} {32768.0}
+set_instance_parameter_value ram {memorySize} ${ram_size}
 set_instance_parameter_value ram {readDuringWriteMode} {DONT_CARE}
 set_instance_parameter_value ram {simAllowMRAMContentsFile} {0}
 set_instance_parameter_value ram {simMemInitOnlyFilename} {0}

--- a/hdl/quartus/build_bladerf.sh
+++ b/hdl/quartus/build_bladerf.sh
@@ -335,6 +335,8 @@ else
     cmd="set nios_impl ${nios_rev}"
     cmd="${cmd}; set device_family {${DEVICE_FAMILY}}"
     cmd="${cmd}; set device ${DEVICE}"
+    cmd="${cmd}; set nios_impl ${nios_rev}"
+    cmd="${cmd}; set ram_size $(get_qsys_ram $size)"
     qsys-script \
         --script=${common_dir}/build/common_system.tcl \
         --cmd="${cmd}"
@@ -347,6 +349,8 @@ else
     cmd="set nios_impl ${nios_rev}"
     cmd="${cmd}; set device_family {${DEVICE_FAMILY}}"
     cmd="${cmd}; set device ${DEVICE}"
+    cmd="${cmd}; set nios_impl ${nios_rev}"
+    cmd="${cmd}; set ram_size $(get_qsys_ram $size)"
     qsys-script \
         --script=${build_dir}/nios_system.tcl \
         --cmd="${cmd}"


### PR DESCRIPTION
On xA4/xA9, we can have a larger memory footprint, and we need it for additional features.