### PR TITLE
host: libbladeRF_test: fix decimal const warning on i386

### DIFF
--- a/host/libraries/libbladeRF_test/test_ctrl/src/test_frequency.c
+++ b/host/libraries/libbladeRF_test/test_ctrl/src/test_frequency.c
@@ -32,7 +32,8 @@ DECLARE_TEST_CASE(frequency);
  * out on this for now... */
 static inline bool freq_match(bladerf_frequency a, bladerf_frequency b)
 {
-    bladerf_frequency const allowed_slack = (a >= 3000000000) ? 5 : 3;
+    bladerf_frequency const band_split = 3000000000UL;
+    bladerf_frequency const allowed_slack = (a >= band_split) ? 5 : 3;
 
     return (a >= (b - allowed_slack) && a <= (b + allowed_slack));
 }


### PR DESCRIPTION
Fixes the following error:

`error: this decimal constant is unsigned only in ISO C90 [-Werror]`

which was introduced by Nuand/bladeRF#706