### PR TITLE
hdl: bladerf2: RFIC control via Nios

### DIFF
--- a/fpga_common/include/ad936x_helpers.h
+++ b/fpga_common/include/ad936x_helpers.h
@@ -22,6 +22,12 @@
 #ifndef FPGA_COMMON_AD936X_HELPERS_H_
 #define FPGA_COMMON_AD936X_HELPERS_H_
 
+#ifdef BLADERF_NIOS_BUILD
+#include "devices.h"
+#endif  // BLADERF_NIOS_BUILD
+
+#if !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
+
 #if !defined(BLADERF_NIOS_BUILD) && !defined(BLADERF_NIOS_PC_SIMULATION)
 #include <libbladeRF.h>
 #else
@@ -117,4 +123,5 @@ enum rf_gain_ctrl_mode gainmode_bladerf_to_ad9361(bladerf_gain_mode gainmode,
 bladerf_gain_mode gainmode_ad9361_to_bladerf(enum rf_gain_ctrl_mode gainmode,
                                              bool *ok);
 
-#endif
+#endif  // !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
+#endif  // FPGA_COMMON_AD936X_HELPERS_H_

--- a/fpga_common/include/bladerf2_common.h
+++ b/fpga_common/include/bladerf2_common.h
@@ -169,6 +169,15 @@ struct band_port_map {
 #define __round_int64(x) (x >= 0 ? (int64_t)(x + 0.5) : (int64_t)(x - 0.5))
 
 /**
+ * Subcommands for the BLADERF_RFIC_COMMAND_INIT RFIC command.
+ */
+typedef enum {
+    BLADERF_RFIC_INIT_STATE_OFF = 0, /** Non-initialized state */
+    BLADERF_RFIC_INIT_STATE_ON,      /** Initialized ("open") */
+    BLADERF_RFIC_INIT_STATE_STANDBY, /** Standby ("closed") */
+} bladerf_rfic_init_state;
+
+/**
  * Commands available with the FPGA-based RFIC interface.
  */
 typedef enum {
@@ -195,8 +204,7 @@ typedef enum {
      *
      * Pass ::BLADERF_CHANNEL_INVALID as the `ch` parameter.
      *
-     * The Read variant returns `true` if the RFIC has been initialized,
-     * `false` otherwise.
+     * Pass/expect a ::bladerf_rfic_init_state value as the `data` parameter.
      */
     BLADERF_RFIC_COMMAND_INIT = 1,
 

--- a/fpga_common/include/bladerf2_common.h
+++ b/fpga_common/include/bladerf2_common.h
@@ -254,6 +254,13 @@ typedef enum {
      * 1 indicates TX mute is enabled, 0 indicates it is not.
      */
     BLADERF_RFIC_COMMAND_TXMUTE = 10,
+
+    /** Store Fastlock profile. (Write)
+     *
+     * Stores the current tuning into a fastlock profile, for later recall
+     */
+    BLADERF_RFIC_COMMAND_FASTLOCK = 11,
+
 } bladerf_rfic_command;
 
 /** NIOS_PKT_16x64_RFIC_STATUS return structure

--- a/fpga_common/include/nios_pkt_16x64.h
+++ b/fpga_common/include/nios_pkt_16x64.h
@@ -100,8 +100,8 @@
 #define NIOS_PKT_16x64_IDX_RESV2      14
 
 /* Target IDs */
-
 #define NIOS_PKT_16x64_TARGET_AD9361  0x00
+#define NIOS_PKT_16x64_TARGET_RFIC    0x01 /* RFIC control */
 
 /* IDs 0x80 through 0xff will not be assigned by Nuand. These are reserved
  * for user customizations */
@@ -111,6 +111,21 @@
 /* Flag bits */
 #define NIOS_PKT_16x64_FLAG_WRITE     (1 << 0)
 #define NIOS_PKT_16x64_FLAG_SUCCESS   (1 << 1)
+
+/**
+ * Sub-addresses for rfic target.
+ *
+ *    +================+============================================+
+ *    |      Bit(s)    |         Value                              |
+ *    +================+============================================+
+ *    |      15:12     | Reserved. Set to 0.                        |
+ *    +----------------+--------------------------------------------+
+ *    |      11:8      | bladerf_channel & 0xf                      |
+ *    |                | 1111 = system-wide                         |
+ *    +----------------+--------------------------------------------+
+ *    |       7:0      | Subaddress. See bladerf_rfic_command enum. |
+ *    +----------------+--------------------------------------------+
+ */
 
 /* Pack the request buffer */
 static inline void nios_pkt_16x64_pack(uint8_t *buf, uint8_t target, bool write,

--- a/fpga_common/src/ad936x_helpers.c
+++ b/fpga_common/src/ad936x_helpers.c
@@ -19,6 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef BLADERF_NIOS_BUILD
+#include "devices.h"
+#endif  // BLADERF_NIOS_BUILD
+
+/* Avoid building this in low-memory situations */
+#if !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
+
 #if !defined(BLADERF_NIOS_BUILD) && !defined(BLADERF_NIOS_PC_SIMULATION)
 #include "log.h"
 #endif
@@ -27,7 +34,6 @@
 #include "bladerf2_common.h"
 
 static bool tx_mute_state[2] = { false };
-
 
 uint32_t txmute_get_cached(struct ad9361_rf_phy *phy, bladerf_channel ch)
 {
@@ -186,3 +192,5 @@ bladerf_gain_mode gainmode_ad9361_to_bladerf(enum rf_gain_ctrl_mode gainmode,
 
     return 0;
 }
+
+#endif  // !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)

--- a/fpga_common/src/ad936x_params.c
+++ b/fpga_common/src/ad936x_params.c
@@ -1,3 +1,10 @@
+#ifdef BLADERF_NIOS_BUILD
+#include "devices.h"
+#endif  // BLADERF_NIOS_BUILD
+
+/* Avoid building this in low-memory situations */
+#if !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
+
 #include "ad9361_api.h"
 #include "platform.h"
 
@@ -725,3 +732,5 @@ AD9361_TXFIRConfig bladerf2_rfic_tx_fir_config_int4 = {
     { 0, 0, 0, 0, 0, 0 },  // tx_path_clks[6]
     0                      // tx_bandwidth
 };
+
+#endif  // !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)

--- a/fpga_common/src/bladerf2_common.c
+++ b/fpga_common/src/bladerf2_common.c
@@ -22,6 +22,13 @@
  * THE SOFTWARE.
  */
 
+#ifdef BLADERF_NIOS_BUILD
+#include "devices.h"
+#endif  // BLADERF_NIOS_BUILD
+
+/* Avoid building this in low-memory situations */
+#if !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
+
 #include "bladerf2_common.h"
 
 /**
@@ -183,3 +190,5 @@ bool _rffe_dir_otherwise_enabled(uint32_t reg, bladerf_channel ch)
 
     return false;
 }
+
+#endif  // !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)

--- a/fpga_common/src/lms.c
+++ b/fpga_common/src/lms.c
@@ -1810,7 +1810,7 @@ static inline int write_vcocap(struct bladerf *dev, uint8_t base,
 #define VCO_NORM 0x00
 #define VCO_LOW  0x01
 
-#ifdef LOGGING_ENABLED
+#if defined(LOGGING_ENABLED) || defined(BLADERF_NIOS_DEBUG)
 static const char *vtune_str(uint8_t value) {
     switch (value) {
         case VCO_HIGH:

--- a/hdl/fpga/ip/analogdevicesinc/no_OS/CMakeLists.txt
+++ b/hdl/fpga/ip/analogdevicesinc/no_OS/CMakeLists.txt
@@ -1,0 +1,196 @@
+cmake_minimum_required(VERSION 3.5)
+project(ad936x C)
+
+message(STATUS "libad936x: Configuring build...")
+
+option(NIOS_HAS_HARDWARE_MULTIPLY_DIVIDE
+       "Use hardware multiply/divide in Nios II/f"
+       OFF
+)
+
+option(BUILD_AD936X_PRINTF
+       "Enable console printf output for the AD936x library."
+       OFF
+)
+
+option(BUILD_AD936X_PRINTF_DEBUG
+       "Enable debugging output for the AD936x library."
+       OFF
+)
+
+################################################################################
+# Paths
+################################################################################
+
+# Repository root
+set(LIBAD936X_BLADERF_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../../..")
+# Source directory for local files (patches, platform_bladerf2, etc)
+set(LIBAD936X_LOCAL_DIR "${LIBAD936X_BLADERF_ROOT}/thirdparty/analogdevicesinc/no-OS_local")
+# libbladeRF relative path
+set(LIBAD936X_LIBBLADERF_DIR "${LIBAD936X_BLADERF_ROOT}/host/libraries/libbladeRF")
+# fpga_common relative path
+set(LIBAD936X_FPGACOMMON_DIR "${LIBAD936X_BLADERF_ROOT}/fpga_common")
+
+# Patch files live here
+set(LIBAD936X_PATCH_DIR "${LIBAD936X_LOCAL_DIR}/patches")
+# Platform files
+set(LIBAD936X_PLATFORM_DIR "${LIBAD936X_LOCAL_DIR}/platform_bladerf2_headless")
+
+# Upstream source (clean)
+set(LIBAD936X_UPSTREAM_DIR "${LIBAD936X_LOCAL_DIR}/../no-OS/ad9361/sw")
+# Upstream source (patched)
+set(LIBAD936X_UPSTREAM_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Use CMake modules from the host tree
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${LIBAD936X_BLADERF_ROOT}/host/cmake/modules/")
+
+
+# Ensure the toolchain file got loaded...
+if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "nios2")
+    message(FATAL_ERROR "CMAKE_SYSTEM_PROCESSOR is ${CMAKE_SYSTEM_PROCESSOR}, expected nios2")
+endif()
+
+
+################################################################################
+# Configure build
+################################################################################
+
+add_library(ad936x STATIC
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361_api.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361_conv.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/util.c
+    ${LIBAD936X_PLATFORM_DIR}/platform.c
+    ${LIBAD936X_PLATFORM_DIR}/adc_core.c
+    ${LIBAD936X_PLATFORM_DIR}/dac_core.c
+    ${LIBAD936X_FPGACOMMON_DIR}/src/ad936x_params.c
+)
+
+target_compile_options(ad936x PRIVATE
+    -DBLADERF_NIOS_BUILD -DNUAND_MODIFICATIONS -Wall -Os
+)
+
+if(NOT NIOS_HAS_HARDWARE_MULTIPLY_DIVIDE)
+    message(STATUS "libad936x: building with software mul/mulx/div operations")
+    target_compile_options(ad936x PRIVATE 
+        -mno-hw-div -mno-hw-mul -mno-hw-mulx
+    )
+endif(NOT NIOS_HAS_HARDWARE_MULTIPLY_DIVIDE)
+
+if(NOT MSVC)
+    target_compile_options(ad936x PRIVATE
+        -ffunction-sections -fdata-sections
+        -Wno-unused-but-set-variable -std=gnu11
+    )
+endif(NOT MSVC)
+
+if(BUILD_AD936X_PRINTF OR BUILD_AD936X_PRINTF_DEBUG)
+    message(STATUS "libad936x: Enabling console output")
+    target_compile_options(ad936x PRIVATE -DHAVE_VERBOSE_MESSAGES)
+endif(BUILD_AD936X_PRINTF OR BUILD_AD936X_PRINTF_DEBUG)
+
+if(BUILD_AD936X_PRINTF_DEBUG)
+    message(STATUS "libad936x: Enabling full debugging output")
+    target_compile_options(ad936x PRIVATE -DHAVE_DEBUG_MESSAGES)
+endif(BUILD_AD936X_PRINTF_DEBUG)
+
+target_include_directories(ad936x PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+
+    ${LIBAD936X_PLATFORM_DIR}
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}
+    ${LIBAD936X_LIBBLADERF_DIR}/src
+    ${LIBAD936X_LIBBLADERF_DIR}/include
+
+    ${LIBAD936X_BLADERF_ROOT}/host/common/include
+    ${LIBAD936X_BLADERF_ROOT}/firmware_common
+
+    ${LIBAD936X_BLADERF_ROOT}/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src
+    ${LIBAD936X_BLADERF_ROOT}/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src
+    ${LIBAD936X_BLADERF_ROOT}/fpga_common/include
+    ${CMAKE_BINARY_DIR}/../bladeRF_nios_bsp
+    ${CMAKE_BINARY_DIR}/../bladeRF_nios_bsp/drivers/inc
+    ${CMAKE_BINARY_DIR}/../bladeRF_nios_bsp/HAL/inc
+)
+
+################################################################################
+# Dependencies
+################################################################################
+
+# If the submodule hasn't been initialized/updated, do so
+if(NOT IS_DIRECTORY ${LIBAD936X_UPSTREAM_DIR})
+    message(STATUS "libad936x: Attempting to initialize missing submodule")
+
+    find_package(Git QUIET)
+
+    if(Git_FOUND)
+        execute_process(
+            COMMAND ${Git_EXECUTABLE} submodule init
+            WORKING_DIRECTORY ${LIBAD936X_BLADERF_ROOT}
+        )
+        execute_process(
+            COMMAND ${Git_EXECUTABLE} submodule update
+            WORKING_DIRECTORY ${LIBAD936X_BLADERF_ROOT}
+        )
+    endif()
+endif()
+
+# Then, re-check for submodule...
+if(NOT IS_DIRECTORY ${LIBAD936X_UPSTREAM_DIR})
+    message(FATAL_ERROR "Directory ${LIBAD936X_UPSTREAM_DIR} was not found. "
+                        "It appears that this submodule has not been properly "
+                        "initialized. Please run 'git submodule init' and "
+                        "'git submodule update', and then re-run cmake.")
+endif()
+
+
+################################################################################
+# Copy files and apply patches
+################################################################################
+
+# Copy needed files from the upstream repository
+set(LIBAD936X_UPSTREAM_FILES
+    ad9361.c
+    ad9361.h
+    ad9361_api.c
+    ad9361_api.h
+    ad9361_conv.c
+    common.h
+    util.c
+    util.h
+)
+
+foreach(cpfile IN ITEMS ${LIBAD936X_UPSTREAM_FILES})
+    configure_file(
+        "${LIBAD936X_UPSTREAM_DIR}/${cpfile}"
+        "${LIBAD936X_UPSTREAM_BUILD_DIR}/"
+        COPYONLY
+    )
+endforeach(cpfile)
+
+# Patch the upstream files
+file(GLOB LIBAD936X_PATCHES
+     LIST_DIRECTORIES false
+     RELATIVE ${LIBAD936X_PATCH_DIR}
+     "${LIBAD936X_PATCH_DIR}/*.patch"
+)
+
+find_package(Patcher REQUIRED)
+
+foreach(patchfile IN ITEMS ${LIBAD936X_PATCHES})
+    message(STATUS "libad936x: Applying patch: ${patchfile}")
+    execute_process(
+        COMMAND ${Patcher_EXECUTABLE} -p3
+        INPUT_FILE ${LIBAD936X_PATCH_DIR}/${patchfile}
+        WORKING_DIRECTORY "${LIBAD936X_UPSTREAM_BUILD_DIR}"
+        OUTPUT_QUIET
+        RESULT_VARIABLE resultcode
+        ERROR_VARIABLE errvar
+    )
+
+    if(resultcode)
+        message(FATAL_ERROR "Failed to apply ${patchfile}: ${errvar}")
+    endif(resultcode)
+endforeach(patchfile)
+
+message(STATUS "libad936x: Build configured")

--- a/hdl/fpga/ip/analogdevicesinc/no_OS/cmake/nios-toolchain.cmake
+++ b/hdl/fpga/ip/analogdevicesinc/no_OS/cmake/nios-toolchain.cmake
@@ -1,0 +1,48 @@
+################################################################################
+# Configure CMake and setup variables for the Nios II environment
+#
+# Inputs:
+#   QUARTUS_ROOTDIR   Path to Quartus Prime installation.
+#
+#
+################################################################################
+cmake_minimum_required(VERSION 2.8)
+
+if(NOT "$ENV{QUARTUS_ROOTDIR}" STREQUAL "")
+    set(QUARTUS_ROOTDIR "$ENV{QUARTUS_ROOTDIR}")
+endif()
+
+# There seems to be some known strange behavior where CMake loses track of
+# cached variables when (re)parsing toolchain files. This is a workaround
+# identified in http://stackoverflow.com/questions/28613394/check-cmake-cache-variable-in-toolchain-file
+if(QUARTUS_ROOTDIR)
+    # Use the environment to back up this definition, per that above workaround
+    set(ENV{_QUARTUS_ROOTDIR} "${QUARTUS_ROOTDIR}")
+else()
+    if(NOT "$ENV{_QUARTUS_ROOTDIR}" STREQUAL "")
+        # Use the definition we backed up in the environment.
+        set(QUARTUS_ROOTDIR "$ENV{_QUARTUS_ROOTDIR}")
+    endif()
+endif()
+
+if("${QUARTUS_ROOTDIR}" STREQUAL "")
+    message(FATAL_ERROR "QUARTUS_ROOTDIR not defined")
+else()
+    message(STATUS "QUARTUS_ROOTDIR = ${QUARTUS_ROOTDIR}")
+endif()
+
+
+################################################################################
+# CMake toolchain file configuration
+################################################################################
+
+find_program(CMAKE_C_COMPILER nios2-elf-gcc ${QUARTUS_ROOTDIR}/nios2eds/)
+find_program(CMAKE_CXX_COMPILER nios2-elf-g++ ${QUARTUS_ROOTDIR}/nios2eds/)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR nios2)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/hdl/fpga/ip/analogdevicesinc/no_OS/include/host_config.h
+++ b/hdl/fpga/ip/analogdevicesinc/no_OS/include/host_config.h
@@ -1,0 +1,8 @@
+#ifndef HOST_CONFIG_H__
+#define HOST_CONFIG_H__
+
+#include <unistd.h>
+
+#define ARRAY_SIZE(n) (sizeof(n) / sizeof(n[0]))
+
+#endif

--- a/hdl/fpga/ip/analogdevicesinc/no_OS/include/thread.h
+++ b/hdl/fpga/ip/analogdevicesinc/no_OS/include/thread.h
@@ -1,0 +1,7 @@
+#ifndef BLADERF_THREAD_H_
+#define BLADERF_THREAD_H_
+
+/* Stub out MUTEX, since we don't really use anything else pthread here */
+#define MUTEX bool
+
+#endif

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
@@ -14,6 +14,7 @@ QUARTUS_OUTDIR     := $(QUARTUS_WORKDIR)/output_files
 
 ALT_INCLUDE_DIRS   += -I ./src
 
+C_SRCS             += $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
 C_SRCS             += ./src/bladeRF_nios.c
 
 #------------------------------------------------------------------------------

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
@@ -4,42 +4,42 @@
 
 # paths are relative to hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios
 
-FPGA_COMMON_DIR		:= ../../../../../../fpga_common
-LIBBLADERF_DIR		:= ../../../../../../host/libraries/libbladeRF
-BLADERF_COMMON_DIR	:= ../../../common/bladerf/software/bladeRF_nios
-HOST_COMMON_DIR		:= ../../../../../../host/common
-FIRMWARE_COMMON_DIR	:= ../../../../../../firmware_common
+FPGA_COMMON_DIR     := ../../../../../../fpga_common
+LIBBLADERF_DIR      := ../../../../../../host/libraries/libbladeRF
+BLADERF_COMMON_DIR  := ../../../common/bladerf/software/bladeRF_nios
+HOST_COMMON_DIR     := ../../../../../../host/common
+FIRMWARE_COMMON_DIR := ../../../../../../firmware_common
 
-QUARTUS_WORKDIR		:= ../../../../../quartus/${WORKDIR}
-NIOS_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios
-MEM_INIT_DIR		:= $(NIOS_BUILD_OUTDIR)/mem_init
-BSP_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
-QUARTUS_OUTDIR		:= $(QUARTUS_WORKDIR)/output_files
+QUARTUS_WORKDIR     := ../../../../../quartus/${WORKDIR}
+NIOS_BUILD_OUTDIR   := $(QUARTUS_WORKDIR)/bladeRF_nios
+MEM_INIT_DIR        := $(NIOS_BUILD_OUTDIR)/mem_init
+BSP_BUILD_OUTDIR    := $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
+QUARTUS_OUTDIR      := $(QUARTUS_WORKDIR)/output_files
 
-ALT_INCLUDE_DIRS	+= ./src
+ALT_INCLUDE_DIRS    += ./src
 
-C_SRCS				+= ./src/bladeRF_nios.c
-C_SRCS				+= $(FPGA_COMMON_DIR)/src/ad936x_helpers.c
-C_SRCS				+= $(FPGA_COMMON_DIR)/src/bladerf2_common.c
-C_SRCS				+= $(BLADERF_COMMON_DIR)/src/devices_rfic.c
-C_SRCS				+= $(BLADERF_COMMON_DIR)/src/devices_rfic_queue.c
-C_SRCS				+= $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
-C_SRCS				+= $(HOST_COMMON_DIR)/src/range.c
+C_SRCS              += ./src/bladeRF_nios.c
+C_SRCS              += $(FPGA_COMMON_DIR)/src/ad936x_helpers.c
+C_SRCS              += $(FPGA_COMMON_DIR)/src/bladerf2_common.c
+C_SRCS              += $(BLADERF_COMMON_DIR)/src/devices_rfic.c
+C_SRCS              += $(BLADERF_COMMON_DIR)/src/devices_rfic_queue.c
+C_SRCS              += $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
+C_SRCS              += $(HOST_COMMON_DIR)/src/range.c
 
-CFLAGS				+= -DBOARD_BLADERF_MICRO
+CFLAGS              += -DBOARD_BLADERF_MICRO
 
 # libad936x build configuration and lib inclusion
 # These variables need to be set before including the common Makefile.
-LIBAD936X_BUILDDIR	:= $(QUARTUS_WORKDIR)/libad936x
-LIBAD936X_DIR		:= ../../../../fpga/ip/analogdevicesinc/no_OS
+LIBAD936X_BUILDDIR  := $(QUARTUS_WORKDIR)/libad936x
+LIBAD936X_DIR       := ../../../../fpga/ip/analogdevicesinc/no_OS
 
-INC_DIRS			+= $(LIBAD936X_BUILDDIR) \
-					   ../$(LIBAD936X_DIR)/include \
-					   ../../../../../../host/common/include
+INC_DIRS            += $(LIBAD936X_BUILDDIR) \
+                       ../$(LIBAD936X_DIR)/include \
+                       ../../../../../../host/common/include
 
-LIB_DIRS			+= $(LIBAD936X_BUILDDIR)
-LDDEPS				+= $(LIBAD936X_BUILDDIR)/libad936x.a
-LIBS				+= ad936x
+LIB_DIRS            += $(LIBAD936X_BUILDDIR)
+LDDEPS              += $(LIBAD936X_BUILDDIR)/libad936x.a
+LIBS                += ad936x
 
 #------------------------------------------------------------------------------
 #              INCLUDE THE COMMON MAKEFILE
@@ -56,12 +56,12 @@ include $(BLADERF_COMMON_DIR)/Makefile
 # - make:   do the actual compile, generate libad936x.a
 
 # if any source file changes, re-run cmake so that patching, etc, occurs
-LIBAD936X_MAKE_DEP	:=	../../../../ip/analogdevicesinc/no_OS/CMakeLists.txt \
-						../../../../../../thirdparty/analogdevicesinc/no-OS/ad9361/sw/* \
-						../../../../../../thirdparty/analogdevicesinc/no-OS_local/patches/* \
-						../../../../../../thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/*
+LIBAD936X_MAKE_DEP  :=  ../../../../ip/analogdevicesinc/no_OS/CMakeLists.txt \
+                        ../../../../../../thirdparty/analogdevicesinc/no-OS/ad9361/sw/* \
+                        ../../../../../../thirdparty/analogdevicesinc/no-OS_local/patches/* \
+                        ../../../../../../thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/*
 
-LIBAD936X_BUILD_DEP	:= 	$(LIBAD936X_BUILDDIR)/Makefile
+LIBAD936X_BUILD_DEP :=  $(LIBAD936X_BUILDDIR)/Makefile
 
 # override clean_libs to ensure libad936x gets cleaned
 clean_libs: $(LIB_CLEAN_TARGETS) clean_libad936x

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
@@ -21,6 +21,8 @@ ALT_INCLUDE_DIRS	+= ./src
 C_SRCS				+= ./src/bladeRF_nios.c
 C_SRCS				+= $(FPGA_COMMON_DIR)/src/ad936x_helpers.c
 C_SRCS				+= $(FPGA_COMMON_DIR)/src/bladerf2_common.c
+C_SRCS				+= $(BLADERF_COMMON_DIR)/src/devices_rfic.c
+C_SRCS				+= $(BLADERF_COMMON_DIR)/src/devices_rfic_queue.c
 C_SRCS				+= $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
 C_SRCS				+= $(HOST_COMMON_DIR)/src/range.c
 

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/Makefile
@@ -2,23 +2,78 @@
 #              VARIABLES TO BE DEFINED BY PLATFORM MAKEFILE
 #------------------------------------------------------------------------------
 
-FPGA_COMMON_DIR    := ../../../../../../fpga_common
-LIBBLADERF_DIR     := ../../../../../../host/libraries/libbladeRF
-BLADERF_COMMON_DIR := ../../../common/bladerf/software/bladeRF_nios
+# paths are relative to hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios
 
-QUARTUS_WORKDIR    := ../../../../../quartus/${WORKDIR}
-NIOS_BUILD_OUTDIR  := $(QUARTUS_WORKDIR)/bladeRF_nios
-MEM_INIT_DIR       := $(NIOS_BUILD_OUTDIR)/mem_init
-BSP_BUILD_OUTDIR   := $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
-QUARTUS_OUTDIR     := $(QUARTUS_WORKDIR)/output_files
+FPGA_COMMON_DIR		:= ../../../../../../fpga_common
+LIBBLADERF_DIR		:= ../../../../../../host/libraries/libbladeRF
+BLADERF_COMMON_DIR	:= ../../../common/bladerf/software/bladeRF_nios
+HOST_COMMON_DIR		:= ../../../../../../host/common
+FIRMWARE_COMMON_DIR	:= ../../../../../../firmware_common
 
-ALT_INCLUDE_DIRS   += -I ./src
+QUARTUS_WORKDIR		:= ../../../../../quartus/${WORKDIR}
+NIOS_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios
+MEM_INIT_DIR		:= $(NIOS_BUILD_OUTDIR)/mem_init
+BSP_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
+QUARTUS_OUTDIR		:= $(QUARTUS_WORKDIR)/output_files
 
-C_SRCS             += $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
-C_SRCS             += ./src/bladeRF_nios.c
+ALT_INCLUDE_DIRS	+= ./src
+
+C_SRCS				+= ./src/bladeRF_nios.c
+C_SRCS				+= $(FPGA_COMMON_DIR)/src/ad936x_helpers.c
+C_SRCS				+= $(FPGA_COMMON_DIR)/src/bladerf2_common.c
+C_SRCS				+= $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
+C_SRCS				+= $(HOST_COMMON_DIR)/src/range.c
+
+CFLAGS				+= -DBOARD_BLADERF_MICRO
+
+# libad936x build configuration and lib inclusion
+# These variables need to be set before including the common Makefile.
+LIBAD936X_BUILDDIR	:= $(QUARTUS_WORKDIR)/libad936x
+LIBAD936X_DIR		:= ../../../../fpga/ip/analogdevicesinc/no_OS
+
+INC_DIRS			+= $(LIBAD936X_BUILDDIR) \
+					   ../$(LIBAD936X_DIR)/include \
+					   ../../../../../../host/common/include
+
+LIB_DIRS			+= $(LIBAD936X_BUILDDIR)
+LDDEPS				+= $(LIBAD936X_BUILDDIR)/libad936x.a
+LIBS				+= ad936x
 
 #------------------------------------------------------------------------------
 #              INCLUDE THE COMMON MAKEFILE
 #------------------------------------------------------------------------------
 
 include $(BLADERF_COMMON_DIR)/Makefile
+
+#------------------------------------------------------------------------------
+#              AD936X LIBRARY
+#------------------------------------------------------------------------------
+
+# Two-stage build:
+# - cmake:  shuffle files, apply patches, generate Makefile
+# - make:   do the actual compile, generate libad936x.a
+
+# if any source file changes, re-run cmake so that patching, etc, occurs
+LIBAD936X_MAKE_DEP	:=	../../../../ip/analogdevicesinc/no_OS/CMakeLists.txt \
+						../../../../../../thirdparty/analogdevicesinc/no-OS/ad9361/sw/* \
+						../../../../../../thirdparty/analogdevicesinc/no-OS_local/patches/* \
+						../../../../../../thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/*
+
+LIBAD936X_BUILD_DEP	:= 	$(LIBAD936X_BUILDDIR)/Makefile
+
+# override clean_libs to ensure libad936x gets cleaned
+clean_libs: $(LIB_CLEAN_TARGETS) clean_libad936x
+
+clean_libad936x:
+	@$(ECHO) Info: Cleaning libad936x
+	@$(MAKE) --no-print-directory -C $(LIBAD936X_BUILDDIR) clean
+
+$(LIBAD936X_BUILDDIR)/Makefile: $(LIBAD936X_MAKE_DEP)
+	@$(ECHO) Info: Generating libad936x Makefile
+	@mkdir -p $(LIBAD936X_BUILDDIR)
+	@cd $(LIBAD936X_BUILDDIR) && \
+		cmake -DCMAKE_TOOLCHAIN_FILE=$(LIBAD936X_DIR)/cmake/nios-toolchain.cmake $(LIBAD936X_DIR)
+
+$(LIBAD936X_BUILDDIR)/libad936x.a: $(LIBAD936X_BUILD_DEP)
+	@$(ECHO) Info: Building libad936x
+	@$(MAKE) --no-print-directory -C $(LIBAD936X_BUILDDIR) ad936x

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/bladeRF_nios.c
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/bladeRF_nios.c
@@ -43,7 +43,6 @@
 #include "pkt_8x64.h"
 #include "pkt_16x64.h"
 #include "pkt_32x32.h"
-#include "pkt_retune.h"
 #include "pkt_retune2.h"
 #include "pkt_legacy.h"
 #include "debug.h"
@@ -84,7 +83,6 @@
  * to include the magic header byte value in the `magics` array.
  */
 static const struct pkt_handler pkt_handlers[] = {
-    PKT_RETUNE,
     PKT_RETUNE2,
     PKT_8x8,
     PKT_8x16,

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/bladeRF_nios.c
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/bladeRF_nios.c
@@ -199,26 +199,26 @@ int main(void)
             // Read AD9361 registers 0x045-0x04c
             for( i=0x45; i < 0x4d; i++ ) {
                 adi_spi_addr = (adi_spi_addr & 0xfc00) | i;
-                adi_spi_data = ad9361_spi_read(adi_spi_addr);
+                adi_spi_data = adi_spi_read(adi_spi_addr);
             }
 
             // Read 0x028
             adi_spi_addr = (adi_spi_addr & 0xfc00) | 0x28;
-            adi_spi_data = ad9361_spi_read(adi_spi_addr);
+            adi_spi_data = adi_spi_read(adi_spi_addr);
 
             // Write 0x5a to 0x028
             adi_spi_addr = (adi_spi_addr & 0xfc00) | 0x28;
             adi_spi_data = (UINT64_C(0x5a) << (64-8));
-            ad9361_spi_write((adi_spi_addr | 0x8000), adi_spi_data);
+            adi_spi_write((adi_spi_addr | 0x8000), adi_spi_data);
 
             // Read 0x028
             adi_spi_addr = (adi_spi_addr & 0xfc00) | 0x28;
-            adi_spi_data = ad9361_spi_read(adi_spi_addr);
+            adi_spi_data = adi_spi_read(adi_spi_addr);
 
             // Write 0x5a to 0x028
             adi_spi_addr = (adi_spi_addr & 0xfc00) | 0x28;
             adi_spi_data = (UINT64_C(0x0) << (64-8));
-            ad9361_spi_write((adi_spi_addr | 0x8000), adi_spi_data);
+            adi_spi_write((adi_spi_addr | 0x8000), adi_spi_data);
 
             usleep(100);
         }

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/bladeRF_nios.c
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/bladeRF_nios.c
@@ -286,7 +286,7 @@ int main(void)
             if (handler == NULL) {
                 /* We somehow got out of sync. Throw away request data until
                  * we hit a magic value */
-                DBG("Got invalid magic value: 0x%02x\n", pkt.req[PKT_MAGIC_IDX]);
+                DBG("Got invalid magic value: 0x%x\n", pkt.req[PKT_MAGIC_IDX]);
                 continue;
             }
 

--- a/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/fpga_version.h
+++ b/hdl/fpga/platforms/bladerf-micro/software/bladeRF_nios/src/fpga_version.h
@@ -8,7 +8,7 @@
 #define FPGA_VERSION_ID         0x7777
 #define FPGA_VERSION_MAJOR      0
 #define FPGA_VERSION_MINOR      10
-#define FPGA_VERSION_PATCH      0
+#define FPGA_VERSION_PATCH      1
 #define FPGA_VERSION ((uint32_t)( FPGA_VERSION_MAJOR        | \
                                  (FPGA_VERSION_MINOR << 8)  | \
                                  (FPGA_VERSION_PATCH << 16) ) )

--- a/hdl/fpga/platforms/bladerf/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf/software/bladeRF_nios/Makefile
@@ -2,26 +2,26 @@
 #              VARIABLES TO BE DEFINED BY PLATFORM MAKEFILE
 #------------------------------------------------------------------------------
 
-FPGA_COMMON_DIR		:= ../../../../../../fpga_common
-LIBBLADERF_DIR		:= ../../../../../../host/libraries/libbladeRF
-BLADERF_COMMON_DIR	:= ../../../common/bladerf/software/bladeRF_nios
-HOST_COMMON_DIR		:= ../../../../../../host/common
-FIRMWARE_COMMON_DIR	:= ../../../../../../firmware_common
+FPGA_COMMON_DIR     := ../../../../../../fpga_common
+LIBBLADERF_DIR      := ../../../../../../host/libraries/libbladeRF
+BLADERF_COMMON_DIR  := ../../../common/bladerf/software/bladeRF_nios
+HOST_COMMON_DIR     := ../../../../../../host/common
+FIRMWARE_COMMON_DIR := ../../../../../../firmware_common
 
-QUARTUS_WORKDIR		:= ../../../../../quartus/${WORKDIR}
-NIOS_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios
-MEM_INIT_DIR		:= $(NIOS_BUILD_OUTDIR)/mem_init
-BSP_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
-QUARTUS_OUTDIR		:= $(QUARTUS_WORKDIR)/output_files
+QUARTUS_WORKDIR     := ../../../../../quartus/${WORKDIR}
+NIOS_BUILD_OUTDIR   := $(QUARTUS_WORKDIR)/bladeRF_nios
+MEM_INIT_DIR        := $(NIOS_BUILD_OUTDIR)/mem_init
+BSP_BUILD_OUTDIR    := $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
+QUARTUS_OUTDIR      := $(QUARTUS_WORKDIR)/output_files
 
-ALT_INCLUDE_DIRS	+= ./src
+ALT_INCLUDE_DIRS    += ./src
 
-C_SRCS				+= ./src/bladeRF_nios.c
-C_SRCS				+= $(FPGA_COMMON_DIR)/src/lms.c
-C_SRCS				+= $(FPGA_COMMON_DIR)/src/band_select.c
-C_SRCS				+= $(BLADERF_COMMON_DIR)/src/pkt_retune.c
+C_SRCS              += ./src/bladeRF_nios.c
+C_SRCS              += $(FPGA_COMMON_DIR)/src/lms.c
+C_SRCS              += $(FPGA_COMMON_DIR)/src/band_select.c
+C_SRCS              += $(BLADERF_COMMON_DIR)/src/pkt_retune.c
 
-CFLAGS				+= -DBOARD_BLADERF
+CFLAGS              += -DBOARD_BLADERF
 
 #------------------------------------------------------------------------------
 #              INCLUDE THE COMMON MAKEFILE

--- a/hdl/fpga/platforms/bladerf/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf/software/bladeRF_nios/Makefile
@@ -14,6 +14,9 @@ QUARTUS_OUTDIR     := $(QUARTUS_WORKDIR)/output_files
 
 ALT_INCLUDE_DIRS   += -I ./src
 
+C_SRCS             += $(FPGA_COMMON_DIR)/src/lms.c
+C_SRCS             += $(FPGA_COMMON_DIR)/src/band_select.c
+C_SRCS             += $(BLADERF_COMMON_DIR)/src/pkt_retune.c
 C_SRCS             += ./src/bladeRF_nios.c
 
 #------------------------------------------------------------------------------

--- a/hdl/fpga/platforms/bladerf/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/bladerf/software/bladeRF_nios/Makefile
@@ -2,22 +2,26 @@
 #              VARIABLES TO BE DEFINED BY PLATFORM MAKEFILE
 #------------------------------------------------------------------------------
 
-FPGA_COMMON_DIR    := ../../../../../../fpga_common
-LIBBLADERF_DIR     := ../../../../../../host/libraries/libbladeRF
-BLADERF_COMMON_DIR := ../../../common/bladerf/software/bladeRF_nios
+FPGA_COMMON_DIR		:= ../../../../../../fpga_common
+LIBBLADERF_DIR		:= ../../../../../../host/libraries/libbladeRF
+BLADERF_COMMON_DIR	:= ../../../common/bladerf/software/bladeRF_nios
+HOST_COMMON_DIR		:= ../../../../../../host/common
+FIRMWARE_COMMON_DIR	:= ../../../../../../firmware_common
 
-QUARTUS_WORKDIR    := ../../../../../quartus/${WORKDIR}
-NIOS_BUILD_OUTDIR  := $(QUARTUS_WORKDIR)/bladeRF_nios
-MEM_INIT_DIR       := $(NIOS_BUILD_OUTDIR)/mem_init
-BSP_BUILD_OUTDIR   := $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
-QUARTUS_OUTDIR     := $(QUARTUS_WORKDIR)/output_files
+QUARTUS_WORKDIR		:= ../../../../../quartus/${WORKDIR}
+NIOS_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios
+MEM_INIT_DIR		:= $(NIOS_BUILD_OUTDIR)/mem_init
+BSP_BUILD_OUTDIR	:= $(QUARTUS_WORKDIR)/bladeRF_nios_bsp
+QUARTUS_OUTDIR		:= $(QUARTUS_WORKDIR)/output_files
 
-ALT_INCLUDE_DIRS   += -I ./src
+ALT_INCLUDE_DIRS	+= ./src
 
-C_SRCS             += $(FPGA_COMMON_DIR)/src/lms.c
-C_SRCS             += $(FPGA_COMMON_DIR)/src/band_select.c
-C_SRCS             += $(BLADERF_COMMON_DIR)/src/pkt_retune.c
-C_SRCS             += ./src/bladeRF_nios.c
+C_SRCS				+= ./src/bladeRF_nios.c
+C_SRCS				+= $(FPGA_COMMON_DIR)/src/lms.c
+C_SRCS				+= $(FPGA_COMMON_DIR)/src/band_select.c
+C_SRCS				+= $(BLADERF_COMMON_DIR)/src/pkt_retune.c
+
+CFLAGS				+= -DBOARD_BLADERF
 
 #------------------------------------------------------------------------------
 #              INCLUDE THE COMMON MAKEFILE

--- a/hdl/fpga/platforms/bladerf/software/bladeRF_nios/src/bladeRF_nios.c
+++ b/hdl/fpga/platforms/bladerf/software/bladeRF_nios/src/bladeRF_nios.c
@@ -176,7 +176,7 @@ int main(void)
             if (handler == NULL) {
                 /* We somehow got out of sync. Throw away request data until
                  * we hit a magic value */
-                DBG("Got invalid magic value: 0x%02x\n", pkt.req[PKT_MAGIC_IDX]);
+                DBG("Got invalid magic value: 0x%x\n", pkt.req[PKT_MAGIC_IDX]);
                 continue;
             }
 

--- a/hdl/fpga/platforms/bladerf/software/bladeRF_nios/src/fpga_version.h
+++ b/hdl/fpga/platforms/bladerf/software/bladeRF_nios/src/fpga_version.h
@@ -8,7 +8,7 @@
 #define FPGA_VERSION_ID         0x7777
 #define FPGA_VERSION_MAJOR      0
 #define FPGA_VERSION_MINOR      10
-#define FPGA_VERSION_PATCH      0
+#define FPGA_VERSION_PATCH      1
 #define FPGA_VERSION ((uint32_t)( FPGA_VERSION_MAJOR        | \
                                  (FPGA_VERSION_MINOR << 8)  | \
                                  (FPGA_VERSION_PATCH << 16) ) )

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/Makefile
@@ -167,12 +167,8 @@ C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_8x32.c
 C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_8x64.c
 C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_16x64.c
 C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_32x32.c
-C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_retune.c
-C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_retune2.c
 C_SRCS += $(BLADERF_COMMON_DIR)/src/pkt_legacy.c
 C_SRCS += $(BLADERF_COMMON_DIR)/src/devices_sim.c
-C_SRCS += $(FPGA_COMMON_DIR)/src/lms.c
-C_SRCS += $(FPGA_COMMON_DIR)/src/band_select.c
 CXX_SRCS :=
 ASM_SRCS :=
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/Makefile
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/Makefile
@@ -2,13 +2,15 @@
 #              VARIABLES TO BE DEFINED BY PLATFORM MAKEFILE
 #------------------------------------------------------------------------------
 
-#  - FPGA_COMMON_DIR    : Path to fpga_common
-#  - LIBBLADERF_DIR     : Path to libbladeRF
-#  - BLADERF_COMMON_DIR : Path to common bladeRF_nios dir
-#  - NIOS_BUILD_OUTDIR  : Path to place the Nios build products
-#  - MEM_INIT_DIR       : Path to place the mem_init build products
-#  - BSP_BUILD_OUTDIR   : Path where BSP build products are located
-#  - QUARTUS_OUTDIR     : Path where Quartus build products are located
+#  - FPGA_COMMON_DIR     : Path to fpga_common
+#  - FIRMWARE_COMMON_DIR : Path to firmware_common
+#  - LIBBLADERF_DIR      : Path to libbladeRF
+#  - BLADERF_COMMON_DIR  : Path to common bladeRF_nios dir
+#  - HOST_COMMON_DIR     : Path to host common directory
+#  - NIOS_BUILD_OUTDIR   : Path to place the Nios build products
+#  - MEM_INIT_DIR        : Path to place the mem_init build products
+#  - BSP_BUILD_OUTDIR    : Path where BSP build products are located
+#  - QUARTUS_OUTDIR      : Path where Quartus build products are located
 #
 # Can opionally define these other variables
 #  - ALT_INCLUDE_DIRS
@@ -20,9 +22,10 @@
 
 # List of include directories for -I compiler option (-I added when used).
 # Includes the BSP.
-ALT_INCLUDE_DIRS += -I $(BLADERF_COMMON_DIR)/src \
-                    -I $(FPGA_COMMON_DIR)/include \
-                    -I $(LIBBLADERF_DIR)/include
+ALT_INCLUDE_DIRS += $(BLADERF_COMMON_DIR)/src \
+                    $(FIRMWARE_COMMON_DIR) \
+                    $(FPGA_COMMON_DIR)/include \
+                    $(LIBBLADERF_DIR)/include
 
 # List of library directories for -L linker option (-L added when used).
 # Includes the BSP.

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.c
@@ -24,13 +24,13 @@
 
 #ifndef BLADERF_NIOS_PC_SIMULATION
 
+#include "devices.h"
+#include "debug.h"
+#include "devices_inline.h"
+#include "fpga_version.h"
+#include <alt_types.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <alt_types.h>
-#include "devices.h"
-#include "devices_inline.h"
-#include "debug.h"
-#include "fpga_version.h"
 
 /* Define a global variable containing the current VCTCXO DAC setting.
  * This is a 'cached' value of what is written to the DAC and is used
@@ -42,40 +42,45 @@ uint16_t vctcxo_trim_dac_value = 0x7FFF;
 /* Define a cached version of the VCTCXO tamer control register */
 uint8_t vctcxo_tamer_ctrl_reg = 0x00;
 
+#ifdef BOARD_BLADERF_MICRO
 /* Cached version of ADF400x registers */
-uint32_t adf400x_reg[4] = {0};
+uint32_t adf400x_reg[4] = { 0 };
 
 /* Define the fast lock profile storage arrays */
 fastlock_profile fastlocks_rx[NUM_BBP_FASTLOCK_PROFILES];
 fastlock_profile fastlocks_tx[NUM_BBP_FASTLOCK_PROFILES];
+#endif  // BOARD_BLADERF_MICRO
 
-static void command_uart_enable_isr(bool enable) {
-    uint32_t val = enable ? 1 : 0 ;
-    IOWR_32DIRECT(COMMAND_UART_BASE, 16, val) ;
-    return ;
+static void command_uart_enable_isr(bool enable)
+{
+    uint32_t val = enable ? 1 : 0;
+    IOWR_32DIRECT(COMMAND_UART_BASE, 16, val);
+    return;
 }
 
-static void command_uart_isr(void *context) {
-    struct pkt_buf *pkt = (struct pkt_buf *)context ;
+static void command_uart_isr(void *context)
+{
+    struct pkt_buf *pkt = (struct pkt_buf *)context;
 
     /* Reading the request should clear the interrupt */
-    command_uart_read_request((uint8_t *)pkt->req) ;
+    command_uart_read_request((uint8_t *)pkt->req);
 
     /* Tell the main loop that there is a request pending */
-    pkt->ready = true ;
+    pkt->ready = true;
 
-    return ;
+    return;
 }
 
-static void vctcxo_tamer_isr(void *context) {
+static void vctcxo_tamer_isr(void *context)
+{
     struct vctcxo_tamer_pkt_buf *pkt = (struct vctcxo_tamer_pkt_buf *)context;
-    uint8_t error_status = 0x00;
+    uint8_t error_status             = 0x00;
 
     /* Disable interrupts */
-    vctcxo_tamer_enable_isr( false );
+    vctcxo_tamer_enable_isr(false);
 
     /* Reset (stop) the counters */
-    vctcxo_tamer_reset_counters( true );
+    vctcxo_tamer_reset_counters(true);
 
     /* Read the current count values */
     pkt->pps_1s_error   = vctcxo_tamer_read_count(VT_ERR_1S_ADDR);
@@ -86,8 +91,8 @@ static void vctcxo_tamer_isr(void *context) {
     error_status = vctcxo_tamer_read(VT_STAT_ADDR);
 
     /* Set the appropriate flags in the packet buffer */
-    pkt->pps_1s_error_flag   = (error_status & VT_STAT_ERR_1S)   ? true : false;
-    pkt->pps_10s_error_flag  = (error_status & VT_STAT_ERR_10S)  ? true : false;
+    pkt->pps_1s_error_flag   = (error_status & VT_STAT_ERR_1S) ? true : false;
+    pkt->pps_10s_error_flag  = (error_status & VT_STAT_ERR_10S) ? true : false;
     pkt->pps_100s_error_flag = (error_status & VT_STAT_ERR_100S) ? true : false;
 
     /* Clear interrupt */
@@ -99,8 +104,9 @@ static void vctcxo_tamer_isr(void *context) {
     return;
 }
 
-void vctcxo_tamer_enable_isr(bool enable) {
-    if( enable ) {
+void vctcxo_tamer_enable_isr(bool enable)
+{
+    if (enable) {
         vctcxo_tamer_ctrl_reg |= VT_CTRL_IRQ_EN;
     } else {
         vctcxo_tamer_ctrl_reg &= ~VT_CTRL_IRQ_EN;
@@ -110,13 +116,15 @@ void vctcxo_tamer_enable_isr(bool enable) {
     return;
 }
 
-void vctcxo_tamer_clear_isr() {
+void vctcxo_tamer_clear_isr()
+{
     vctcxo_tamer_write(VT_CTRL_ADDR, vctcxo_tamer_ctrl_reg | VT_CTRL_IRQ_CLR);
     return;
 }
 
-void vctcxo_tamer_reset_counters(bool reset) {
-    if( reset ) {
+void vctcxo_tamer_reset_counters(bool reset)
+{
+    if (reset) {
         vctcxo_tamer_ctrl_reg |= VT_CTRL_RESET;
     } else {
         vctcxo_tamer_ctrl_reg &= ~VT_CTRL_RESET;
@@ -126,8 +134,8 @@ void vctcxo_tamer_reset_counters(bool reset) {
     return;
 }
 
-void vctcxo_tamer_set_tune_mode(bladerf_vctcxo_tamer_mode mode) {
-
+void vctcxo_tamer_set_tune_mode(bladerf_vctcxo_tamer_mode mode)
+{
     switch (mode) {
         case BLADERF_VCTCXO_TAMER_DISABLED:
         case BLADERF_VCTCXO_TAMER_1_PPS:
@@ -142,15 +150,15 @@ void vctcxo_tamer_set_tune_mode(bladerf_vctcxo_tamer_mode mode) {
 
     /* Set tuning mode */
     vctcxo_tamer_ctrl_reg &= ~VT_CTRL_TUNE_MODE;
-    vctcxo_tamer_ctrl_reg |= (((uint8_t) mode) << 6);
+    vctcxo_tamer_ctrl_reg |= (((uint8_t)mode) << 6);
     vctcxo_tamer_write(VT_CTRL_ADDR, vctcxo_tamer_ctrl_reg);
 
     /* Reset the counters */
-    vctcxo_tamer_reset_counters( true );
+    vctcxo_tamer_reset_counters(true);
 
     /* Take counters out of reset if tuning mode is not DISABLED */
-    if( mode != 0x00 ) {
-        vctcxo_tamer_reset_counters( false );
+    if (mode != 0x00) {
+        vctcxo_tamer_reset_counters(false);
     }
 
     switch (mode) {
@@ -170,61 +178,66 @@ void vctcxo_tamer_set_tune_mode(bladerf_vctcxo_tamer_mode mode) {
 bladerf_vctcxo_tamer_mode vctcxo_tamer_get_tune_mode()
 {
     uint8_t tmp = vctcxo_tamer_read(VT_CTRL_ADDR);
-    tmp = (tmp & VT_CTRL_TUNE_MODE) >> 6;
+    tmp         = (tmp & VT_CTRL_TUNE_MODE) >> 6;
 
     switch (tmp) {
         case BLADERF_VCTCXO_TAMER_DISABLED:
         case BLADERF_VCTCXO_TAMER_1_PPS:
         case BLADERF_VCTCXO_TAMER_10_MHZ:
-            return (bladerf_vctcxo_tamer_mode) tmp;
+            return (bladerf_vctcxo_tamer_mode)tmp;
 
         default:
             return BLADERF_VCTCXO_TAMER_INVALID;
     }
 }
 
-int32_t vctcxo_tamer_read_count(uint8_t addr) {
-    uint32_t base = VCTCXO_TAMER_0_BASE;
+int32_t vctcxo_tamer_read_count(uint8_t addr)
+{
+    uint32_t base  = VCTCXO_TAMER_0_BASE;
     uint8_t offset = addr;
-    int32_t value = 0;
+    int32_t value  = 0;
 
-    value  = IORD_8DIRECT(base, offset++);
-    value |= ((int32_t) IORD_8DIRECT(base, offset++)) << 8;
-    value |= ((int32_t) IORD_8DIRECT(base, offset++)) << 16;
-    value |= ((int32_t) IORD_8DIRECT(base, offset++)) << 24;
+    value = IORD_8DIRECT(base, offset++);
+    value |= ((int32_t)IORD_8DIRECT(base, offset++)) << 8;
+    value |= ((int32_t)IORD_8DIRECT(base, offset++)) << 16;
+    value |= ((int32_t)IORD_8DIRECT(base, offset++)) << 24;
 
     return value;
 }
 
-uint8_t vctcxo_tamer_read(uint8_t addr) {
+uint8_t vctcxo_tamer_read(uint8_t addr)
+{
     return (uint8_t)IORD_8DIRECT(VCTCXO_TAMER_0_BASE, addr);
 }
 
-void vctcxo_tamer_write(uint8_t addr, uint8_t data) {
+void vctcxo_tamer_write(uint8_t addr, uint8_t data)
+{
     IOWR_8DIRECT(VCTCXO_TAMER_0_BASE, addr, data);
 }
 
-void tamer_schedule(bladerf_module m, uint64_t time) {
-    uint32_t base = (m == BLADERF_MODULE_RX) ? RX_TAMER_BASE : TX_TAMER_BASE ;
+void tamer_schedule(bladerf_module m, uint64_t time)
+{
+    uint32_t base = (m == BLADERF_MODULE_RX) ? RX_TAMER_BASE : TX_TAMER_BASE;
 
     /* Set the holding time */
-    IOWR_8DIRECT(base, 0, (time>> 0)&0xff) ;
-    IOWR_8DIRECT(base, 1, (time>> 8)&0xff) ;
-    IOWR_8DIRECT(base, 2, (time>>16)&0xff) ;
-    IOWR_8DIRECT(base, 3, (time>>24)&0xff) ;
-    IOWR_8DIRECT(base, 4, (time>>32)&0xff) ;
-    IOWR_8DIRECT(base, 5, (time>>40)&0xff) ;
-    IOWR_8DIRECT(base, 6, (time>>48)&0xff) ;
-    IOWR_8DIRECT(base, 7, (time>>54)&0xff) ;
+    IOWR_8DIRECT(base, 0, (time >> 0) & 0xff);
+    IOWR_8DIRECT(base, 1, (time >> 8) & 0xff);
+    IOWR_8DIRECT(base, 2, (time >> 16) & 0xff);
+    IOWR_8DIRECT(base, 3, (time >> 24) & 0xff);
+    IOWR_8DIRECT(base, 4, (time >> 32) & 0xff);
+    IOWR_8DIRECT(base, 5, (time >> 40) & 0xff);
+    IOWR_8DIRECT(base, 6, (time >> 48) & 0xff);
+    IOWR_8DIRECT(base, 7, (time >> 54) & 0xff);
 
     /* Commit it and arm the comparison */
-    IOWR_8DIRECT(base, 8, 0) ;
+    IOWR_8DIRECT(base, 8, 0);
 
-    return ;
+    return;
 }
 
-void bladerf_nios_init(struct pkt_buf *pkt, struct vctcxo_tamer_pkt_buf *vctcxo_tamer_pkt) {
-
+void bladerf_nios_init(struct pkt_buf *pkt,
+                       struct vctcxo_tamer_pkt_buf *vctcxo_tamer_pkt)
+{
     /* Set the prescaler for 400kHz with an 80MHz clock:
      *      (prescaler = clock / (5*desired) - 1)
      */
@@ -244,41 +257,37 @@ void bladerf_nios_init(struct pkt_buf *pkt, struct vctcxo_tamer_pkt_buf *vctcxo_
     IOWR_ALTERA_AVALON_PIO_DATA(RX_TRIGGER_CTL_BASE, 0x00);
 
     /* Register Command UART ISR */
-    alt_ic_isr_register(
-        COMMAND_UART_IRQ_INTERRUPT_CONTROLLER_ID,
-        COMMAND_UART_IRQ,
-        command_uart_isr,
-        pkt,
-        NULL
-    ) ;
+    alt_ic_isr_register(COMMAND_UART_IRQ_INTERRUPT_CONTROLLER_ID,
+                        COMMAND_UART_IRQ, command_uart_isr, pkt, NULL);
 
     /* Register the VCTCXO Tamer ISR */
-    alt_ic_isr_register(
-        VCTCXO_TAMER_0_IRQ_INTERRUPT_CONTROLLER_ID,
-        VCTCXO_TAMER_0_IRQ,
-        vctcxo_tamer_isr,
-        vctcxo_tamer_pkt,
-        NULL
-    );
+    alt_ic_isr_register(VCTCXO_TAMER_0_IRQ_INTERRUPT_CONTROLLER_ID,
+                        VCTCXO_TAMER_0_IRQ, vctcxo_tamer_isr, vctcxo_tamer_pkt,
+                        NULL);
 
     /* Default VCTCXO Tamer and its interrupts to be disabled. */
     vctcxo_tamer_set_tune_mode(BLADERF_VCTCXO_TAMER_DISABLED);
 
     /* Enable interrupts */
-    command_uart_enable_isr(true) ;
-    alt_ic_irq_enable(COMMAND_UART_IRQ_INTERRUPT_CONTROLLER_ID, COMMAND_UART_IRQ);
-    alt_ic_irq_enable(VCTCXO_TAMER_0_IRQ_INTERRUPT_CONTROLLER_ID, VCTCXO_TAMER_0_IRQ);
+    command_uart_enable_isr(true);
+    alt_ic_irq_enable(COMMAND_UART_IRQ_INTERRUPT_CONTROLLER_ID,
+                      COMMAND_UART_IRQ);
+    alt_ic_irq_enable(VCTCXO_TAMER_0_IRQ_INTERRUPT_CONTROLLER_ID,
+                      VCTCXO_TAMER_0_IRQ);
 }
 
 static void i2c_complete_transfer(uint8_t check_rxack)
 {
     if ((IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_TIP) == 0) {
-        while ( (IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_TIP) == 0);
+        while ((IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_TIP) == 0)
+            ;
     }
 
-    while (IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_TIP);
+    while (IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_TIP)
+        ;
 
-    while (check_rxack && (IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_RXACK));
+    while (check_rxack && (IORD_8DIRECT(I2C, OC_I2C_CMD_STATUS) & OC_I2C_RXACK))
+        ;
 }
 
 void spi_arbiter_lock()
@@ -291,8 +300,8 @@ void spi_arbiter_lock()
 
     do {
         data = IORD_8DIRECT(ARBITER_0_BASE, 1);
-    } while((data & 1) == 0);
-#endif // ARBITER_0_BASE
+    } while ((data & 1) == 0);
+#endif  // ARBITER_0_BASE
 }
 
 void spi_arbiter_unlock()
@@ -300,7 +309,7 @@ void spi_arbiter_unlock()
 // Applies only to bladeRF1
 #ifdef ARBITER_0_BASE
     IOWR_32DIRECT(ARBITER_0_BASE, 0, 2);
-#endif // ARBITER_0_BASE
+#endif  // ARBITER_0_BASE
 }
 
 uint8_t lms6_read(uint8_t addr)
@@ -321,12 +330,13 @@ void lms6_write(uint8_t addr, uint8_t data)
     spi_arbiter_unlock();
 }
 
+#ifdef BOARD_BLADERF_MICRO
 uint64_t adi_spi_read(uint16_t addr)
 {
-    alt_u8   addr8[2];
-    alt_u8   data8[8];
-    alt_u8   bytes;
-    uint8_t  i;
+    alt_u8 addr8[2];
+    alt_u8 data8[8];
+    alt_u8 bytes;
+    uint8_t i;
     uint64_t rv;
 
     // The alt_avalon_spi_command expects parameters to be arrays of bytes
@@ -343,18 +353,20 @@ uint64_t adi_spi_read(uint16_t addr)
 
     // Build the uint64_t return value
     rv = UINT64_C(0x0);
-    for( i = 0; i < 8; i++ ) {
-        rv |= (((uint64_t)data8[i]) << 8*(7-i));
+    for (i = 0; i < 8; i++) {
+        rv |= (((uint64_t)data8[i]) << 8 * (7 - i));
     }
 
     return rv;
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adi_spi_write(uint16_t addr, uint64_t data)
 {
-    alt_u8   data8[10];
-    alt_u8   bytes;
-    uint8_t  i;
+    alt_u8 data8[10];
+    alt_u8 bytes;
+    uint8_t i;
 
     // The alt_avalon_spi_command expects parameters to be arrays of bytes
 
@@ -363,8 +375,8 @@ void adi_spi_write(uint16_t addr, uint64_t data)
     data8[1] = (addr & 0xff);
 
     // Convert the uint64_t data into an array of 8 uint8_t
-    for( i = 0; i < 8; i++ ) {
-        data8[i+2] = (data >> 8*(7-i)) & 0xff;
+    for (i = 0; i < 8; i++) {
+        data8[i + 2] = (data >> 8 * (7 - i)) & 0xff;
     }
 
     // Calculate number of command and data bytes in this command
@@ -373,32 +385,37 @@ void adi_spi_write(uint16_t addr, uint64_t data)
     // Send down the command and the data
     alt_avalon_spi_command(RFFE_SPI_BASE, 0, bytes, &data8[0], 0, 0, 0);
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 uint32_t adi_axi_read(uint16_t addr)
 {
     uint32_t data = 0;
-#ifdef AXI_AD9361_0_BASE // Temporary hack for bladeRF1 compat
+#ifdef AXI_AD9361_0_BASE  // Temporary hack for bladeRF1 compat
     data = IORD_32DIRECT(AXI_AD9361_0_BASE, addr);
 #endif
     return data;
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adi_axi_write(uint16_t addr, uint32_t data)
 {
-#ifdef AXI_AD9361_0_BASE // Temporary hack for bladeRF1 compat
+#ifdef AXI_AD9361_0_BASE  // Temporary hack for bladeRF1 compat
     IOWR_32DIRECT(AXI_AD9361_0_BASE, addr, data);
 #endif
 }
+#endif  // BOARD_BLADERF_MICRO
 
-void adi_fastlock_save(bool is_tx, uint8_t rffe_profile,
-                          uint16_t nios_profile)
+#ifdef BOARD_BLADERF_MICRO
+void adi_fastlock_save(bool is_tx, uint8_t rffe_profile, uint16_t nios_profile)
 {
     uint16_t fl_prog_addr_reg;
     uint16_t fl_prog_rddata_reg;
     uint16_t addr;
     uint64_t data;
     uint32_t i;
-    fastlock_profile* fastlocks;
+    fastlock_profile *fastlocks;
 
     if (is_tx) {
         fl_prog_addr_reg   = 0x29c;
@@ -411,28 +428,29 @@ void adi_fastlock_save(bool is_tx, uint8_t rffe_profile,
     }
 
     /* Read out the profile data and save to Nios memory */
-    for( i = 0; i < 16; i++ ) {
+    for (i = 0; i < 16; i++) {
         addr = (0x1 << 15) | (0x0 << 12) | (fl_prog_addr_reg & 0x3ff);
-        data  = (uint64_t)(((rffe_profile & 0x7) << 4) | (i & 0xf)) << 8*7;
-        adi_spi_write( addr, data );
+        data = (uint64_t)(((rffe_profile & 0x7) << 4) | (i & 0xf)) << 8 * 7;
+        adi_spi_write(addr, data);
 
         addr = (0x0 << 15) | (0x0 << 12) | (fl_prog_rddata_reg & 0x3ff);
         fastlocks[nios_profile].profile_data[i] = adi_spi_read(addr) >> 56;
     }
 
     /* Kick out any other profile stored in the Nios that was in this slot */
-    for( i = 0; i < NUM_BBP_FASTLOCK_PROFILES; i++ ) {
-        if( (fastlocks[i].profile_num == rffe_profile) &&
-            (fastlocks[i].state == FASTLOCK_STATE_BBP_RFFE) ) {
+    for (i = 0; i < NUM_BBP_FASTLOCK_PROFILES; i++) {
+        if ((fastlocks[i].profile_num == rffe_profile) &&
+            (fastlocks[i].state == FASTLOCK_STATE_BBP_RFFE)) {
             fastlocks[i].state = FASTLOCK_STATE_BBP;
         }
     }
 
     /* Update profile state */
     fastlocks[nios_profile].state = FASTLOCK_STATE_BBP_RFFE;
-
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adi_fastlock_load(bladerf_module m, fastlock_profile *p)
 {
     static const uint8_t fl_prog_write = 1 << 1;
@@ -443,7 +461,7 @@ void adi_fastlock_load(bladerf_module m, fastlock_profile *p)
     uint32_t i;
     uint16_t addr;
     uint64_t data;
-    fastlock_profile* fastlocks;
+    fastlock_profile *fastlocks;
 
     if (BLADERF_CHANNEL_IS_TX(m)) {
         fl_prog_data_reg = 0x29d;
@@ -461,7 +479,7 @@ void adi_fastlock_load(bladerf_module m, fastlock_profile *p)
         return;
     } else {
         /* Kick out any other loaded profile that's in this slot */
-        for( i = 0; i < NUM_BBP_FASTLOCK_PROFILES; i++ ) {
+        for (i = 0; i < NUM_BBP_FASTLOCK_PROFILES; i++) {
             if ((fastlocks[i].profile_num == p->profile_num) &&
                 (fastlocks[i].state == FASTLOCK_STATE_BBP_RFFE)) {
                 fastlocks[i].state = FASTLOCK_STATE_BBP;
@@ -469,59 +487,63 @@ void adi_fastlock_load(bladerf_module m, fastlock_profile *p)
         }
 
         /* Write 2 bytes to fast lock program data register */
-        addr  = (0x1 << 15) | (0x1 << 12) | (fl_prog_data_reg & 0x3ff);
-        data  = (uint64_t)(p->profile_data[0]) << 8*7;
-        data |= (uint64_t)(((p->profile_num & 0x7) << 4) | (i & 0xf)) << 8*6;
-        adi_spi_write( addr, data );
+        addr = (0x1 << 15) | (0x1 << 12) | (fl_prog_data_reg & 0x3ff);
+        data = (uint64_t)(p->profile_data[0]) << 8 * 7;
+        data |= (uint64_t)(((p->profile_num & 0x7) << 4) | (i & 0xf)) << 8 * 6;
+        adi_spi_write(addr, data);
 
-        for( i = 1; i < fl_prog_bytes; i++ ) {
+        for (i = 1; i < fl_prog_bytes; i++) {
             /* Write 4 bytes to fast lock program control register */
-            addr  = (0x1 << 15) | (0x3 << 12) | (fl_prog_ctrl_reg & 0x3ff);
-            data  = (uint64_t)(fl_prog_write | fl_prog_clken) << 8*7;
-            data |= UINT64_C(0x0)                             << 8*6;
-            data |= (uint64_t)(p->profile_data[i])            << 8*5;
+            addr = (0x1 << 15) | (0x3 << 12) | (fl_prog_ctrl_reg & 0x3ff);
+            data = (uint64_t)(fl_prog_write | fl_prog_clken) << 8 * 7;
+            data |= UINT64_C(0x0) << 8 * 6;
+            data |= (uint64_t)(p->profile_data[i]) << 8 * 5;
             data |= ((uint64_t)(((p->profile_num & 0x7) << 4) | (i & 0xf))
-                     << 8*4);
-            adi_spi_write( addr, data );
+                     << 8 * 4);
+            adi_spi_write(addr, data);
         }
 
         /* Write 1 byte to fast lock program control register */
-        addr  = (0x1 << 15) | (0x0 << 12) | (fl_prog_ctrl_reg & 0x3ff);
-        data  = (uint64_t)(fl_prog_write | fl_prog_clken) << 8*7;
-        adi_spi_write( addr, data );
+        addr = (0x1 << 15) | (0x0 << 12) | (fl_prog_ctrl_reg & 0x3ff);
+        data = (uint64_t)(fl_prog_write | fl_prog_clken) << 8 * 7;
+        adi_spi_write(addr, data);
 
         /* Write 1 byte to fast lock program control register */
-        addr  = (0x1 << 15) | (0x0 << 12) | (fl_prog_ctrl_reg & 0x3ff);
-        adi_spi_write( addr, 0 );
+        addr = (0x1 << 15) | (0x0 << 12) | (fl_prog_ctrl_reg & 0x3ff);
+        adi_spi_write(addr, 0);
 
         /* Update profile state */
         p->state = FASTLOCK_STATE_BBP_RFFE;
     }
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adi_fastlock_recall(bladerf_module m, fastlock_profile *p)
 {
     uint16_t fl_setup_reg = BLADERF_CHANNEL_IS_TX(m) ? 0x29a : 0x25a;
     uint16_t addr;
     uint64_t data = 0;
 
-    addr  = (0x1 << 15) | (0x0 << 12) | (fl_setup_reg & 0x3ff);
-    data  = (uint64_t)(((p->profile_num & 0x7) << 5) | (0x1)) << 8*7;
+    addr = (0x1 << 15) | (0x0 << 12) | (fl_setup_reg & 0x3ff);
+    data = (uint64_t)(((p->profile_num & 0x7) << 5) | (0x1)) << 8 * 7;
 
-    adi_spi_write( addr, data );
+    adi_spi_write(addr, data);
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adi_rfport_select(fastlock_profile *p)
 {
     static const uint16_t input_sel_reg = 0x4;
-    static const uint8_t  rx_port_mask  = 0x3f;
-    static const uint8_t  tx_port_mask  = 0x40;
+    static const uint8_t rx_port_mask   = 0x3f;
+    static const uint8_t tx_port_mask   = 0x40;
     uint16_t addr;
     uint64_t data;
 
     /* Get current port selection */
-    addr  = (0x0 << 15) | (0x0 << 12) | (input_sel_reg & 0x3ff);
-    data  = adi_spi_read(addr) >> 56;
+    addr = (0x0 << 15) | (0x0 << 12) | (input_sel_reg & 0x3ff);
+    data = adi_spi_read(addr) >> 56;
 
     if (p->port >> 7) {
         /* RX bit is set, only modify RX port selection */
@@ -532,11 +554,13 @@ void adi_rfport_select(fastlock_profile *p)
     }
 
     /* Write the new port selection to AD9361 */
-    addr  = (0x1 << 15) | (0x0 << 12) | (input_sel_reg & 0x3ff);
-    data  = data << 56;
-    adi_spi_write( addr, data );
+    addr = (0x1 << 15) | (0x0 << 12) | (input_sel_reg & 0x3ff);
+    data = data << 56;
+    adi_spi_write(addr, data);
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adi_rfspdt_select(bladerf_module m, fastlock_profile *p)
 {
     static const uint32_t tx_spdt_mask = 0x7800;
@@ -554,6 +578,7 @@ void adi_rfspdt_select(bladerf_module m, fastlock_profile *p)
 
     rffe_csr_write(rffe_gpio);
 }
+#endif  // BOARD_BLADERF_MICRO
 
 uint8_t si5338_read(uint8_t addr)
 {
@@ -566,12 +591,12 @@ uint8_t si5338_read(uint8_t addr)
 
     IOWR_8DIRECT(I2C, OC_I2C_DATA, addr);
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_WR | OC_I2C_STO);
-    i2c_complete_transfer(1) ;
+    i2c_complete_transfer(1);
 
     /* Next transfer is a read operation, so '1' in the read/write bit */
     IOWR_8DIRECT(I2C, OC_I2C_DATA, SI5338_I2C | 1);
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_STA | OC_I2C_WR);
-    i2c_complete_transfer(1) ;
+    i2c_complete_transfer(1);
 
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_RD | OC_I2C_NACK | OC_I2C_STO);
     i2c_complete_transfer(0);
@@ -583,7 +608,7 @@ uint8_t si5338_read(uint8_t addr)
 void si5338_write(uint8_t addr, uint8_t data)
 {
     /* Set the address to the Si5338 */
-    IOWR_8DIRECT(I2C, OC_I2C_DATA, SI5338_I2C) ;
+    IOWR_8DIRECT(I2C, OC_I2C_DATA, SI5338_I2C);
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_STA | OC_I2C_WR);
     i2c_complete_transfer(1);
 
@@ -596,6 +621,7 @@ void si5338_write(uint8_t addr, uint8_t data)
     i2c_complete_transfer(0);
 }
 
+#ifdef BOARD_BLADERF_MICRO
 uint16_t ina219_read(uint8_t addr)
 {
     uint16_t data;
@@ -607,14 +633,14 @@ uint16_t ina219_read(uint8_t addr)
 
     IOWR_8DIRECT(I2C, OC_I2C_DATA, addr);
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_WR | OC_I2C_STO);
-    i2c_complete_transfer(1) ;
+    i2c_complete_transfer(1);
 
     /* Next transfer is a read operation, so '1' in the read/write bit */
     IOWR_8DIRECT(I2C, OC_I2C_DATA, INA219_I2C | 1);
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_STA | OC_I2C_WR);
-    i2c_complete_transfer(1) ;
+    i2c_complete_transfer(1);
 
-    IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_RD );
+    IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_RD);
     i2c_complete_transfer(1);
     data = IORD_8DIRECT(I2C, OC_I2C_DATA) << 8;
 
@@ -624,11 +650,13 @@ uint16_t ina219_read(uint8_t addr)
     data |= IORD_8DIRECT(I2C, OC_I2C_DATA);
     return data;
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void ina219_write(uint8_t addr, uint16_t data)
 {
     /* Set the address to the INA219 */
-    IOWR_8DIRECT(I2C, OC_I2C_DATA, INA219_I2C) ;
+    IOWR_8DIRECT(I2C, OC_I2C_DATA, INA219_I2C);
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_STA | OC_I2C_WR);
     i2c_complete_transfer(1);
 
@@ -644,6 +672,7 @@ void ina219_write(uint8_t addr, uint16_t data)
     IOWR_8DIRECT(I2C, OC_I2C_CMD_STATUS, OC_I2C_WR | OC_I2C_STO);
     i2c_complete_transfer(0);
 }
+#endif  // BOARD_BLADERF_MICRO
 
 void vctcxo_trim_dac_write(uint8_t cmd, uint16_t val)
 {
@@ -656,19 +685,21 @@ void vctcxo_trim_dac_write(uint8_t cmd, uint16_t val)
     /* Update cached value of trim DAC setting */
     vctcxo_trim_dac_value = val;
 
-    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 3, data, 0, 0, 0) ;
+    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 3, data, 0, 0, 0);
 }
 
 void vctcxo_trim_dac_read(uint8_t cmd, uint16_t *val)
 {
     alt_u8 data[2];
 
-    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 1, &cmd, 0, 0, ALT_AVALON_SPI_COMMAND_MERGE);
+    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 1, &cmd, 0, 0,
+                           ALT_AVALON_SPI_COMMAND_MERGE);
     alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 0, 0, 2, &data[0], 0);
 
     *val = ((uint8_t)data[0] << 8) | (uint8_t)data[1];
 }
 
+#ifdef BOARD_BLADERF_MICRO
 void ad56x1_vctcxo_trim_dac_write(uint16_t val)
 {
     uint8_t data[2] = {
@@ -679,30 +710,33 @@ void ad56x1_vctcxo_trim_dac_write(uint16_t val)
     /* Update cached value of trim DAC setting */
     vctcxo_trim_dac_value = val;
 
-    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 2, data, 0, 0, 0) ;
+    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 0, 2, data, 0, 0, 0);
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void ad56x1_vctcxo_trim_dac_read(uint16_t *val)
 {
     /* The AD56x1 DAC does not have readback functionality.
      * Return the cached DAC value */
     *val = vctcxo_trim_dac_value;
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 void adf400x_spi_write(uint32_t val)
 {
-    uint8_t data[3] = {
-        (val >> 16) & 0xff,
-        (val >> 8)  & 0xff,
-        (val >> 0)  & 0xff
-    };
+    uint8_t data[3] = { (val >> 16) & 0xff, (val >> 8) & 0xff,
+                        (val >> 0) & 0xff };
 
     /* Update cached value of ADF400x setting */
     adf400x_reg[val & 0x3] = val;
 
-    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 1, 3, data, 0, 0, 0) ;
+    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 1, 3, data, 0, 0, 0);
 }
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
 uint32_t adf400x_spi_read(uint8_t addr)
 {
     /* This assumes the AD400x MUXOUT is set to SDO/MISO,
@@ -715,11 +749,13 @@ uint32_t adf400x_spi_read(uint8_t addr)
     }; */
 
     /* Perform the SPI operation so we can take a look on SignalTap */
-    //alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 1, 3, sdi_data, 3, sdo_data, 0);
+    // alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 1, 3, sdi_data, 3, sdo_data,
+    // 0);
 
     /* Just return the cached value */
     return adf400x_reg[addr & 0x3];
 }
+#endif  // BOARD_BLADERF_MICRO
 
 void adf4351_write(uint32_t val)
 {
@@ -731,15 +767,16 @@ void adf4351_write(uint32_t val)
     uint8_t t;
     sval.val = val;
 
-    t = sval.byte[0];
+    t            = sval.byte[0];
     sval.byte[0] = sval.byte[3];
     sval.byte[3] = t;
 
-    t = sval.byte[1];
+    t            = sval.byte[1];
     sval.byte[1] = sval.byte[2];
     sval.byte[2] = t;
 
-    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 1, 4, (uint8_t*)&sval.val, 0, 0, 0);
+    alt_avalon_spi_command(PERIPHERAL_SPI_BASE, 1, 4, (uint8_t *)&sval.val, 0,
+                           0, 0);
 }
 
 // Temporary for bladeRF2 compat
@@ -756,15 +793,15 @@ static inline uint32_t module_to_iqcorr_base(bladerf_module m)
 
 uint16_t iqbal_get_gain(bladerf_module m)
 {
-    const uint32_t base = module_to_iqcorr_base(m);
+    const uint32_t base   = module_to_iqcorr_base(m);
     const uint32_t regval = IORD_ALTERA_AVALON_PIO_DATA(base);
-    return (uint16_t) regval;
+    return (uint16_t)regval;
 }
 
 void iqbal_set_gain(bladerf_module m, uint16_t value)
 {
     const uint32_t base = module_to_iqcorr_base(m);
-    uint32_t regval = IORD_ALTERA_AVALON_PIO_DATA(base);
+    uint32_t regval     = IORD_ALTERA_AVALON_PIO_DATA(base);
 
     regval &= 0xffff0000;
     regval |= value;
@@ -782,46 +819,52 @@ uint16_t iqbal_get_phase(bladerf_module m)
         regval = IORD_ALTERA_AVALON_PIO_DATA(IQ_CORR_TX_PHASE_GAIN_BASE);
     }
 
-    return (uint16_t) (regval >> 16);
+    return (uint16_t)(regval >> 16);
 }
 
 void iqbal_set_phase(bladerf_module m, uint16_t value)
 {
     const uint32_t base = module_to_iqcorr_base(m);
-    uint32_t regval = IORD_ALTERA_AVALON_PIO_DATA(base);
+    uint32_t regval     = IORD_ALTERA_AVALON_PIO_DATA(base);
 
     regval &= 0x0000ffff;
-    regval |= ((uint32_t) value) << 16;
+    regval |= ((uint32_t)value) << 16;
 
     IOWR_ALTERA_AVALON_PIO_DATA(base, regval);
 }
 
 #endif
 #else
-uint16_t iqbal_get_gain(bladerf_module m) { return 0; }
-void     iqbal_set_gain(bladerf_module m, uint16_t value) { }
-uint16_t iqbal_get_phase(bladerf_module m) { return 0; }
-void     iqbal_set_phase(bladerf_module m, uint16_t value) { }
+uint16_t iqbal_get_gain(bladerf_module m)
+{
+    return 0;
+}
+void iqbal_set_gain(bladerf_module m, uint16_t value) {}
+uint16_t iqbal_get_phase(bladerf_module m)
+{
+    return 0;
+}
+void iqbal_set_phase(bladerf_module m, uint16_t value) {}
 #endif
 
 void tx_trigger_ctl_write(uint8_t data)
 {
-  IOWR_ALTERA_AVALON_PIO_DATA(TX_TRIGGER_CTL_BASE, data);
+    IOWR_ALTERA_AVALON_PIO_DATA(TX_TRIGGER_CTL_BASE, data);
 }
 
 uint8_t tx_trigger_ctl_read(void)
 {
-  return IORD_ALTERA_AVALON_PIO_DATA(TX_TRIGGER_CTL_BASE);
+    return IORD_ALTERA_AVALON_PIO_DATA(TX_TRIGGER_CTL_BASE);
 }
 
 void rx_trigger_ctl_write(uint8_t data)
 {
-  IOWR_ALTERA_AVALON_PIO_DATA(RX_TRIGGER_CTL_BASE, data);
+    IOWR_ALTERA_AVALON_PIO_DATA(RX_TRIGGER_CTL_BASE, data);
 }
 
 uint8_t rx_trigger_ctl_read(void)
 {
-  return IORD_ALTERA_AVALON_PIO_DATA(RX_TRIGGER_CTL_BASE);
+    return IORD_ALTERA_AVALON_PIO_DATA(RX_TRIGGER_CTL_BASE);
 }
 
 void agc_dc_corr_write(uint16_t addr, uint16_t value)
@@ -840,23 +883,23 @@ void agc_dc_corr_write(uint16_t addr, uint16_t value)
         IOWR_ALTERA_AVALON_PIO_DATA(AGC_DC_Q_MIN_BASE, value);
     else if (addr == NIOS_PKT_8x16_ADDR_AGC_DC_I_MIN)
         IOWR_ALTERA_AVALON_PIO_DATA(AGC_DC_I_MIN_BASE, value);
-#endif // AGC_DC_I_MIN_BASE
+#endif  // AGC_DC_I_MIN_BASE
 }
 
 uint64_t time_tamer_read(bladerf_module m)
 {
-    uint32_t base = (m == BLADERF_MODULE_RX) ? RX_TAMER_BASE : TX_TAMER_BASE ;
+    uint32_t base  = (m == BLADERF_MODULE_RX) ? RX_TAMER_BASE : TX_TAMER_BASE;
     uint8_t offset = 0;
     uint64_t value = 0;
 
-    value  = IORD_8DIRECT(base, offset++);
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 8;
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 16;
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 24;
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 32;
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 40;
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 48;
-    value |= ((uint64_t) IORD_8DIRECT(base, offset++)) << 56;
+    value = IORD_8DIRECT(base, offset++);
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 8;
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 16;
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 24;
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 32;
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 40;
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 48;
+    value |= ((uint64_t)IORD_8DIRECT(base, offset++)) << 56;
 
     return value;
 }

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.c
@@ -43,6 +43,9 @@ uint16_t vctcxo_trim_dac_value = 0x7FFF;
 uint8_t vctcxo_tamer_ctrl_reg = 0x00;
 
 #ifdef BOARD_BLADERF_MICRO
+/* Common bladeRF2 header */
+#include "bladerf2_common.h"
+
 /* Cached version of ADF400x registers */
 uint32_t adf400x_reg[4] = { 0 };
 
@@ -563,17 +566,21 @@ void adi_rfport_select(fastlock_profile *p)
 #ifdef BOARD_BLADERF_MICRO
 void adi_rfspdt_select(bladerf_module m, fastlock_profile *p)
 {
-    static const uint32_t tx_spdt_mask = 0x7800;
-    static const uint32_t rx_spdt_mask = 0x03c0;
+    static const uint32_t tx_spdt_shift = RFFE_CONTROL_TX_SPDT_1;
+    static const uint32_t tx_spdt_mask  = (0xF << tx_spdt_shift);
+    static const uint32_t rx_spdt_shift = RFFE_CONTROL_RX_SPDT_1;
+    static const uint32_t rx_spdt_mask  = (0xF << rx_spdt_shift);
 
     uint32_t rffe_gpio;
 
     rffe_gpio = rffe_csr_read();
 
     if (BLADERF_CHANNEL_IS_TX(m)) {
-        rffe_gpio = (rffe_gpio & ~tx_spdt_mask) | (p->spdt >> 4);
+        rffe_gpio &= (~tx_spdt_mask);
+        rffe_gpio |= ((p->spdt >> 4) << tx_spdt_shift);
     } else {
-        rffe_gpio = (rffe_gpio & ~rx_spdt_mask) | (p->spdt & 0xf);
+        rffe_gpio &= (~rx_spdt_mask);
+        rffe_gpio |= ((p->spdt & 0xf) << rx_spdt_shift);
     }
 
     rffe_csr_write(rffe_gpio);

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
@@ -581,6 +581,37 @@ uint8_t rx_trigger_ctl_read(void);
  */
 void agc_dc_corr_write(uint16_t addr, uint16_t value);
 
+/**
+ * Initialize the RFIC command handler. Run once at startup.
+ */
+void rfic_command_init(void);
+
+/**
+ * Do background RFIC command processing.
+ */
+void rfic_command_work(void);
+
+/**
+ * RFIC command write
+ *
+ * @param   addr    Address
+ * @param   data    Value
+ *
+ * @return bool (true = success)
+ */
+bool rfic_command_write(uint16_t addr, uint64_t data);
+
+/**
+ * RFIC command read
+ *
+ * @param   addr    Address
+ * @param   data    Value (out)
+ *
+ * @return bool (true = success)
+ */
+bool rfic_command_read(uint16_t addr, uint64_t *data);
+
+
 /* A number of rountines define here are implemented as just a register
  * access, where incurring function call overhead is wasteful. Therefore,
  * these have been implemented as static inline functions.

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
@@ -122,6 +122,12 @@
 /* Number of fast lock profiles that can be stored in the RFFE */
 #define NUM_RFFE_FASTLOCK_PROFILES 8
 
+/* Enable libad936x if we have enough RAM. Note that it is very important
+ * that all calls to ad9361_* be ifdef-wrapped! */
+#   if COMMON_SYSTEM_0_RAM_SPAN >= 131072
+#       define BLADERF_NIOS_LIBAD936X
+#   endif
+
 #else
 #   define INLINE
     void SIMULATION_FLUSH_UART();

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
@@ -192,7 +192,7 @@ void lms6_write(uint8_t addr, uint8_t data);
  *
  * @return  Register data
  */
-uint64_t ad9361_spi_read(uint16_t addr);
+uint64_t adi_spi_read(uint16_t addr);
 
 /**
  * Write to AD9361 SPI register(s)
@@ -200,7 +200,7 @@ uint64_t ad9361_spi_read(uint16_t addr);
  * @param   addr    Register address to write to
  * @param   data    Data to write
  */
-void ad9361_spi_write(uint16_t addr, uint64_t data);
+void adi_spi_write(uint16_t addr, uint64_t data);
 
 /**
  * Read from ADI AXI space
@@ -226,7 +226,7 @@ void adi_axi_write(uint16_t addr, uint32_t data);
  * @param rffe_profile AD9361 profile number (0-::NUM_RFFE_FASTLOCK_PROFILES)
  * @param nios_profile Nios profile number (0-::NUM_BBP_FASTLOCK_PROFILES)
  */
-void ad9361_fastlock_save(bool is_tx, uint8_t rffe_profile,
+void adi_fastlock_save(bool is_tx, uint8_t rffe_profile,
                           uint16_t nios_profile);
 
 /**
@@ -235,7 +235,7 @@ void ad9361_fastlock_save(bool is_tx, uint8_t rffe_profile,
  * @param m    Which module to load.
  * @param *p   Fast lock profile structure
  */
-void ad9361_fastlock_load(bladerf_module m, fastlock_profile *p);
+void adi_fastlock_load(bladerf_module m, fastlock_profile *p);
 
 /**
  * Recall a stored fast lock profile.
@@ -243,14 +243,14 @@ void ad9361_fastlock_load(bladerf_module m, fastlock_profile *p);
  * @param m    Which module to recall.
  * @param *p   Fast lock profile structure
  */
-void ad9361_fastlock_recall(bladerf_module m, fastlock_profile *p);
+void adi_fastlock_recall(bladerf_module m, fastlock_profile *p);
 
 /**
  * Set the AD9361 port.
  *
  * @param *p   Fast lock profile structure
  */
-void ad9361_rfport_select(fastlock_profile *p);
+void adi_rfport_select(fastlock_profile *p);
 
 /**
  * Set the RF switches.
@@ -258,7 +258,7 @@ void ad9361_rfport_select(fastlock_profile *p);
  * @param m    Which module's switches to control.
  * @param *p   Fast lock profile structure
  */
-void ad9361_rfspdt_select(bladerf_module m, fastlock_profile *p);
+void adi_rfspdt_select(bladerf_module m, fastlock_profile *p);
 
 /**
  * Read from Si5338 clock generator register

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_inline.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_inline.h
@@ -33,9 +33,6 @@
 #include "altera_avalon_jtag_uart_regs.h"
 #include "altera_avalon_pio_regs.h"
 
-#include <stdint.h>
-#include <stdbool.h>
-
 
 static inline uint32_t control_reg_read(void)
 {

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
@@ -1,0 +1,892 @@
+/* This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (c) 2018 Nuand LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BLADERF_NIOS_PC_SIMULATION
+
+#include "bladerf2_common.h"
+#include "debug.h"
+#include "devices.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef BLADERF_NIOS_LIBAD936X
+
+#include "ad936x.h"
+#include "ad936x_helpers.h"
+#include "devices_rfic.h"
+
+extern AD9361_InitParam bladerf2_rfic_init_params;
+extern AD9361_RXFIRConfig bladerf2_rfic_rx_fir_config;
+extern AD9361_TXFIRConfig bladerf2_rfic_tx_fir_config;
+extern AD9361_RXFIRConfig bladerf2_rfic_rx_fir_config_dec2;
+extern AD9361_TXFIRConfig bladerf2_rfic_tx_fir_config_int2;
+extern AD9361_RXFIRConfig bladerf2_rfic_rx_fir_config_dec4;
+extern AD9361_TXFIRConfig bladerf2_rfic_tx_fir_config_int4;
+
+static struct rfic_state state;
+
+/* Uncomment to enable detailed debugging */
+// #define BLADERF_RFIC_LOTS_OF_DEBUG
+
+
+/******************************************************************************/
+/* Helpers */
+/******************************************************************************/
+
+#define CHECK_BOOL(_fn)        \
+    do {                       \
+        int s = _fn;           \
+        if (s < 0) {           \
+            RFIC_ERR(#_fn, s); \
+            return false;      \
+        }                      \
+    } while (0)
+
+static inline bool _is_initialized(struct ad9361_rf_phy *phy)
+{
+    return phy != NULL;
+}
+
+
+/******************************************************************************/
+/* Command implementations */
+/******************************************************************************/
+
+static bool _rfic_cmd_rd_status(bladerf_channel channel, uint64_t *data)
+{
+    *data = ((_is_initialized(state.phy) & BLADERF_RFIC_STATUS_INIT_MASK)
+             << BLADERF_RFIC_STATUS_INIT_SHIFT) |
+
+            ((state.write_queue.count & BLADERF_RFIC_STATUS_WQLEN_MASK)
+             << BLADERF_RFIC_STATUS_WQLEN_SHIFT) |
+
+            ((state.write_queue.last_rv & BLADERF_RFIC_STATUS_WQSUCCESS_MASK)
+             << BLADERF_RFIC_STATUS_WQSUCCESS_SHIFT);
+
+    return true;
+}
+
+/**
+ * @brief      Initialize the RFIC
+ *
+ * @param      data     0 to de-initialize, > 0 to initialize
+ *
+ * @return     true if successful, false if not
+ */
+static bool _rfic_cmd_wr_init(bladerf_channel channel, uint64_t data)
+{
+    if (data > 0) {
+        uint32_t reg;
+
+        if (_is_initialized(state.phy)) {
+            DBG("%s: already initialized\n", __FUNCTION__);
+            return true;
+        }
+
+        /* Initialize AD9361 */
+        CHECK_BOOL(ad9361_init(&state.phy, &bladerf2_rfic_init_params, NULL));
+
+        /* Clear TXNRX and ENABLE */
+        reg = rffe_csr_read();
+        reg &= ~(1 << RFFE_CONTROL_TXNRX);
+        reg &= ~(1 << RFFE_CONTROL_ENABLE);
+        rffe_csr_write(reg);
+
+        /* Initialize TX mute */
+        CHECK_BOOL(
+            txmute_set_cached(state.phy, BLADERF_CHANNEL_TX(0),
+                              bladerf2_rfic_init_params.tx_attenuation_mdB));
+        CHECK_BOOL(
+            txmute_set_cached(state.phy, BLADERF_CHANNEL_TX(1),
+                              bladerf2_rfic_init_params.tx_attenuation_mdB));
+        CHECK_BOOL(txmute_set(state.phy, BLADERF_CHANNEL_TX(0), 0));
+        CHECK_BOOL(txmute_set(state.phy, BLADERF_CHANNEL_TX(1), 0));
+
+        return true;
+    } else {
+        if (NULL != state.phy) {
+            CHECK_BOOL(ad9361_deinit(state.phy));
+            state.phy = NULL;
+        }
+
+        return true;
+    }
+}
+
+static bool _rfic_cmd_rd_init(bladerf_channel channel, uint64_t *data)
+{
+    *data = _is_initialized(state.phy);
+    return true;
+}
+
+/**
+ * @brief      Set the enabled status for a given channel
+ *
+ * @param[in]  ch    Channel
+ * @param[in]  data  0 to disable, >= 1 to enable
+ *
+ * @return     true if successful, false otherwise
+ */
+static bool _rfic_cmd_wr_enable(bladerf_channel ch, uint64_t data)
+{
+    bladerf_direction dir = BLADERF_CHANNEL_IS_TX(ch) ? BLADERF_TX : BLADERF_RX;
+    uint32_t reg;     /* RFFE register value */
+    bool ch_enabled;  /* Channel: initial state */
+    bool ch_enable;   /* Channel: target state */
+    bool ch_pending;  /* Channel: target state is not initial state */
+    bool dir_enabled; /* Direction: initial state */
+    bool dir_enable;  /* Direction: target state */
+    bool dir_pending; /* Direction: target state is not initial state */
+
+    bladerf_frequency freq = 0;
+
+    /* Verify that this is not a wildcard channel */
+    if (_rfic_chan_is_system(ch)) {
+        return false;
+    }
+
+    /* Read RFFE control register */
+    reg = rffe_csr_read();
+
+#ifdef BLADERF_RFIC_LOTS_OF_DEBUG
+    uint32_t reg_old = reg;
+#endif
+
+    /* Pre-compute useful values */
+    /* Calculate initial and target states */
+    ch_enabled  = _rffe_ch_enabled(reg, ch);
+    dir_enabled = _rffe_dir_enabled(reg, dir);
+    ch_enable   = (data > 0);
+    dir_enable  = ch_enable || _rffe_dir_otherwise_enabled(reg, ch);
+    ch_pending  = ch_enabled != ch_enable;
+    dir_pending = dir_enabled != dir_enable;
+
+    /* Query the current frequency if we are enabling this channel */
+    if (ch_enable && (ch_pending || dir_pending)) {
+        if (BLADERF_CHANNEL_IS_TX(ch)) {
+            CHECK_BOOL(ad9361_get_tx_lo_freq(state.phy, &freq));
+        } else {
+            CHECK_BOOL(ad9361_get_rx_lo_freq(state.phy, &freq));
+        }
+    }
+
+    /* Channel Setup/Teardown */
+    if (ch_pending) {
+        /* Modify SPDT bits */
+        CHECK_BOOL(_modify_spdt_bits_by_freq(&reg, ch, ch_enable, freq));
+
+        /* Modify MIMO channel enable bits */
+        if (ch_enable) {
+            reg |= (1 << _get_rffe_control_bit_for_ch(ch));
+        } else {
+            reg &= ~(1 << _get_rffe_control_bit_for_ch(ch));
+        }
+    }
+
+    /* Direction Setup/Teardown */
+    if (dir_pending) {
+        struct band_port_map const *port_map;
+
+        /* Modify ENABLE/TXNRX bits */
+        if (dir_enable) {
+            reg |= (1 << _get_rffe_control_bit_for_dir(dir));
+        } else {
+            reg &= ~(1 << _get_rffe_control_bit_for_dir(dir));
+        }
+
+        /* Select RFIC port */
+        /* Look up the port configuration for this frequency */
+        port_map = _get_band_port_map_by_freq(ch, ch_enable ? freq : 0);
+        if (NULL == port_map) {
+            return false;
+        }
+
+        /* Set the AD9361 port accordingly */
+        if (BLADERF_CHANNEL_IS_TX(ch)) {
+            CHECK_BOOL(
+                ad9361_set_tx_rf_port_output(state.phy, port_map->rfic_port));
+        } else {
+            CHECK_BOOL(
+                ad9361_set_rx_rf_port_input(state.phy, port_map->rfic_port));
+        }
+    }
+
+#ifdef BLADERF_RFIC_LOTS_OF_DEBUG
+    DBG("%s: ch=%x dir=%x ch_en=%x ch_pend=%x dir_en=%x dir_pend=%x "
+        "reg=%x->%x\n",
+        __FUNCTION__, ch, dir, ch_enable, ch_pending, dir_enable, dir_pending,
+        reg_old, reg);
+#endif
+
+    /* Write RFFE control register */
+    rffe_csr_write(reg);
+
+    return true;
+}
+
+/**
+ * @brief      Get the enabled status for a given channel
+ *
+ * @param[in]  ch    Channel
+ * @param[out] data  Pointer to return val. 0 if disabled, 1 if enabled
+ *
+ * @return     true if successful, false otherwise
+ */
+static bool _rfic_cmd_rd_enable(bladerf_channel ch, uint64_t *data)
+{
+    if (_rfic_chan_is_system(ch)) {
+        return false;
+    }
+
+    *data = _rffe_ch_enabled(rffe_csr_read(), ch) ? 1 : 0;
+
+    return true;
+}
+
+/**
+ * @brief      Set sample rate for a given channel
+ *
+ * @param[in]  channel    The channel
+ * @param[in]  rate       The rate
+ *
+ * @return     true if successful, false if not
+ */
+static bool _rfic_cmd_wr_samplerate(bladerf_channel channel, uint64_t rate)
+{
+    if (_rfic_chan_is_system(channel)) {
+        return false;
+    }
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_set_tx_sampling_freq(state.phy, rate));
+    } else {
+        CHECK_BOOL(ad9361_set_rx_sampling_freq(state.phy, rate));
+    }
+
+    return true;
+}
+
+/**
+ * @brief      Get sample rate for a given channel
+ *
+ * @param[in]  channel    The channel
+ * @param[out] rate       The sample rate
+ *
+ * @return     true if successful, false if not
+ */
+static bool _rfic_cmd_rd_samplerate(bladerf_channel channel, uint64_t *rate)
+{
+    uint32_t readval;
+
+    if (_rfic_chan_is_system(channel)) {
+        return false;
+    };
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_get_tx_sampling_freq(state.phy, &readval));
+    } else {
+        CHECK_BOOL(ad9361_get_rx_sampling_freq(state.phy, &readval));
+    }
+
+    *rate = (uint64_t)readval;
+
+    return true;
+}
+
+/**
+ * @brief      Set LO frequency for a given channel
+ *
+ * @param[in]  channel    The channel
+ * @param[in]  frequency  The frequency
+ *
+ * @return     true if successful, false if not
+ */
+static bool _rfic_cmd_wr_frequency(bladerf_channel channel, uint64_t frequency)
+{
+    if (_rfic_chan_is_system(channel)) {
+        return false;
+    }
+
+    uint32_t reg;
+
+    reg = rffe_csr_read();
+
+    /* We have to do this for all the channels sharing the same LO. */
+    for (size_t i = 0; i < 2; ++i) {
+        bladerf_channel bch = BLADERF_CHANNEL_IS_TX(channel)
+                                  ? BLADERF_CHANNEL_TX(i)
+                                  : BLADERF_CHANNEL_RX(i);
+
+        /* Is this channel enabled? */
+        bool enable = _rffe_ch_enabled(reg, bch);
+
+        /* Update SPDT bits accordingly */
+        CHECK_BOOL(_modify_spdt_bits_by_freq(&reg, bch, enable, frequency));
+    }
+
+    rffe_csr_write(reg);
+
+    CHECK_BOOL(set_ad9361_port_by_freq(
+        state.phy, channel, _rffe_ch_enabled(reg, channel), frequency));
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_set_tx_lo_freq(state.phy, frequency));
+    } else {
+        CHECK_BOOL(ad9361_set_rx_lo_freq(state.phy, frequency));
+    }
+
+    return true;
+}
+
+/**
+ * @brief      Get LO frequency for a given channel
+ *
+ * @param[in]  channel    The channel
+ * @param[out] frequency  The frequency
+ *
+ * @return     true if successful, false if not
+ */
+static bool _rfic_cmd_rd_frequency(bladerf_channel channel, uint64_t *frequency)
+{
+    uint64_t readval;
+
+    if (_rfic_chan_is_system(channel)) {
+        return false;
+    };
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_get_tx_lo_freq(state.phy, &readval));
+    } else {
+        CHECK_BOOL(ad9361_get_rx_lo_freq(state.phy, &readval));
+    }
+
+    *frequency = readval;
+
+    return true;
+}
+
+static bool _rfic_cmd_wr_bandwidth(bladerf_channel channel, uint64_t bandwidth)
+{
+    if (_rfic_chan_is_system(channel)) {
+        return false;
+    }
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_set_tx_rf_bandwidth(state.phy, bandwidth));
+    } else {
+        CHECK_BOOL(ad9361_set_rx_rf_bandwidth(state.phy, bandwidth));
+    }
+
+    return true;
+}
+
+static bool _rfic_cmd_rd_bandwidth(bladerf_channel channel, uint64_t *bandwidth)
+{
+    uint32_t readval;
+
+    if (_rfic_chan_is_system(channel)) {
+        return false;
+    };
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_get_tx_rf_bandwidth(state.phy, &readval));
+    } else {
+        CHECK_BOOL(ad9361_get_rx_rf_bandwidth(state.phy, &readval));
+    }
+
+    *bandwidth = (uint64_t)readval;
+
+    return true;
+}
+
+static bool _rfic_cmd_wr_gainmode(bladerf_channel channel, uint64_t gainmode)
+{
+    uint8_t const rfic_ch = channel >> 1;
+    enum rf_gain_ctrl_mode gc_mode;
+    bool ok;
+
+    switch (channel) {
+        case BLADERF_CHANNEL_RX(0):
+            gc_mode = bladerf2_rfic_init_params.gc_rx1_mode;
+            break;
+
+        case BLADERF_CHANNEL_RX(1):
+            gc_mode = bladerf2_rfic_init_params.gc_rx2_mode;
+            break;
+
+        default:
+            return false;
+    }
+
+    /* Mode conversion */
+    if (gainmode != BLADERF_GAIN_DEFAULT) {
+        gc_mode = gainmode_bladerf_to_ad9361(gainmode, &ok);
+    }
+
+    if (!ok) {
+        return false;
+    }
+
+    /* Set the mode! */
+    CHECK_BOOL(ad9361_set_rx_gain_control_mode(state.phy, rfic_ch, gc_mode));
+
+    return true;
+}
+
+static bool _rfic_cmd_rd_gainmode(bladerf_channel channel, uint64_t *gainmode)
+{
+    uint8_t const rfic_ch = channel >> 1;
+    uint8_t gc_mode;
+    bool ok;
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        return false;
+    }
+
+    /* Get the gain */
+    CHECK_BOOL(ad9361_get_rx_gain_control_mode(state.phy, rfic_ch, &gc_mode));
+
+    /* Mode conversion */
+    if (gainmode != NULL) {
+        *gainmode = gainmode_ad9361_to_bladerf(gc_mode, &ok);
+    }
+
+    if (!ok) {
+        return false;
+    }
+
+    return true;
+}
+
+static bool _rfic_cmd_wr_gain(bladerf_channel channel, uint64_t data)
+{
+    /* expects values that are ready to be passed down to the device.
+     * e.g.:
+     *  TX: mdB attenuation (-10 dB gain -> data = 10000)
+     *  RX: dB gain (10 dB gain -> data = 10)
+     * Values may be negative, and the uint64_t will be casted appropriately
+     */
+
+    uint8_t const rfic_ch = channel >> 1;
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        bool muted;
+
+        CHECK_BOOL(txmute_get(state.phy, channel, &muted));
+
+        if (muted) {
+            CHECK_BOOL(txmute_set_cached(state.phy, channel, (uint32_t)data));
+        } else {
+            CHECK_BOOL(
+                ad9361_set_tx_attenuation(state.phy, rfic_ch, (uint32_t)data));
+        }
+    } else {
+        CHECK_BOOL(ad9361_set_rx_rf_gain(state.phy, rfic_ch, (int32_t)data));
+    }
+
+    return true;
+}
+
+static bool _rfic_cmd_rd_gain(bladerf_channel channel, uint64_t *data)
+{
+    /* returns values that are direct from the device.
+     * e.g.:
+     *  TX: mdB attenuation (data = 10000 -> -10 dB gain)
+     *  RX: dB gain (data = 10 -> 10 dB gain)
+     * Values may be negative, and will be casted to uint64_t
+     */
+
+    uint8_t const rfic_ch = channel >> 1;
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        uint32_t atten;
+        bool muted;
+
+        CHECK_BOOL(txmute_get(state.phy, channel, &muted));
+
+        if (muted) {
+            atten = txmute_get_cached(state.phy, channel);
+        } else {
+            CHECK_BOOL(ad9361_get_tx_attenuation(state.phy, rfic_ch, &atten));
+        }
+
+        *data = (uint64_t)atten;
+    } else {
+        struct rf_rx_gain rx_gain;
+
+        CHECK_BOOL(ad9361_get_rx_gain(state.phy, rfic_ch + 1, &rx_gain));
+
+        *data = (uint64_t)rx_gain.gain_db;
+    }
+
+    return true;
+}
+
+static bool _rfic_cmd_rd_rssi(bladerf_channel channel, uint64_t *data)
+{
+    uint8_t const rfic_ch = channel >> 1;
+    int16_t pre, sym, mul;
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        uint32_t rssi = 0;
+
+        CHECK_BOOL(ad9361_get_tx_rssi(state.phy, rfic_ch, &rssi));
+
+        mul = -1000;
+        pre = rssi;
+        sym = rssi;
+    } else {
+        struct rf_rssi rssi;
+
+        CHECK_BOOL(ad9361_get_rx_rssi(state.phy, rfic_ch, &rssi));
+
+        mul = -rssi.multiplier;
+        pre = rssi.preamble;
+        sym = rssi.symbol;
+    }
+
+    *data = ((uint64_t)((uint16_t)mul & BLADERF_RFIC_RSSI_MULT_MASK)
+             << BLADERF_RFIC_RSSI_MULT_SHIFT);
+
+    *data |= ((uint64_t)((uint16_t)pre & BLADERF_RFIC_RSSI_PRE_MASK)
+              << BLADERF_RFIC_RSSI_PRE_SHIFT);
+
+    *data |= ((uint64_t)((uint16_t)sym & BLADERF_RFIC_RSSI_SYM_MASK)
+              << BLADERF_RFIC_RSSI_SYM_SHIFT);
+
+    return true;
+}
+
+static bool _rfic_cmd_wr_filter(bladerf_channel channel, uint64_t data)
+{
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        bladerf_rfic_txfir txfir       = (bladerf_rfic_txfir)data;
+        AD9361_TXFIRConfig *fir_config = NULL;
+        uint8_t enable;
+
+        if (BLADERF_RFIC_TXFIR_CUSTOM == txfir) {
+            // custom FIR not implemented, assuming default
+            txfir = BLADERF_RFIC_TXFIR_DEFAULT;
+        }
+
+        switch (txfir) {
+            case BLADERF_RFIC_TXFIR_BYPASS:
+                fir_config = &bladerf2_rfic_tx_fir_config;
+                enable     = 0;
+                break;
+            case BLADERF_RFIC_TXFIR_INT1:
+                fir_config = &bladerf2_rfic_tx_fir_config;
+                enable     = 1;
+                break;
+            case BLADERF_RFIC_TXFIR_INT2:
+                fir_config = &bladerf2_rfic_tx_fir_config_int2;
+                enable     = 1;
+                break;
+            case BLADERF_RFIC_TXFIR_INT4:
+                fir_config = &bladerf2_rfic_tx_fir_config_int4;
+                enable     = 1;
+                break;
+            default:
+                return false;
+        }
+
+        CHECK_BOOL(ad9361_set_tx_fir_config(state.phy, *fir_config));
+        CHECK_BOOL(ad9361_set_tx_fir_en_dis(state.phy, enable));
+
+        state.txfir = txfir;
+
+        return true;
+    } else {
+        bladerf_rfic_rxfir rxfir       = (bladerf_rfic_rxfir)data;
+        AD9361_RXFIRConfig *fir_config = NULL;
+        uint8_t enable;
+
+        if (BLADERF_RFIC_RXFIR_CUSTOM == rxfir) {
+            // custom FIR not implemented, assuming default
+            rxfir = BLADERF_RFIC_RXFIR_DEFAULT;
+        }
+
+        switch (rxfir) {
+            case BLADERF_RFIC_RXFIR_BYPASS:
+                fir_config = &bladerf2_rfic_rx_fir_config;
+                enable     = 0;
+                break;
+            case BLADERF_RFIC_RXFIR_DEC1:
+                fir_config = &bladerf2_rfic_rx_fir_config;
+                enable     = 1;
+                break;
+            case BLADERF_RFIC_RXFIR_DEC2:
+                fir_config = &bladerf2_rfic_rx_fir_config_dec2;
+                enable     = 1;
+                break;
+            case BLADERF_RFIC_RXFIR_DEC4:
+                fir_config = &bladerf2_rfic_rx_fir_config_dec4;
+                enable     = 1;
+                break;
+            default:
+                return false;
+        }
+
+        CHECK_BOOL(ad9361_set_rx_fir_config(state.phy, *fir_config));
+        CHECK_BOOL(ad9361_set_rx_fir_en_dis(state.phy, enable));
+
+        state.rxfir = rxfir;
+
+        return true;
+    }
+
+    return false;
+}
+
+static bool _rfic_cmd_rd_filter(bladerf_channel channel, uint64_t *data)
+{
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        *data = (uint64_t)state.txfir;
+    } else {
+        *data = (uint64_t)state.rxfir;
+    }
+
+    return true;
+}
+
+static bool _rfic_cmd_wr_txmute(bladerf_channel channel, uint64_t data)
+{
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        bool val = (data > 0);
+
+        CHECK_BOOL(txmute_set(state.phy, channel, val));
+
+        return true;
+    }
+
+    return false;
+}
+
+static bool _rfic_cmd_rd_txmute(bladerf_channel channel, uint64_t *data)
+{
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        bool val;
+
+        CHECK_BOOL(txmute_get(state.phy, channel, &val));
+
+        *data = val ? 1 : 0;
+
+        return true;
+    }
+
+    return false;
+}
+
+
+/******************************************************************************/
+/* Dispatchers */
+/******************************************************************************/
+
+struct rfic_command_fns {
+    uint8_t command;
+    bool (*write)(bladerf_channel channel, uint64_t data);
+    bool (*read)(bladerf_channel channel, uint64_t *data);
+};
+
+struct rfic_command_fns const funcs[] = {
+    // clang-format off
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_STATUS),
+        FIELD_INIT(.write, NULL),
+        FIELD_INIT(.read, _rfic_cmd_rd_status),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_INIT),
+        FIELD_INIT(.write, _rfic_cmd_wr_init),
+        FIELD_INIT(.read, _rfic_cmd_rd_init),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_ENABLE),
+        FIELD_INIT(.write, _rfic_cmd_wr_enable),
+        FIELD_INIT(.read, _rfic_cmd_rd_enable),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_SAMPLERATE),
+        FIELD_INIT(.write, _rfic_cmd_wr_samplerate),
+        FIELD_INIT(.read, _rfic_cmd_rd_samplerate),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_FREQUENCY),
+        FIELD_INIT(.write, _rfic_cmd_wr_frequency),
+        FIELD_INIT(.read, _rfic_cmd_rd_frequency),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_BANDWIDTH),
+        FIELD_INIT(.write, _rfic_cmd_wr_bandwidth),
+        FIELD_INIT(.read, _rfic_cmd_rd_bandwidth),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_GAINMODE),
+        FIELD_INIT(.write, _rfic_cmd_wr_gainmode),
+        FIELD_INIT(.read, _rfic_cmd_rd_gainmode),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_GAIN),
+        FIELD_INIT(.write, _rfic_cmd_wr_gain),
+        FIELD_INIT(.read, _rfic_cmd_rd_gain),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_RSSI),
+        FIELD_INIT(.write, NULL),
+        FIELD_INIT(.read, _rfic_cmd_rd_rssi),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_FILTER),
+        FIELD_INIT(.write, _rfic_cmd_wr_filter),
+        FIELD_INIT(.read, _rfic_cmd_rd_filter),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_TXMUTE),
+        FIELD_INIT(.write, _rfic_cmd_wr_txmute),
+        FIELD_INIT(.read, _rfic_cmd_rd_txmute),
+    },
+    // clang-format on
+};
+
+static struct rfic_command_fns const *_get_cmd_ptr(uint8_t command)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(funcs); ++i) {
+        if (command == funcs[i].command) {
+            return &funcs[i];
+        }
+    }
+
+    return NULL;
+}
+
+/* Write queue worker */
+static void rfic_command_work_wq(struct rfic_queue *q)
+{
+    struct rfic_queue_entry *e = rfic_queue_peek(q);
+
+    if (NULL == e) {
+        return;
+    }
+
+#ifndef BLADERF_RFIC_LOTS_OF_DEBUG
+    if (ENTRY_STATE_COMPLETE == e->state)
+#endif
+    {
+        RFIC_DBG("WRW", _rfic_cmdstr(e->cmd), _rfic_chanstr(e->ch),
+                 _rfic_statestr(e->state), -1, e->value);
+    }
+
+    switch (e->state) {
+        case ENTRY_STATE_NEW: {
+            e->state = ENTRY_STATE_RUNNING;
+            break;
+        }
+
+        case ENTRY_STATE_RUNNING: {
+            struct rfic_command_fns const *f = _get_cmd_ptr(e->cmd);
+
+            if (NULL == f || NULL == f->write) {
+                e->rv = 0xFE;
+                break;
+            }
+
+            e->rv    = f->write(e->ch, e->value);
+            e->state = ENTRY_STATE_COMPLETE;
+
+            break;
+        }
+
+        case ENTRY_STATE_COMPLETE: {
+            /* Drop the item from the queue */
+            q->last_rv = e->rv;
+            rfic_dequeue(q, NULL);
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
+/* Write command dispatcher */
+bool rfic_command_write(uint16_t addr, uint64_t data)
+{
+    struct rfic_command_fns const *f = _get_cmd_ptr(_rfic_unpack_cmd(addr));
+    bool rv;
+
+    if (NULL == f || NULL == f->write) {
+        rv = false;
+    } else {
+        rv = rfic_enqueue(&state.write_queue, _rfic_unpack_chan(addr),
+                          _rfic_unpack_cmd(addr), data) != COMMAND_QUEUE_FULL;
+    }
+
+#ifdef BLADERF_RFIC_LOTS_OF_DEBUG
+    RFIC_DBG("WR ", _rfic_cmdstr(_rfic_unpack_cmd(addr)),
+             _rfic_chanstr(_rfic_unpack_chan(addr)), rv ? "ENQ" : "BAD", addr,
+             data);
+#endif
+
+    return rv;
+}
+
+/* Read command dispatcher */
+bool rfic_command_read(uint16_t addr, uint64_t *data)
+{
+    uint8_t cmd                      = _rfic_unpack_cmd(addr);
+    uint8_t ch                       = _rfic_unpack_chan(addr);
+    struct rfic_command_fns const *f = _get_cmd_ptr(cmd);
+    bool rv                          = false;
+
+    // Canary
+    *data = 0xDEADBEEF;
+
+    if (NULL == f || NULL == f->read) {
+        rv = false;
+    } else {
+        rv = f->read(ch, data);
+    }
+
+    RFIC_DBG("RD ", _rfic_cmdstr(cmd), _rfic_chanstr(ch), rv ? "OK " : "BAD",
+             addr, *data);
+
+    return rv;
+}
+
+void rfic_command_init(void)
+{
+    rfic_queue_reset(&state.write_queue);
+
+    return;
+}
+
+void rfic_command_work(void)
+{
+    rfic_command_work_wq(&state.write_queue);
+
+    return;
+}
+
+#endif  // BLADERF_NIOS_LIBAD936X
+#endif  // !BLADERF_NIOS_PC_SIMULATION

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
@@ -698,6 +698,19 @@ static bool _rfic_cmd_rd_txmute(bladerf_channel channel, uint64_t *data)
     return false;
 }
 
+static bool _rfic_cmd_wr_fastlock(bladerf_channel channel, uint64_t data)
+{
+    uint32_t profile = (uint32_t)data;
+
+    if (BLADERF_CHANNEL_IS_TX(channel)) {
+        CHECK_BOOL(ad9361_tx_fastlock_store(state.phy, profile));
+    } else {
+        CHECK_BOOL(ad9361_rx_fastlock_store(state.phy, profile));
+    }
+
+    return true;
+}
+
 
 /******************************************************************************/
 /* Dispatchers */
@@ -765,6 +778,11 @@ struct rfic_command_fns const funcs[] = {
         FIELD_INIT(.command, BLADERF_RFIC_COMMAND_TXMUTE),
         FIELD_INIT(.write, _rfic_cmd_wr_txmute),
         FIELD_INIT(.read, _rfic_cmd_rd_txmute),
+    },
+    {
+        FIELD_INIT(.command, BLADERF_RFIC_COMMAND_FASTLOCK),
+        FIELD_INIT(.write, _rfic_cmd_wr_fastlock),
+        FIELD_INIT(.read, NULL),
     },
     // clang-format on
 };

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
@@ -212,6 +212,7 @@ static bool _rfic_initialize()
 
 static bool _rfic_standby()
 {
+    AD9361_InitParam *init_param = &bladerf2_rfic_init_params;
     size_t i;
     bladerf_direction dir;
 
@@ -233,6 +234,15 @@ static bool _rfic_standby()
         FOR_EACH_DIRECTION(dir)
         {
             if (state.frequency_invalid[dir]) {
+                if (BLADERF_TX == dir) {
+                    CHECK_BOOL(_rfic_cmd_wr_frequency(
+                        BLADERF_CHANNEL_TX(0),
+                        init_param->tx_synthesizer_frequency_hz));
+                } else {
+                    CHECK_BOOL(_rfic_cmd_wr_frequency(
+                        BLADERF_CHANNEL_RX(0),
+                        init_param->rx_synthesizer_frequency_hz));
+                }
             }
         }
     }

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
@@ -352,11 +352,18 @@ static bool _rfic_cmd_wr_frequency(bladerf_channel channel, uint64_t frequency)
 
     if (BLADERF_CHANNEL_IS_TX(channel)) {
         CHECK_BOOL(ad9361_set_tx_lo_freq(state.phy, frequency));
+        state.frequency_invalid[BLADERF_TX] = false;
     } else {
         CHECK_BOOL(ad9361_set_rx_lo_freq(state.phy, frequency));
+        state.frequency_invalid[BLADERF_RX] = false;
     }
 
     return true;
+}
+
+void rfic_invalidate_frequency(bladerf_module module)
+{
+    state.frequency_invalid[module] = true;
 }
 
 /**
@@ -376,8 +383,14 @@ static bool _rfic_cmd_rd_frequency(bladerf_channel channel, uint64_t *frequency)
     };
 
     if (BLADERF_CHANNEL_IS_TX(channel)) {
+        if (state.frequency_invalid[BLADERF_TX]) {
+            return false;
+        }
         CHECK_BOOL(ad9361_get_tx_lo_freq(state.phy, &readval));
     } else {
+        if (state.frequency_invalid[BLADERF_RX]) {
+            return false;
+        }
         CHECK_BOOL(ad9361_get_rx_lo_freq(state.phy, &readval));
     }
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
@@ -83,6 +83,9 @@ struct rfic_state {
     /* RX and TX FIR filter memory */
     bladerf_rfic_rxfir rxfir;
     bladerf_rfic_txfir txfir;
+
+    /* Frequency retrieval is invalid due to fastlock shenanigans */
+    bool frequency_invalid[NUM_MODULES];
 };
 
 uint8_t rfic_enqueue(struct rfic_queue *q,
@@ -95,6 +98,8 @@ uint8_t rfic_dequeue(struct rfic_queue *q, struct rfic_queue_entry *e);
 struct rfic_queue_entry *rfic_queue_peek(struct rfic_queue *q);
 
 void rfic_queue_reset(struct rfic_queue *q);
+
+void rfic_invalidate_frequency(bladerf_module module);
 
 static inline bool _rfic_chan_is_system(uint8_t ch)
 {

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
@@ -147,6 +147,9 @@ static inline char const *_rfic_cmdstr(uint8_t cmd)
         case BLADERF_RFIC_COMMAND_TXMUTE:
             return "TXMUTE  ";
 
+        case BLADERF_RFIC_COMMAND_FASTLOCK:
+            return "FASTLOCK";
+
         default:
             return "        ";
     }

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
@@ -1,0 +1,190 @@
+/* This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (c) 2018 Nuand LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BLADERF_NIOS_DEVICES_RFIC_H_
+#define BLADERF_NIOS_DEVICES_RFIC_H_
+
+#ifdef BOARD_BLADERF_MICRO
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "bladerf2_common.h"
+
+#define COMMAND_QUEUE_MAX 16
+#define COMMAND_QUEUE_FULL 0xff
+#define COMMAND_QUEUE_EMPTY 0xfe
+
+/* Packet decoding debugging output */
+static char const RFIC_DBG_FMT[] = "%s: cmd=%s ch=%s state=%s [%x]=%x(-%x)\n";
+#define RFIC_DBG(prefix, cmd, ch, state, addr, data) \
+    DBG(RFIC_DBG_FMT, prefix, cmd, ch, state, addr, data, -data)
+
+/* Error message output */
+static char const RFIC_ERR_FMT[] = "%s: error: %s returned %x (-%x)\n";
+#define RFIC_ERR(thing, retval) \
+    DBG(RFIC_ERR_FMT, __FUNCTION__, thing, retval, -retval)
+
+/* State of items in the command queue */
+enum rfic_entry_state {
+    ENTRY_STATE_INVALID = 0, /* Marks entry invalid and not in use */
+    ENTRY_STATE_NEW,         /* We have a new command request to satisfy */
+    ENTRY_STATE_RUNNING,     /* Currently executing a job */
+    ENTRY_STATE_COMPLETE,    /* The job is complete */
+};
+
+/* An entry in the command queue */
+struct rfic_queue_entry {
+    volatile enum rfic_entry_state state; /* State of this queue entry */
+    uint8_t rv;                           /* Return value */
+    uint8_t ch;                           /* Channel */
+    uint8_t cmd;                          /* Command */
+    uint64_t value;                       /* Value to pass to command */
+};
+
+/* A queue itself */
+struct rfic_queue {
+    uint8_t count;   /* Total number of items in the queue */
+    uint8_t ins_idx; /* Insertion index */
+    uint8_t rem_idx; /* Removal index */
+    uint8_t last_rv; /* Returned value from executing last command */
+
+    struct rfic_queue_entry entries[COMMAND_QUEUE_MAX];
+};
+
+struct rfic_state {
+    /* AD9361 state structure */
+    struct ad9361_rf_phy *phy;
+
+    /* Queue for handling long-running write operations */
+    struct rfic_queue write_queue;
+
+    /* RX and TX FIR filter memory */
+    bladerf_rfic_rxfir rxfir;
+    bladerf_rfic_txfir txfir;
+};
+
+uint8_t rfic_enqueue(struct rfic_queue *q,
+                     uint8_t ch,
+                     uint8_t cmd,
+                     uint64_t value);
+
+uint8_t rfic_dequeue(struct rfic_queue *q, struct rfic_queue_entry *e);
+
+struct rfic_queue_entry *rfic_queue_peek(struct rfic_queue *q);
+
+void rfic_queue_reset(struct rfic_queue *q);
+
+static inline bool _rfic_chan_is_system(uint8_t ch)
+{
+    return 0xF == ch;
+}
+
+static inline uint8_t _rfic_unpack_chan(uint16_t addr)
+{
+    return (addr >> 8) & 0xF;
+}
+
+static inline uint8_t _rfic_unpack_cmd(uint16_t addr)
+{
+    return addr & 0xF;
+}
+
+static inline char const *_rfic_cmdstr(uint8_t cmd)
+{
+    switch (cmd) {
+        case BLADERF_RFIC_COMMAND_STATUS:
+            return "STATUS  ";
+
+        case BLADERF_RFIC_COMMAND_INIT:
+            return "INIT    ";
+
+        case BLADERF_RFIC_COMMAND_ENABLE:
+            return "ENABLE  ";
+
+        case BLADERF_RFIC_COMMAND_SAMPLERATE:
+            return "SAMPRATE";
+
+        case BLADERF_RFIC_COMMAND_FREQUENCY:
+            return "FREQ    ";
+
+        case BLADERF_RFIC_COMMAND_BANDWIDTH:
+            return "BNDWDTH ";
+
+        case BLADERF_RFIC_COMMAND_GAINMODE:
+            return "GAINMD  ";
+
+        case BLADERF_RFIC_COMMAND_GAIN:
+            return "GAIN    ";
+
+        case BLADERF_RFIC_COMMAND_RSSI:
+            return "RSSI    ";
+
+        case BLADERF_RFIC_COMMAND_FILTER:
+            return "FILTER  ";
+
+        case BLADERF_RFIC_COMMAND_TXMUTE:
+            return "TXMUTE  ";
+
+        default:
+            return "        ";
+    }
+}
+
+static inline char const *_rfic_chanstr(uint8_t ch)
+{
+    switch (ch) {
+        case BLADERF_CHANNEL_TX(0):
+            return "TX1";
+        case BLADERF_CHANNEL_TX(1):
+            return "TX2";
+        case BLADERF_CHANNEL_RX(0):
+            return "RX1";
+        case BLADERF_CHANNEL_RX(1):
+            return "RX2";
+        case 0xF:
+            return "SYS";
+        default:
+            return "   ";
+    }
+}
+
+static inline char const *_rfic_statestr(enum rfic_entry_state state)
+{
+    switch (state) {
+        case ENTRY_STATE_INVALID:
+            return "BAD";
+        case ENTRY_STATE_NEW:
+            return "NEW";
+        case ENTRY_STATE_RUNNING:
+            return "RUN";
+        case ENTRY_STATE_COMPLETE:
+            return "OK ";
+        default:
+            return "   ";
+    }
+}
+
+#endif  // BOARD_BLADERF_MICRO
+#endif  // BLADERF_NIOS_DEVICES_RFIC_H_

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic_queue.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic_queue.c
@@ -1,0 +1,128 @@
+/* This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (c) 2018 Nuand LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BLADERF_NIOS_PC_SIMULATION
+
+#include "devices.h"
+#include "devices_rfic.h"
+
+#ifdef BLADERF_NIOS_LIBAD936X
+
+/******************************************************************************/
+/* Queue Management */
+/******************************************************************************/
+
+/**
+ * @brief       Enqueue a command
+ *
+ * @param       q       Queue
+ * @param[in]   ch      Channel
+ * @param[in]   cmd     Command
+ * @param[in]   value   Value to pass to command
+ *
+ * @return  queue size after the enqueue operation, or COMMAND_QUEUE_FULL if
+ *          the queue was full.
+ */
+uint8_t rfic_enqueue(struct rfic_queue *q,
+                     uint8_t ch,
+                     uint8_t cmd,
+                     uint64_t value)
+{
+    if (q->count >= COMMAND_QUEUE_MAX) {
+        return COMMAND_QUEUE_FULL;
+    }
+
+    q->entries[q->ins_idx].ch    = ch;
+    q->entries[q->ins_idx].cmd   = cmd;
+    q->entries[q->ins_idx].value = value;
+    q->entries[q->ins_idx].state = ENTRY_STATE_NEW;
+    q->entries[q->ins_idx].rv    = 0xFF;
+
+    q->ins_idx = (q->ins_idx + 1) & (COMMAND_QUEUE_MAX - 1);
+
+    return ++q->count;
+}
+
+/**
+ * @brief       Dequeue a command
+ *
+ * @param       q   Queue
+ * @param[out]  e   Pointer to a queue entry struct
+ *
+ * @return  queue size after the dequeue operation, or COMMAND_QUEUE_EMPTY if
+ *          the queue was empty.
+ */
+uint8_t rfic_dequeue(struct rfic_queue *q, struct rfic_queue_entry *e)
+{
+    if (0 == q->count) {
+        return COMMAND_QUEUE_EMPTY;
+    }
+
+    if (e != NULL) {
+        memcpy(&e, &q->entries[q->rem_idx], sizeof(e[0]));
+    }
+
+    q->rem_idx = (q->rem_idx + 1) & (COMMAND_QUEUE_MAX - 1);
+
+    return --q->count;
+}
+
+/**
+ * @brief       Get the state of the next item in the queue
+ *
+ * @param[in]   q   Queue
+ *
+ * @return      pointer to the next item in the queue, or NULL if the
+ *              queue is empty
+ */
+struct rfic_queue_entry *rfic_queue_peek(struct rfic_queue *q)
+{
+    if (0 == q->count) {
+        return NULL;
+    } else {
+        return &q->entries[q->rem_idx];
+    }
+}
+
+/**
+ * @brief      Reset/initialize the queue
+ *
+ * @param      q    Queue
+ */
+void rfic_queue_reset(struct rfic_queue *q)
+{
+    q->count = 0;
+
+    for (size_t i = 0; i < COMMAND_QUEUE_MAX; i++) {
+        q->entries[i].state = ENTRY_STATE_INVALID;
+    }
+
+    q->last_rv = 0xFF;
+    q->rem_idx = 0;
+    q->ins_idx = 0;
+}
+
+#endif  // BLADERF_NIOS_LIBAD936X
+
+#endif  // !BLADERF_NIOS_PC_SIMULATION

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_sim.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_sim.c
@@ -362,4 +362,17 @@ void command_uart_write_response(uint8_t *resp) {
         printf("Pass.\n\n");
     }
 }
+
+bool rfic_command_write(uint16_t addr, uint64_t data)
+{
+    DBG("%s: addr=%02x data=%08" PRIx64 "\n", __FUNCTION__, addr, data);
+    return true;
+}
+
+bool rfic_command_read(uint16_t addr, uint64_t *data)
+{
+    DBG("%s: addr=%02x *data=%08" PRIx64 "\n", __FUNCTION__, addr, *data);
+    return true;
+}
+
 #endif

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_sim.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_sim.c
@@ -73,14 +73,14 @@ void lms6_write(uint8_t addr, uint8_t data)
     ASSERT(data == 0x09);
 }
 
-uint64_t ad9361_spi_read(uint16_t addr) {
+uint64_t adi_spi_read(uint16_t addr) {
     const uint64_t ret = 0x17;
     DBG("%s: addr=0x%04x, returning 0x%04x\n", __FUNCTION__, addr, ret);
     ASSERT(addr == 0x2f2f);
     return ret;
 }
 
-void ad9361_spi_write(uint16_t addr, uint64_t data)
+void adi_spi_write(uint16_t addr, uint64_t data)
 {
     DBG("%s: addr=0x%04x, data=0x%04x\n", __FUNCTION__, addr, data);
     ASSERT(addr == 0x0707);

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/libbladeRF_nios_compat.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/libbladeRF_nios_compat.h
@@ -37,7 +37,9 @@
 #endif
 
 /* libbladeRF code uses a FIELD_INIT macro as an MSVC workaround */
-#define FIELD_INIT(param, val) param = val
+#define FIELD_INIT(param, ...) param = __VA_ARGS__
+
+#define ARRAY_SIZE(n) (sizeof(n) / sizeof(n[0]))
 
 /* For >= 1.5 GHz uses the high band should be used. Otherwise, the low
  * band should be selected */
@@ -50,6 +52,10 @@
 #define log_warning(...) DBG(__VA_ARGS__)
 #define log_error(...)   DBG(__VA_ARGS__)
 #define log_fatal(...)   DBG(__VA_ARGS__)
+
+/* Output formats... "x" is what alt_printf supports */
+#define PRIi64 "x"
+#define PRIu64 "x"
 
 /* NIOS II builds don't need a device handle. Just forward-declare it to avoid
  * complaints from unused functions */
@@ -75,6 +81,9 @@ struct bladerf;
         control_reg_write(data); \
         0; /* "Return" 0 */ \
     })
+
+/* Stub out pthread type */
+typedef void *pthread_cond_t;
 
 #endif
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.c
@@ -34,7 +34,7 @@ static inline bool perform_write(uint8_t id, uint16_t addr, uint64_t data)
 
     switch (id) {
         case NIOS_PKT_16x64_TARGET_AD9361:
-            ad9361_spi_write(addr, data);
+            adi_spi_write(addr, data);
             break;
 
         /* Add user customizations here
@@ -59,7 +59,7 @@ static inline bool perform_read(uint8_t id, uint16_t addr, uint64_t *data)
 
     switch (id) {
         case NIOS_PKT_16x64_TARGET_AD9361:
-            *data = ad9361_spi_read(addr);
+            *data = adi_spi_read(addr);
             break;
 
         /* Add user customizations here

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.c
@@ -46,7 +46,7 @@ static inline bool perform_write(uint8_t id, uint16_t addr, uint64_t data)
         */
 
         default:
-            DBG("Unknown ID: 0x%02x\n", id);
+            DBG("Unknown ID: 0x%x\n", id);
             success = false;
     }
 
@@ -71,7 +71,7 @@ static inline bool perform_read(uint8_t id, uint16_t addr, uint64_t *data)
         */
 
         default:
-            DBG("Invalid ID: 0x%02x\n", id);
+            DBG("Invalid ID: 0x%x\n", id);
             success = false;
 
     }

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.c
@@ -1,7 +1,7 @@
 /* This file is part of the bladeRF project:
  *   http://www.github.com/nuand/bladeRF
  *
- * Copyright (c) 2017 Nuand LLC
+ * Copyright (c) 2017-2018 Nuand LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,9 +33,17 @@ static inline bool perform_write(uint8_t id, uint16_t addr, uint64_t data)
     bool success = true;
 
     switch (id) {
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_16x64_TARGET_AD9361:
             adi_spi_write(addr, data);
             break;
+#endif  // BOARD_BLADERF_MICRO
+
+#ifdef BLADERF_NIOS_LIBAD936X
+        case NIOS_PKT_16x64_TARGET_RFIC:
+            success = rfic_command_write(addr, data);
+            break;
+#endif  // BLADERF_NIOS_LIBAD936X
 
         /* Add user customizations here
 
@@ -58,9 +66,17 @@ static inline bool perform_read(uint8_t id, uint16_t addr, uint64_t *data)
     bool success = true;
 
     switch (id) {
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_16x64_TARGET_AD9361:
             *data = adi_spi_read(addr);
             break;
+#endif  // BOARD_BLADERF_MICRO
+
+#ifdef BLADERF_NIOS_LIBAD936X
+        case NIOS_PKT_16x64_TARGET_RFIC:
+            success = rfic_command_read(addr, data);
+            break;
+#endif  // BLADERF_NIOS_LIBAD936X
 
         /* Add user customizations here
 
@@ -96,4 +112,18 @@ void pkt_16x64(struct pkt_buf *b)
     }
 
     nios_pkt_16x64_resp_pack(b->resp, id, is_write, addr, data, success);
+}
+
+void pkt_16x64_init(void)
+{
+#ifdef BLADERF_NIOS_LIBAD936X
+    rfic_command_init();
+#endif  // BLADERF_NIOS_LIBAD936X
+}
+
+void pkt_16x64_work(void)
+{
+#ifdef BLADERF_NIOS_LIBAD936X
+    rfic_command_work();
+#endif  // BLADERF_NIOS_LIBAD936X
 }

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_16x64.h
@@ -28,7 +28,22 @@
 #include "pkt_handler.h"
 #include "nios_pkt_16x64.h"
 
+void pkt_16x64_init(void);
+
 void pkt_16x64(struct pkt_buf *b);
+
+void pkt_16x64_work(void);
+
+#ifdef BLADERF_NIOS_LIBAD936X
+
+#define PKT_16x64 { \
+    .magic          = NIOS_PKT_16x64_MAGIC, \
+    .init           = pkt_16x64_init, \
+    .exec           = pkt_16x64, \
+    .do_work        = pkt_16x64_work, \
+}
+
+#else
 
 #define PKT_16x64 { \
     .magic          = NIOS_PKT_16x64_MAGIC, \
@@ -37,4 +52,5 @@ void pkt_16x64(struct pkt_buf *b);
     .do_work        = NULL, \
 }
 
+#endif  // BLADERF_NIOS_LIBAD936X
 #endif

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_32x32.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_32x32.c
@@ -55,9 +55,11 @@ static inline bool perform_write(uint8_t id, uint32_t addr, uint32_t data)
             }
             break;
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_32x32_TARGET_ADI_AXI:
             adi_axi_write(addr, data);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
         /* Add user customizations here
 
@@ -87,9 +89,11 @@ static inline bool perform_read(uint8_t id, uint32_t addr, uint32_t *data)
             *data = expansion_port_get_direction() & addr;
             break;
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_32x32_TARGET_ADI_AXI:
             *data = adi_axi_read(addr);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
         /* Add user customizations here
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_32x32.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_32x32.c
@@ -68,7 +68,7 @@ static inline bool perform_write(uint8_t id, uint32_t addr, uint32_t data)
         */
 
         default:
-            DBG("Invalid ID: 0x%02x\n", id);
+            DBG("Invalid ID: 0x%x\n", id);
             return false;
     }
 
@@ -100,7 +100,7 @@ static inline bool perform_read(uint8_t id, uint32_t addr, uint32_t *data)
         */
 
         default:
-            DBG("Invalid ID: 0x%02x\n", id);
+            DBG("Invalid ID: 0x%x\n", id);
             return false;
     }
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x16.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x16.c
@@ -48,7 +48,7 @@ static inline bool iq_corr_read(uint8_t addr, uint16_t *data)
             break;
 
         default:
-            DBG("%s: Invalid IQ corr addr: 0x%02x\n", __FUNCTION__, addr);
+            DBG("%s: Invalid IQ corr addr: 0x%x\n", __FUNCTION__, addr);
             return false;
     }
 
@@ -75,7 +75,7 @@ static inline bool iq_corr_write(uint8_t addr, uint16_t data)
             break;
 
         default:
-            DBG("%s: Invalid IQ corr addr: 0x%02x\n", __FUNCTION__, addr);
+            DBG("%s: Invalid IQ corr addr: 0x%x\n", __FUNCTION__, addr);
             return false;
     }
 
@@ -112,7 +112,7 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint16_t *data)
         */
 
         default:
-            DBG("%s: Invalid ID: 0x%02x\n", __FUNCTION__, id);
+            DBG("%s: Invalid ID: 0x%x\n", __FUNCTION__, id);
             return false;
     }
 
@@ -152,7 +152,7 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint16_t data)
         */
 
         default:
-            DBG("%s: Invalid ID: 0x%02x\n", __FUNCTION__, id);
+            DBG("%s: Invalid ID: 0x%x\n", __FUNCTION__, id);
             return false;
     }
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x16.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x16.c
@@ -95,13 +95,17 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint16_t *data)
             iq_corr_read(addr, data);
             break;
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x16_TARGET_AD56X1_DAC:
             ad56x1_vctcxo_trim_dac_read(data);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x16_TARGET_INA219:
             *data = ina219_read(addr);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
         /* Add user customizations here
 
@@ -135,13 +139,17 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint16_t data)
             agc_dc_corr_write(addr, data);
             break;
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x16_TARGET_AD56X1_DAC:
             ad56x1_vctcxo_trim_dac_write(data);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x16_TARGET_INA219:
             ina219_write(addr, data);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
         /* Add user customizations here
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x32.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x32.c
@@ -49,14 +49,18 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint32_t *data)
             *data = rffe_csr_read();
             break;
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x32_TARGET_ADF400X:
             *data = adf400x_spi_read(addr);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x32_TARGET_FASTLOCK:
             DBG("Read from AD9361 fast lock not supported.\n");
             *data = 0x00;
             return false;
+#endif  // BOARD_BLADERF_MICRO
 
         default:
             DBG("Invalid id: 0x%x\n", id);
@@ -86,13 +90,17 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint32_t data)
             rffe_csr_write(data);
             break;
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x32_TARGET_ADF400X:
             adf400x_spi_write(data);
             break;
+#endif  // BOARD_BLADERF_MICRO
 
+#ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x32_TARGET_FASTLOCK:
             ad9361_fastlock_save( (addr == 1), (data >> 16), (data & 0xff));
             break;
+#endif  // BOARD_BLADERF_MICRO
 
         default:
             DBG("Invalid id: 0x%x\n", id);

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x32.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x32.c
@@ -98,7 +98,7 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint32_t data)
 
 #ifdef BOARD_BLADERF_MICRO
         case NIOS_PKT_8x32_TARGET_FASTLOCK:
-            ad9361_fastlock_save( (addr == 1), (data >> 16), (data & 0xff));
+            adi_fastlock_save( (addr == 1), (data >> 16), (data & 0xff));
             break;
 #endif  // BOARD_BLADERF_MICRO
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x32.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x32.c
@@ -59,7 +59,7 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint32_t *data)
             return false;
 
         default:
-            DBG("Invalid id: 0x%02x\n", id);
+            DBG("Invalid id: 0x%x\n", id);
             *data = 0x00;
             return false;
     }
@@ -95,7 +95,7 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint32_t data)
             break;
 
         default:
-            DBG("Invalid id: 0x%02x\n", id);
+            DBG("Invalid id: 0x%x\n", id);
             return false;
     }
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x64.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x64.c
@@ -32,7 +32,7 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint64_t data)
 {
     switch (id) {
         case NIOS_PKT_8x64_TARGET_TIMESTAMP:
-            DBG("Invalid write acess to timestamp: 0x%02x\n", addr);
+            DBG("Invalid write access to timestamp: 0x%x\n", addr);
             return false;
 
         /* Add user customizations here
@@ -44,7 +44,7 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint64_t data)
         */
 
         default:
-            DBG("Unknown ID: 0x%02x\n", id);
+            DBG("Unknown ID: 0x%x\n", id);
             return false;
     }
 }
@@ -61,7 +61,7 @@ static inline bool read_timestamp(uint8_t addr, uint64_t *data)
             break;
 
         default:
-            DBG("Invalid addr: 0x%02x\n", addr);
+            DBG("Invalid addr: 0x%x\n", addr);
             return false;
     }
 
@@ -86,7 +86,7 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint64_t *data)
         */
 
         default:
-            DBG("Invalid ID: 0x%02x\n", id);
+            DBG("Invalid ID: 0x%x\n", id);
             success = false;
 
     }

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x8.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_8x8.c
@@ -69,7 +69,7 @@ static inline bool perform_read(uint8_t id, uint8_t addr, uint8_t *data)
         */
 
         default:
-            DBG("%s: Invalid ID: 0x%02x\n", __FUNCTION__, id);
+            DBG("%s: Invalid ID: 0x%x\n", __FUNCTION__, id);
             *data = 0xff;
             return false;
     }
@@ -119,7 +119,7 @@ static inline bool perform_write(uint8_t id, uint8_t addr, uint8_t data)
         */
 
         default:
-            DBG("%s: Invalid ID: 0x%02x\n", __FUNCTION__, id);
+            DBG("%s: Invalid ID: 0x%x\n", __FUNCTION__, id);
             return false;
     }
 

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_legacy.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_legacy.c
@@ -33,6 +33,12 @@
 #define ADDR_IDX    PAYLOAD_IDX
 #define DATA_IDX    (ADDR_IDX + 1)
 
+/* Omit debug output from this file. */
+#ifdef BLADERF_NIOS_DEBUG
+#undef DBG
+#define DBG(...)
+#endif
+
 /**
  * Configuration options
  *
@@ -110,12 +116,12 @@ static inline enum config_param lookup_param(uint8_t addr)
 {
     uint8_t i;
 
-    DBG("Perip lookup for addr=%d\n", addr);
+    DBG("Perip lookup for addr=0x%x\n", addr);
 
     for (i = 0; i < ARRAY_SIZE(config_params); i++) {
         if (config_params[i].start <= addr &&
             (config_params[i].start + config_params[i].len) > addr) {
-            DBG("Found match at entry %d\n", i);
+            DBG("Found match at entry 0x%x\n", i);
             return (enum config_param) i;
         }
     }
@@ -192,7 +198,7 @@ static uint64_t perform_config_read(enum config_param param)
             break;
 
         default:
-            DBG("Invalid config read parameter: %u\n", param);
+            DBG("Invalid config read parameter: 0x%x\n", param);
             payload = (uint64_t) -1;
     }
 
@@ -226,7 +232,7 @@ static inline void legacy_config_read(uint8_t count, struct pkt_buf *b)
          * that we got a different request while in the middle of the previous
          * series of accesses. */
         if (n == 0 || (param != last_param)) {
-            DBG("Resetting read state for param=%d with n=%d\n", param, n);
+            DBG("Resetting read state for param=0x%x with n=0x%x\n", param, n);
             n = 0;
             payload = perform_config_read(param);
             last_param = param;
@@ -274,7 +280,7 @@ static inline void legacy_pkt_read(uint8_t dev_id, uint8_t count,
             break;
 
         default:
-            DBG("Got invalid device ID: 0x%04x\n", dev_id);
+            DBG("Got invalid device ID: 0x%x\n", dev_id);
             break;
     }
 }
@@ -338,7 +344,7 @@ static inline void perform_config_write(enum config_param p, uint64_t payload)
             break;
 
         default:
-            DBG("Invalid config param write: %u\n", p);
+            DBG("Invalid config param write: 0x%x\n", p);
             break;
     }
 }
@@ -369,7 +375,7 @@ static inline void legacy_config_write(uint8_t count, struct pkt_buf *b)
      * that we got a different request while in the middle of the previous
      * series of accesses. */
     if (n == 0 || (param != last_param)) {
-        DBG("Resetting write state for param=%d with n=%d\n", param, n);
+        DBG("Resetting write state for param=0x%x with n=0x%x\n", param, n);
         payload = 0;
         n = 0;
     }
@@ -421,7 +427,7 @@ static inline void legacy_pkt_write(uint8_t dev_id, uint8_t count,
             break;
 
         default:
-            DBG("Got invalid device ID: 0x%04x\n", dev_id);
+            DBG("Got invalid device ID: 0x%x\n", dev_id);
             break;
     }
 }
@@ -439,7 +445,7 @@ void pkt_legacy(struct pkt_buf *b)
     b->resp[PKT_MAGIC_IDX] = b->req[PKT_MAGIC_IDX];
     b->resp[PKT_CFG_IDX]   = b->req[PKT_CFG_IDX];
 
-    DBG("%s: read=%s, write=%s, dev_id=0x%x, cfg=%x, count=%d\n", __FUNCTION__,
+    DBG("%s: read=%s, write=%s, dev_id=0x%x, cfg=0x%x, count=0x%x\n", __FUNCTION__,
         is_read ? "true" : "false", is_write ? "true" : "false", dev_id, cfg, count);
 
     if (is_read) {

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_retune2.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_retune2.c
@@ -29,6 +29,10 @@
 #include "devices.h"
 #include "debug.h"
 
+#ifdef BLADERF_NIOS_LIBAD936X
+void rfic_invalidate_frequency(bladerf_module module);
+#endif  // BLADERF_NIOS_LIBAD936X
+
 #ifdef BLADERF_NIOS_DEBUG
     volatile uint32_t pkt_retune2_error_count = 0;
 #   define INCREMENT_ERROR_COUNT() do { pkt_retune2_error_count++; } while (0)
@@ -199,6 +203,11 @@ static inline void profile_activate(bladerf_module module, fastlock_profile *p)
     if (p == NULL) {
         return;
     }
+
+#ifdef BLADERF_NIOS_LIBAD936X
+    /* Invalidate current frequency knowledge */
+    rfic_invalidate_frequency(module);
+#endif  // BLADERF_NIOS_LIBAD936X
 
     /* Activate the RFFE fast lock profile */
     adi_fastlock_recall(module, p);

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_retune2.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/pkt_retune2.c
@@ -161,7 +161,7 @@ static inline void profile_load(bladerf_module module, fastlock_profile *p)
         return;
     }
 
-    ad9361_fastlock_load(module, p);
+    adi_fastlock_load(module, p);
 }
 
 static inline void profile_load_scheduled(struct queue *q,
@@ -201,13 +201,13 @@ static inline void profile_activate(bladerf_module module, fastlock_profile *p)
     }
 
     /* Activate the RFFE fast lock profile */
-    ad9361_fastlock_recall(module, p);
+    adi_fastlock_recall(module, p);
 
     /* Adjust the RFFE port */
-    ad9361_rfport_select(p);
+    adi_rfport_select(p);
 
     /* Adjust the RF switches */
-    ad9361_rfspdt_select(module, p);
+    adi_rfspdt_select(module, p);
 }
 
 static inline void retune_isr(struct queue *q)

--- a/host/common/src/range.c
+++ b/host/common/src/range.c
@@ -19,6 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef BLADERF_NIOS_BUILD
+#include "devices.h"
+#endif  // BLADERF_NIOS_BUILD
+
+/* Avoid building this in low-memory situations */
+#if !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
+
 #include "range.h"
 
 #if !defined(BLADERF_NIOS_BUILD) && !defined(BLADERF_NIOS_PC_SIMULATION)
@@ -63,3 +70,5 @@ int64_t clamp_to_range(struct bladerf_range const *range, int64_t value)
 
     return value;
 }
+
+#endif  // !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/adc_core.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/adc_core.c
@@ -1,0 +1,264 @@
+/*******************************************************************************
+ *   @file   adc_core.c
+ *   @brief  Implementation of ADC Core Driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+ *******************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+
+#include "adc_core.h"
+#include "platform.h"
+#include "util.h"
+
+/*******************************************************************************
+ * @brief adc_read
+ ******************************************************************************/
+int adc_read(struct ad9361_rf_phy *phy, uint32_t regAddr, uint32_t *data)
+{
+    return axiadc_read(phy->adc_state, regAddr, data);
+}
+
+/*******************************************************************************
+ * @brief adc_write
+ ******************************************************************************/
+int adc_write(struct ad9361_rf_phy *phy, uint32_t regAddr, uint32_t data)
+{
+    return axiadc_write(phy->adc_state, regAddr, data);
+}
+
+/*******************************************************************************
+ * @brief adc_init
+ ******************************************************************************/
+int adc_init(struct ad9361_rf_phy *phy)
+{
+    int ret;
+
+    ret = adc_write(phy, ADC_REG_RSTN, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = adc_write(phy, ADC_REG_RSTN, ADC_RSTN);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = adc_write(phy, ADC_REG_CHAN_CNTRL(0),
+                    ADC_IQCOR_ENB | ADC_FORMAT_SIGNEXT | ADC_FORMAT_ENABLE |
+                        ADC_ENABLE);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = adc_write(phy, ADC_REG_CHAN_CNTRL(1),
+                    ADC_IQCOR_ENB | ADC_FORMAT_SIGNEXT | ADC_FORMAT_ENABLE |
+                        ADC_ENABLE);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (phy->pdata->rx2tx2) {
+        ret = adc_write(phy, ADC_REG_CHAN_CNTRL(2),
+                        ADC_IQCOR_ENB | ADC_FORMAT_SIGNEXT | ADC_FORMAT_ENABLE |
+                            ADC_ENABLE);
+        if (ret < 0) {
+            return ret;
+        }
+
+        ret = adc_write(phy, ADC_REG_CHAN_CNTRL(3),
+                        ADC_IQCOR_ENB | ADC_FORMAT_SIGNEXT | ADC_FORMAT_ENABLE |
+                            ADC_ENABLE);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief adc_set_calib_scale_phase
+ ******************************************************************************/
+int32_t adc_set_calib_scale_phase(struct ad9361_rf_phy *phy,
+                                  uint32_t phase,
+                                  uint32_t chan,
+                                  int32_t val,
+                                  int32_t val2)
+{
+    int ret;
+    uint32_t fract;
+    uint64_t llval;
+    uint32_t tmp;
+
+    switch (val) {
+        case 1:
+            fract = 0x4000;
+            break;
+        case -1:
+            fract = 0xC000;
+            break;
+        case 0:
+            fract = 0;
+            if (val2 < 0) {
+                fract = 0x8000;
+                val2 *= -1;
+            }
+            break;
+        default:
+            return -1;
+    }
+
+    llval = (uint64_t)val2 * 0x4000UL + (1000000UL / 2);
+    do_div(&llval, 1000000UL);
+    fract |= llval;
+
+    ret = adc_read(phy, ADC_REG_CHAN_CNTRL_2(chan), &tmp);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (!((chan + phase) % 2)) {
+        tmp &= ~ADC_IQCOR_COEFF_1(~0);
+        tmp |= ADC_IQCOR_COEFF_1(fract);
+    } else {
+        tmp &= ~ADC_IQCOR_COEFF_2(~0);
+        tmp |= ADC_IQCOR_COEFF_2(fract);
+    }
+
+    ret = adc_write(phy, ADC_REG_CHAN_CNTRL_2(chan), tmp);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief adc_get_calib_scale_phase
+ ******************************************************************************/
+int32_t adc_get_calib_scale_phase(struct ad9361_rf_phy *phy,
+                                  uint32_t phase,
+                                  uint32_t chan,
+                                  int32_t *val,
+                                  int32_t *val2)
+{
+    int ret;
+    uint32_t tmp;
+    int32_t sign;
+    uint64_t llval;
+
+    ret = adc_read(phy, ADC_REG_CHAN_CNTRL_2(chan), &tmp);
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* format is 1.1.14 (sign, integer and fractional bits) */
+
+    if (!((phase + chan) % 2)) {
+        tmp = ADC_TO_IQCOR_COEFF_1(tmp);
+    } else {
+        tmp = ADC_TO_IQCOR_COEFF_2(tmp);
+    }
+
+    if (tmp & 0x8000)
+        sign = -1;
+    else
+        sign = 1;
+
+    if (tmp & 0x4000)
+        *val = 1 * sign;
+    else
+        *val = 0;
+
+    tmp &= ~0xC000;
+
+    llval = tmp * 1000000ULL + (0x4000 / 2);
+    do_div(&llval, 0x4000);
+    if (*val == 0)
+        *val2 = (int32_t)llval * sign;
+    else
+        *val2 = (int32_t)llval;
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief adc_set_calib_scale
+ ******************************************************************************/
+int32_t adc_set_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2)
+{
+    return adc_set_calib_scale_phase(phy, 0, chan, val, val2);
+}
+
+/*******************************************************************************
+ * @brief adc_get_calib_scale
+ ******************************************************************************/
+int32_t adc_get_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2)
+{
+    return adc_get_calib_scale_phase(phy, 0, chan, val, val2);
+}
+
+/*******************************************************************************
+ * @brief adc_set_calib_phase
+ ******************************************************************************/
+int32_t adc_set_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2)
+{
+    return adc_set_calib_scale_phase(phy, 1, chan, val, val2);
+}
+
+/*******************************************************************************
+ * @brief adc_get_calib_phase
+ ******************************************************************************/
+int32_t adc_get_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2)
+{
+    return adc_get_calib_scale_phase(phy, 1, chan, val, val2);
+}

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/adc_core.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/adc_core.h
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ *   @file   adc_core.h
+ *   @brief  Header file of ADC Core Driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+ *******************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef ADC_CORE_API_H_
+#define ADC_CORE_API_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "ad9361.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+/* ADC COMMON */
+#define ADC_REG_RSTN 0x0040
+#define ADC_RSTN (1 << 0)
+#define ADC_MMCM_RSTN (1 << 1)
+
+#define ADC_REG_CNTRL 0x0044
+#define ADC_R1_MODE (1 << 2)
+#define ADC_DDR_EDGESEL (1 << 1)
+#define ADC_PIN_MODE (1 << 0)
+
+#define ADC_REG_STATUS 0x005C
+#define ADC_MUX_PN_ERR (1 << 3)
+#define ADC_MUX_PN_OOS (1 << 2)
+#define ADC_MUX_OVER_RANGE (1 << 1)
+#define ADC_STATUS (1 << 0)
+
+#define ADC_REG_DMA_CNTRL 0x0080
+#define ADC_DMA_STREAM (1 << 1)
+#define ADC_DMA_START (1 << 0)
+
+#define ADC_REG_DMA_COUNT 0x0084
+#define ADC_DMA_COUNT(x) (((x)&0xFFFFFFFF) << 0)
+#define ADC_TO_DMA_COUNT(x) (((x) >> 0) & 0xFFFFFFFF)
+
+#define ADC_REG_DMA_STATUS 0x0088
+#define ADC_DMA_OVF (1 << 2)
+#define ADC_DMA_UNF (1 << 1)
+#define ADC_DMA_STATUS (1 << 0)
+
+#define ADC_REG_DMA_BUSWIDTH 0x008C
+#define ADC_DMA_BUSWIDTH(x) (((x)&0xFFFFFFFF) << 0)
+#define ADC_TO_DMA_BUSWIDTH(x) (((x) >> 0) & 0xFFFFFFFF)
+
+/* ADC CHANNEL */
+#define ADC_REG_CHAN_CNTRL(c) (0x0400 + (c)*0x40)
+#define ADC_LB_EN (1 << 11)
+#define ADC_PN_SEL (1 << 10)
+#define ADC_IQCOR_ENB (1 << 9)
+#define ADC_DCFILT_ENB (1 << 8)
+#define ADC_FORMAT_SIGNEXT (1 << 6)
+#define ADC_FORMAT_TYPE (1 << 5)
+#define ADC_FORMAT_ENABLE (1 << 4)
+#define ADC_PN23_TYPE (1 << 1)
+#define ADC_ENABLE (1 << 0)
+
+#define ADC_REG_CHAN_STATUS(c) (0x0404 + (c)*0x40)
+#define ADC_PN_ERR (1 << 2)
+#define ADC_PN_OOS (1 << 1)
+#define ADC_OVER_RANGE (1 << 0)
+
+#define ADC_REG_CHAN_CNTRL_1(c) (0x0410 + (c)*0x40)
+#define ADC_DCFILT_OFFSET(x) (((x)&0xFFFF) << 16)
+#define ADC_TO_DCFILT_OFFSET(x) (((x) >> 16) & 0xFFFF)
+#define ADC_DCFILT_COEFF(x) (((x)&0xFFFF) << 0)
+#define ADC_TO_DCFILT_COEFF(x) (((x) >> 0) & 0xFFFF)
+
+#define ADC_REG_CHAN_CNTRL_2(c) (0x0414 + (c)*0x40)
+#define ADC_IQCOR_COEFF_1(x) (((x)&0xFFFF) << 16)
+#define ADC_TO_IQCOR_COEFF_1(x) (((x) >> 16) & 0xFFFF)
+#define ADC_IQCOR_COEFF_2(x) (((x)&0xFFFF) << 0)
+#define ADC_TO_IQCOR_COEFF_2(x) (((x) >> 0) & 0xFFFF)
+
+#define ADC_REG_CHAN_CNTRL_3(c) (0x0418 + (c)*0x40) /* v8.0 */
+#define ADC_ADC_PN_SEL(x) (((x)&0xF) << 16)
+#define ADC_TO_ADC_PN_SEL(x) (((x) >> 16) & 0xF)
+#define ADC_ADC_DATA_SEL(x) (((x)&0xF) << 0)
+#define ADC_TO_ADC_DATA_SEL(x) (((x) >> 0) & 0xF)
+
+#define AXI_DMAC_REG_IRQ_MASK 0x80
+#define AXI_DMAC_REG_IRQ_PENDING 0x84
+#define AXI_DMAC_REG_IRQ_SOURCE 0x88
+
+#define AXI_DMAC_REG_CTRL 0x400
+#define AXI_DMAC_REG_TRANSFER_ID 0x404
+#define AXI_DMAC_REG_START_TRANSFER 0x408
+#define AXI_DMAC_REG_FLAGS 0x40c
+#define AXI_DMAC_REG_DEST_ADDRESS 0x410
+#define AXI_DMAC_REG_SRC_ADDRESS 0x414
+#define AXI_DMAC_REG_X_LENGTH 0x418
+#define AXI_DMAC_REG_Y_LENGTH 0x41c
+#define AXI_DMAC_REG_DEST_STRIDE 0x420
+#define AXI_DMAC_REG_SRC_STRIDE 0x424
+#define AXI_DMAC_REG_TRANSFER_DONE 0x428
+#define AXI_DMAC_REG_ACTIVE_TRANSFER_ID 0x42c
+#define AXI_DMAC_REG_STATUS 0x430
+#define AXI_DMAC_REG_CURRENT_DEST_ADDR 0x434
+#define AXI_DMAC_REG_CURRENT_SRC_ADDR 0x438
+#define AXI_DMAC_REG_DBG0 0x43c
+#define AXI_DMAC_REG_DBG1 0x440
+
+#define AXI_DMAC_CTRL_ENABLE (1 << 0)
+#define AXI_DMAC_CTRL_PAUSE (1 << 1)
+
+#define AXI_DMAC_IRQ_SOT (1 << 0)
+#define AXI_DMAC_IRQ_EOT (1 << 1)
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int adc_init(struct ad9361_rf_phy *phy);
+int adc_read(struct ad9361_rf_phy *phy, uint32_t regAddr, uint32_t *data);
+int adc_write(struct ad9361_rf_phy *phy, uint32_t regAddr, uint32_t data);
+int32_t adc_set_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2);
+int32_t adc_get_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2);
+int32_t adc_set_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2);
+int32_t adc_get_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2);
+#endif

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/config.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/config.h
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *   @file   config.h
+ *   @brief  Config file of AD9361/API Driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+ *******************************************************************************
+ * Copyright 2015(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef CONFIG_H_
+#define CONFIG_H_
+
+/* Recommended during development prints errors and warnings */
+//#define HAVE_VERBOSE_MESSAGES
+
+/* For Debug purposes only */
+//#define HAVE_DEBUG_MESSAGES
+
+/*
+ * In case memory footprint is a concern these options allow
+ * to disable unused functionality which may free up a few kb
+ *
+ * only set to 0 in case split_gain_table_mode_enable = 0
+ */
+
+#define HAVE_SPLIT_GAIN_TABLE 0
+#define HAVE_TDD_SYNTH_TABLE 0
+
+#define AD9361_DEVICE 1  /* set it 1 if AD9361 device is used, 0 otherwise */
+#define AD9364_DEVICE 0  /* set it 1 if AD9364 device is used, 0 otherwise */
+#define AD9363A_DEVICE 0 /* set it 1 if AD9363A device is used, 0 otherwise */
+
+//#define CONSOLE_COMMANDS
+//#define XILINX_PLATFORM
+//#define ALTERA_PLATFORM
+//#define FMCOMMS5
+//#define PICOZED_SDR
+//#define PICOZED_SDR_CMOS
+//#define CAPTURE_SCRIPT
+//#define AXI_ADC_NOT_PRESENT
+//#define TDD_SWITCH_STATE_EXAMPLE
+
+#endif

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/dac_core.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/dac_core.c
@@ -1,0 +1,710 @@
+/*******************************************************************************
+ *   @file   dac_core.c
+ *   @brief  Implementation of DAC Core Driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+ *******************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+
+#include "dac_core.h"
+#include "platform.h"
+#include "util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+const uint16_t sine_lut[32] = { 0x000, 0x031, 0x061, 0x08D, 0x0B4, 0x0D4, 0x0EC,
+                                0x0FA, 0x0FF, 0x0FA, 0x0EC, 0x0D4, 0x0B4, 0x08D,
+                                0x061, 0x031, 0x000, 0xFCE, 0xF9E, 0xF72, 0xF4B,
+                                0xF2B, 0xF13, 0xF05, 0xF00, 0xF05, 0xF13, 0xF2B,
+                                0xF4B, 0xF72, 0xF9E, 0xFCE };
+
+/*******************************************************************************
+ * @brief dac_read
+ ******************************************************************************/
+int dac_read(struct ad9361_rf_phy *phy, uint32_t regAddr, uint32_t *data)
+{
+    return axiadc_read(phy->adc_state, regAddr + 0x4000, data);
+}
+
+/*******************************************************************************
+ * @brief dac_write
+ ******************************************************************************/
+int dac_write(struct ad9361_rf_phy *phy, uint32_t regAddr, uint32_t data)
+{
+    return axiadc_write(phy->adc_state, regAddr + 0x4000, data);
+}
+
+/*******************************************************************************
+ * @brief dds_default_setup
+ ******************************************************************************/
+static int dds_default_setup(struct ad9361_rf_phy *phy,
+                             uint32_t chan,
+                             uint32_t phase,
+                             uint32_t freq,
+                             int32_t scale)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+
+    ret = dds_set_phase(phy, chan, phase);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dds_set_frequency(phy, chan, freq);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dds_set_scale(phy, chan, scale);
+    if (ret < 0) {
+        return ret;
+    }
+
+    dds_st->cached_freq[chan]  = freq;
+    dds_st->cached_phase[chan] = phase;
+    dds_st->cached_scale[chan] = scale;
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dac_stop
+ ******************************************************************************/
+int dac_stop(struct ad9361_rf_phy *phy)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+
+    if (PCORE_VERSION_MAJOR(dds_st->pcore_version) < 8) {
+        return dac_write(phy, DAC_REG_CNTRL_1, 0);
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dac_start_sync
+ ******************************************************************************/
+int dac_start_sync(struct ad9361_rf_phy *phy, bool force_on)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+
+    if (PCORE_VERSION_MAJOR(dds_st->pcore_version) < 8) {
+        return dac_write(phy, DAC_REG_CNTRL_1,
+                         (dds_st->enable || force_on) ? DAC_ENABLE : 0);
+    } else {
+        return dac_write(phy, DAC_REG_CNTRL_1, DAC_SYNC);
+    }
+}
+
+/*******************************************************************************
+ * @brief dac_init
+ ******************************************************************************/
+int dac_init(struct ad9361_rf_phy *phy, uint8_t data_sel, uint8_t config_dma)
+{
+    struct dds_state *dds_st;
+    int ret;
+    uint32_t reg_ctrl_2;
+
+    dds_st = &phy->adc_state->dac_dds_state;
+
+    ret = dac_write(phy, DAC_REG_RSTN, 0x0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_write(phy, DAC_REG_RSTN, DAC_RSTN);
+    if (ret < 0) {
+        return ret;
+    }
+
+    dds_st->dac_clk = &phy->clks[TX_SAMPL_CLK]->rate;
+    dds_st->rx2tx2  = phy->pdata->rx2tx2;
+
+    ret = dac_read(phy, DAC_REG_CNTRL_2, &reg_ctrl_2);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (dds_st->rx2tx2) {
+        dds_st->num_dds_channels = 8;
+
+        if (phy->pdata->port_ctrl.pp_conf[2] & LVDS_MODE)
+            ret = dac_write(phy, DAC_REG_RATECNTRL, DAC_RATE(3));
+        else
+            ret = dac_write(phy, DAC_REG_RATECNTRL, DAC_RATE(1));
+
+        if (ret < 0) {
+            return ret;
+        }
+
+        reg_ctrl_2 &= ~DAC_R1_MODE;
+    } else {
+        dds_st->num_dds_channels = 4;
+
+        if (phy->pdata->port_ctrl.pp_conf[2] & LVDS_MODE)
+            ret = dac_write(phy, DAC_REG_RATECNTRL, DAC_RATE(1));
+        else
+            ret = dac_write(phy, DAC_REG_RATECNTRL, DAC_RATE(0));
+
+        if (ret < 0) {
+            return ret;
+        }
+
+        reg_ctrl_2 |= DAC_R1_MODE;
+    }
+
+    ret = dac_write(phy, DAC_REG_CNTRL_2, reg_ctrl_2);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_read(phy, DAC_REG_VERSION, &dds_st->pcore_version);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_write(phy, DAC_REG_CNTRL_1, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    switch (data_sel) {
+        case DATA_SEL_DDS:
+            ret = dds_default_setup(phy, DDS_CHAN_TX1_I_F1, 90000, 1000000,
+                                    250000);
+            if (ret < 0) {
+                return ret;
+            }
+
+            ret = dds_default_setup(phy, DDS_CHAN_TX1_I_F2, 90000, 1000000,
+                                    250000);
+            if (ret < 0) {
+                return ret;
+            }
+
+            ret = dds_default_setup(phy, DDS_CHAN_TX1_Q_F1, 0, 1000000, 250000);
+            if (ret < 0) {
+                return ret;
+            }
+
+            ret = dds_default_setup(phy, DDS_CHAN_TX1_Q_F2, 0, 1000000, 250000);
+            if (ret < 0) {
+                return ret;
+            }
+
+            if (dds_st->rx2tx2) {
+                ret = dds_default_setup(phy, DDS_CHAN_TX2_I_F1, 90000, 1000000,
+                                        250000);
+                if (ret < 0) {
+                    return ret;
+                }
+
+                ret = dds_default_setup(phy, DDS_CHAN_TX2_I_F2, 90000, 1000000,
+                                        250000);
+                if (ret < 0) {
+                    return ret;
+                }
+
+                ret = dds_default_setup(phy, DDS_CHAN_TX2_Q_F1, 0, 1000000,
+                                        250000);
+                if (ret < 0) {
+                    return ret;
+                }
+
+                ret = dds_default_setup(phy, DDS_CHAN_TX2_Q_F2, 0, 1000000,
+                                        250000);
+                if (ret < 0) {
+                    return ret;
+                }
+            }
+
+            ret = dac_datasel(phy, -1, DATA_SEL_DDS);
+            if (ret < 0) {
+                return ret;
+            }
+
+            break;
+        case DATA_SEL_DMA:
+            ret = dac_datasel(phy, -1, DATA_SEL_DMA);
+            if (ret < 0) {
+                return ret;
+            }
+            break;
+        default:
+            break;
+    }
+
+    dds_st->enable = true;
+
+    ret = dac_start_sync(phy, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_set_frequency
+ ******************************************************************************/
+int dds_set_frequency(struct ad9361_rf_phy *phy, uint32_t chan, uint32_t freq)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+    uint64_t val64;
+    uint32_t reg;
+
+    dds_st->cached_freq[chan] = freq;
+
+    ret = dac_stop(phy);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_read(phy, DAC_REG_CHAN_CNTRL_2_IIOCHAN(chan), &reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    reg &= ~DAC_DDS_INCR(~0);
+    val64 = (uint64_t)freq * 0xFFFFULL;
+    do_div(&val64, *dds_st->dac_clk);
+    reg |= DAC_DDS_INCR(val64) | 1;
+
+    ret = dac_write(phy, DAC_REG_CHAN_CNTRL_2_IIOCHAN(chan), reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_start_sync(phy, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_set_phase
+ ******************************************************************************/
+int dds_set_phase(struct ad9361_rf_phy *phy, uint32_t chan, uint32_t phase)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+    uint64_t val64;
+    uint32_t reg;
+
+    dds_st->cached_phase[chan] = phase;
+
+    ret = dac_stop(phy);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_read(phy, DAC_REG_CHAN_CNTRL_2_IIOCHAN(chan), &reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    reg &= ~DAC_DDS_INIT(~0);
+    val64 = (uint64_t)phase * 0x10000ULL + (360000 / 2);
+    do_div(&val64, 360000);
+    reg |= DAC_DDS_INIT(val64);
+
+    ret = dac_write(phy, DAC_REG_CHAN_CNTRL_2_IIOCHAN(chan), reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_start_sync(phy, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_set_phase
+ ******************************************************************************/
+int dds_set_scale(struct ad9361_rf_phy *phy,
+                  uint32_t chan,
+                  int32_t scale_micro_units)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+    uint32_t scale_reg;
+    uint32_t sign_part;
+    uint32_t int_part;
+    uint32_t fract_part;
+
+    if (PCORE_VERSION_MAJOR(dds_st->pcore_version) > 6) {
+        if (scale_micro_units >= 1000000) {
+            sign_part                  = 0;
+            int_part                   = 1;
+            fract_part                 = 0;
+            dds_st->cached_scale[chan] = 1000000;
+            goto set_scale_reg;
+        }
+        if (scale_micro_units <= -1000000) {
+            sign_part                  = 1;
+            int_part                   = 1;
+            fract_part                 = 0;
+            dds_st->cached_scale[chan] = -1000000;
+            goto set_scale_reg;
+        }
+        dds_st->cached_scale[chan] = scale_micro_units;
+        if (scale_micro_units < 0) {
+            sign_part = 1;
+            int_part  = 0;
+            scale_micro_units *= -1;
+        } else {
+            sign_part = 0;
+            int_part  = 0;
+        }
+        fract_part =
+            (uint32_t)(((uint64_t)scale_micro_units * 0x4000) / 1000000);
+    set_scale_reg:
+        scale_reg = (sign_part << 15) | (int_part << 14) | fract_part;
+    } else {
+        if (scale_micro_units >= 1000000) {
+            scale_reg         = 0;
+            scale_micro_units = 1000000;
+        }
+        if (scale_micro_units <= 0) {
+            scale_reg         = 0;
+            scale_micro_units = 0;
+        }
+        dds_st->cached_scale[chan] = scale_micro_units;
+        fract_part                 = (uint32_t)(scale_micro_units);
+        scale_reg                  = 500000 / fract_part;
+    }
+
+    ret = dac_stop(phy);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_write(phy, DAC_REG_CHAN_CNTRL_1_IIOCHAN(chan),
+                    DAC_DDS_SCALE(scale_reg));
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_start_sync(phy, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_update
+ ******************************************************************************/
+int dds_update(struct ad9361_rf_phy *phy)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+    uint32_t chan;
+
+    for (chan = DDS_CHAN_TX1_I_F1; chan <= DDS_CHAN_TX2_Q_F2; chan++) {
+        ret = dds_set_frequency(phy, chan, dds_st->cached_freq[chan]);
+        if (ret < 0) {
+            return ret;
+        }
+
+        ret = dds_set_phase(phy, chan, dds_st->cached_phase[chan]);
+        if (ret < 0) {
+            return ret;
+        }
+
+        ret = dds_set_scale(phy, chan, dds_st->cached_scale[chan]);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dac_datasel
+ ******************************************************************************/
+int dac_datasel(struct ad9361_rf_phy *phy,
+                int32_t chan,
+                enum dds_data_select sel)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+
+    if (PCORE_VERSION_MAJOR(dds_st->pcore_version) > 7) {
+        if (chan < 0) { /* ALL */
+            uint32_t i;
+            for (i = 0; i < dds_st->num_dds_channels; i++) {
+                ret = dac_write(phy, DAC_REG_CHAN_CNTRL_7(i), sel);
+                if (ret < 0) {
+                    return ret;
+                }
+            }
+        } else {
+            ret = dac_write(phy, DAC_REG_CHAN_CNTRL_7(chan), sel);
+            if (ret < 0) {
+                return ret;
+            }
+        }
+    } else {
+        uint32_t reg;
+
+        switch (sel) {
+            case DATA_SEL_DDS:
+            case DATA_SEL_SED:
+            case DATA_SEL_DMA:
+                ret = dac_read(phy, DAC_REG_CNTRL_2, &reg);
+                if (ret < 0) {
+                    return ret;
+                }
+
+                reg &= ~DAC_DATA_SEL(~0);
+                reg |= DAC_DATA_SEL(sel);
+
+                ret = dac_write(phy, DAC_REG_CNTRL_2, reg);
+                if (ret < 0) {
+                    return ret;
+                }
+                break;
+            default:
+                return -EINVAL;
+        }
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_to_signed_mag_fmt
+ ******************************************************************************/
+uint32_t dds_to_signed_mag_fmt(int32_t val, int32_t val2)
+{
+    uint32_t i;
+    uint64_t val64;
+
+    /* format is 1.1.14 (sign, integer and fractional bits) */
+
+    switch (val) {
+        case 1:
+            i = 0x4000;
+            break;
+        case -1:
+            i = 0xC000;
+            break;
+        case 0:
+            i = 0;
+            if (val2 < 0) {
+                i = 0x8000;
+                val2 *= -1;
+            }
+            break;
+        default:
+            /* Invalid Value */
+            i = 0;
+    }
+
+    val64 = (uint64_t)val2 * 0x4000UL + (1000000UL / 2);
+    do_div(&val64, 1000000UL);
+
+    return i | (uint32_t)val64;
+}
+
+/*******************************************************************************
+ * @brief dds_from_signed_mag_fmt
+ ******************************************************************************/
+void dds_from_signed_mag_fmt(uint32_t val, int32_t *r_val, int32_t *r_val2)
+{
+    uint64_t val64;
+    int32_t sign;
+
+    if (val & 0x8000)
+        sign = -1;
+    else
+        sign = 1;
+
+    if (val & 0x4000)
+        *r_val = 1 * sign;
+    else
+        *r_val = 0;
+
+    val &= ~0xC000;
+
+    val64 = val * 1000000ULL + (0x4000 / 2);
+    do_div(&val64, 0x4000);
+
+    if (*r_val == 0)
+        *r_val2 = (uint32_t)val64 * sign;
+    else
+        *r_val2 = (uint32_t)val64;
+}
+
+/*******************************************************************************
+ * @brief dds_set_calib_scale_phase
+ ******************************************************************************/
+int32_t dds_set_calib_scale_phase(struct ad9361_rf_phy *phy,
+                                  uint32_t phase,
+                                  uint32_t chan,
+                                  int32_t val,
+                                  int32_t val2)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+    uint32_t reg;
+    uint32_t i;
+
+    if (PCORE_VERSION_MAJOR(dds_st->pcore_version) < 8) {
+        return -1;
+    }
+
+    i = dds_to_signed_mag_fmt(val, val2);
+
+    ret = dac_read(phy, DAC_REG_CHAN_CNTRL_8(chan), &reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (!((chan + phase) % 2)) {
+        reg &= ~DAC_IQCOR_COEFF_1(~0);
+        reg |= DAC_IQCOR_COEFF_1(i);
+    } else {
+        reg &= ~DAC_IQCOR_COEFF_2(~0);
+        reg |= DAC_IQCOR_COEFF_2(i);
+    }
+
+    ret = dac_write(phy, DAC_REG_CHAN_CNTRL_8(chan), reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    ret = dac_write(phy, DAC_REG_CHAN_CNTRL_6(chan), DAC_IQCOR_ENB);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_get_calib_scale_phase
+ ******************************************************************************/
+int32_t dds_get_calib_scale_phase(struct ad9361_rf_phy *phy,
+                                  uint32_t phase,
+                                  uint32_t chan,
+                                  int32_t *val,
+                                  int32_t *val2)
+{
+    struct dds_state *dds_st = &phy->adc_state->dac_dds_state;
+    int ret;
+    uint32_t reg;
+
+    if (PCORE_VERSION_MAJOR(dds_st->pcore_version) < 8) {
+        return -1;
+    }
+
+    ret = dac_read(phy, DAC_REG_CHAN_CNTRL_8(chan), &reg);
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* format is 1.1.14 (sign, integer and fractional bits) */
+
+    if (!((phase + chan) % 2)) {
+        reg = DAC_TO_IQCOR_COEFF_1(reg);
+    } else {
+        reg = DAC_TO_IQCOR_COEFF_2(reg);
+    }
+
+    dds_from_signed_mag_fmt(reg, val, val2);
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief dds_set_calib_scale
+ ******************************************************************************/
+int32_t dds_set_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2)
+{
+    return dds_set_calib_scale_phase(phy, 0, chan, val, val2);
+}
+
+/*******************************************************************************
+ * @brief dds_get_calib_scale
+ ******************************************************************************/
+int32_t dds_get_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2)
+{
+    return dds_get_calib_scale_phase(phy, 0, chan, val, val2);
+}
+
+/*******************************************************************************
+ * @brief dds_set_calib_phase
+ ******************************************************************************/
+int32_t dds_set_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2)
+{
+    return dds_set_calib_scale_phase(phy, 1, chan, val, val2);
+}
+
+/*******************************************************************************
+ * @brief dds_get_calib_phase
+ ******************************************************************************/
+int32_t dds_get_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2)
+{
+    return dds_get_calib_scale_phase(phy, 1, chan, val, val2);
+}

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/dac_core.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/dac_core.h
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ *   @file   dac_core.h
+ *   @brief  Header file of DAC Core Driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+ *******************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef DAC_CORE_API_H_
+#define DAC_CORE_API_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "ad9361.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define DAC_REG_VERSION 0x0000
+#define DAC_VERSION(x) (((x)&0xffffffff) << 0)
+#define VERSION_IS(x, y, z) ((x) << 16 | (y) << 8 | (z))
+#define DAC_REG_ID 0x0004
+#define DAC_ID(x) (((x)&0xffffffff) << 0)
+#define DAC_REG_SCRATCH 0x0008
+#define DAC_SCRATCH(x) (((x)&0xffffffff) << 0)
+
+#define PCORE_VERSION_MAJOR(version) (version >> 16)
+
+#define DAC_REG_RSTN 0x0040
+#define DAC_RSTN (1 << 0)
+#define DAC_MMCM_RSTN (1 << 1)
+
+#define DAC_REG_RATECNTRL 0x004C
+#define DAC_RATE(x) (((x)&0xFF) << 0)
+#define DAC_TO_RATE(x) (((x) >> 0) & 0xFF)
+
+#define DAC_REG_CNTRL_1 0x0044
+#define DAC_ENABLE (1 << 0) /* v7.0 */
+#define DAC_SYNC (1 << 0)   /* v8.0 */
+
+#define DAC_REG_CNTRL_2 0x0048
+#define DAC_PAR_TYPE (1 << 7)
+#define DAC_PAR_ENB (1 << 6)
+#define DAC_R1_MODE (1 << 5)
+#define DAC_DATA_FORMAT (1 << 4)
+#define DAC_DATA_SEL(x) (((x)&0xF) << 0)      /* v7.0 */
+#define DAC_TO_DATA_SEL(x) (((x) >> 0) & 0xF) /* v7.0 */
+
+#define DAC_REG_VDMA_FRMCNT 0x0084
+#define DAC_VDMA_FRMCNT(x) (((x)&0xFFFFFFFF) << 0)
+#define DAC_TO_VDMA_FRMCNT(x) (((x) >> 0) & 0xFFFFFFFF)
+
+#define DAC_REG_VDMA_STATUS 0x0088
+#define DAC_VDMA_OVF (1 << 1)
+#define DAC_VDMA_UNF (1 << 0)
+
+enum dds_data_select {
+    DATA_SEL_DDS,
+    DATA_SEL_SED,
+    DATA_SEL_DMA,
+    DATA_SEL_ZERO, /* OUTPUT 0 */
+    DATA_SEL_PN7,
+    DATA_SEL_PN15,
+    DATA_SEL_PN23,
+    DATA_SEL_PN31,
+    DATA_SEL_LB,   /* loopback data (ADC) */
+    DATA_SEL_PNXX, /* (Device specific) */
+};
+
+#define DAC_REG_CHAN_CNTRL_1_IIOCHAN(x) \
+    (0x0400 + ((x) >> 1) * 0x40 + ((x)&1) * 0x8)
+#define DAC_DDS_SCALE(x) (((x)&0xFFFF) << 0)
+#define DAC_TO_DDS_SCALE(x) (((x) >> 0) & 0xFFFF)
+
+#define DAC_REG_CHAN_CNTRL_2_IIOCHAN(x) \
+    (0x0404 + ((x) >> 1) * 0x40 + ((x)&1) * 0x8)
+#define DAC_DDS_INIT(x) (((x)&0xFFFF) << 16)
+#define DAC_TO_DDS_INIT(x) (((x) >> 16) & 0xFFFF)
+#define DAC_DDS_INCR(x) (((x)&0xFFFF) << 0)
+#define DAC_TO_DDS_INCR(x) (((x) >> 0) & 0xFFFF)
+
+#define DDS_CHAN_TX1_I_F1 0
+#define DDS_CHAN_TX1_I_F2 1
+#define DDS_CHAN_TX1_Q_F1 2
+#define DDS_CHAN_TX1_Q_F2 3
+#define DDS_CHAN_TX2_I_F1 4
+#define DDS_CHAN_TX2_I_F2 5
+#define DDS_CHAN_TX2_Q_F1 6
+#define DDS_CHAN_TX2_Q_F2 7
+
+#define AXI_DMAC_REG_IRQ_MASK 0x80
+#define AXI_DMAC_REG_IRQ_PENDING 0x84
+#define AXI_DMAC_REG_IRQ_SOURCE 0x88
+
+#define AXI_DMAC_REG_CTRL 0x400
+#define AXI_DMAC_REG_TRANSFER_ID 0x404
+#define AXI_DMAC_REG_START_TRANSFER 0x408
+#define AXI_DMAC_REG_FLAGS 0x40c
+#define AXI_DMAC_REG_DEST_ADDRESS 0x410
+#define AXI_DMAC_REG_SRC_ADDRESS 0x414
+#define AXI_DMAC_REG_X_LENGTH 0x418
+#define AXI_DMAC_REG_Y_LENGTH 0x41c
+#define AXI_DMAC_REG_DEST_STRIDE 0x420
+#define AXI_DMAC_REG_SRC_STRIDE 0x424
+#define AXI_DMAC_REG_TRANSFER_DONE 0x428
+#define AXI_DMAC_REG_ACTIVE_TRANSFER_ID 0x42c
+#define AXI_DMAC_REG_STATUS 0x430
+#define AXI_DMAC_REG_CURRENT_DEST_ADDR 0x434
+#define AXI_DMAC_REG_CURRENT_SRC_ADDR 0x438
+#define AXI_DMAC_REG_DBG0 0x43c
+#define AXI_DMAC_REG_DBG1 0x440
+
+#define AXI_DMAC_CTRL_ENABLE (1 << 0)
+#define AXI_DMAC_CTRL_PAUSE (1 << 1)
+
+#define AXI_DMAC_IRQ_SOT (1 << 0)
+#define AXI_DMAC_IRQ_EOT (1 << 1)
+
+struct dds_state {
+    uint32_t cached_freq[8];
+    uint32_t cached_phase[8];
+    int32_t cached_scale[8];
+    uint32_t *dac_clk;
+    uint32_t pcore_version;
+    uint32_t num_dds_channels;
+    bool enable;
+    bool rx2tx2;
+};
+
+#define DAC_REG_CHAN_CNTRL_6(c) (0x0414 + (c)*0x40)
+#define DAC_IQCOR_ENB (1 << 2) /* v8.0 */
+
+#define DAC_REG_CHAN_CNTRL_7(c) (0x0418 + (c)*0x40) /* v8.0 */
+#define DAC_DAC_DDS_SEL(x) (((x)&0xF) << 0)
+#define DAC_TO_DAC_DDS_SEL(x) (((x) >> 0) & 0xF)
+
+#define DAC_REG_CHAN_CNTRL_8(c) (0x041C + (c)*0x40) /* v8.0 */
+#define DAC_IQCOR_COEFF_1(x) (((x)&0xFFFF) << 16)
+#define DAC_TO_IQCOR_COEFF_1(x) (((x) >> 16) & 0xFFFF)
+#define DAC_IQCOR_COEFF_2(x) (((x)&0xFFFF) << 0)
+#define DAC_TO_IQCOR_COEFF_2(x) (((x) >> 0) & 0xFFFF)
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int dac_init(struct ad9361_rf_phy *phy, uint8_t data_sel, uint8_t config_dma);
+int dds_set_frequency(struct ad9361_rf_phy *phy, uint32_t chan, uint32_t freq);
+int dds_set_phase(struct ad9361_rf_phy *phy, uint32_t chan, uint32_t phase);
+int dds_set_scale(struct ad9361_rf_phy *phy,
+                  uint32_t chan,
+                  int32_t scale_micro_units);
+int dds_update(struct ad9361_rf_phy *phy);
+int dac_datasel(struct ad9361_rf_phy *phy,
+                int32_t chan,
+                enum dds_data_select sel);
+int32_t dds_set_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2);
+int32_t dds_get_calib_scale(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2);
+int32_t dds_set_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t val,
+                            int32_t val2);
+int32_t dds_get_calib_phase(struct ad9361_rf_phy *phy,
+                            uint32_t chan,
+                            int32_t *val,
+                            int32_t *val2);
+#endif

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/platform.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/platform.c
@@ -1,0 +1,272 @@
+#include <stdint.h>
+#include <unistd.h>
+
+#include "devices.h"
+#include "platform.h"
+
+#include "adc_core.h"
+#include "dac_core.h"
+
+/*******************************************************************************
+ * @brief spi_init
+ ******************************************************************************/
+
+int spi_init(struct ad9361_rf_phy *phy, void *userdata)
+{
+    phy->spi->userdata = userdata;
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief spi_write
+ ******************************************************************************/
+
+int spi_write(struct spi_device *spi,
+              uint16_t cmd,
+              const uint8_t *buf,
+              unsigned int len)
+{
+    uint64_t data;
+    size_t i;
+
+    /* Copy buf to data */
+    data = 0;
+    for (i = 0; i < len; i++) {
+        data |= (((uint64_t)buf[i]) << 8 * (7 - i));
+    }
+
+    /* SPI transaction */
+    adi_spi_write(cmd, data);
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief spi_read
+ ******************************************************************************/
+
+#include <inttypes.h>
+
+int spi_read(struct spi_device *spi,
+             uint16_t cmd,
+             uint8_t *buf,
+             unsigned int len)
+{
+    uint64_t data = 0;
+    size_t i;
+
+    /* SPI transaction */
+    data = adi_spi_read(cmd);
+
+    /* Copy data to buf */
+    for (i = 0; i < len; i++) {
+        buf[i] = (data >> 8 * (7 - i)) & 0xff;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief gpio_init
+ ******************************************************************************/
+
+int gpio_init(struct ad9361_rf_phy *phy, void *userdata)
+{
+    phy->gpio->userdata = userdata;
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief gpio_is_valid
+ ******************************************************************************/
+
+bool gpio_is_valid(struct gpio_device *gpio, int32_t number)
+{
+    if (number == RFFE_CONTROL_RESET_N) {
+        return true;
+    } else if (number == RFFE_CONTROL_SYNC_IN) {
+        return true;
+    }
+
+    return false;
+}
+
+/*******************************************************************************
+ * @brief gpio_set_value
+ ******************************************************************************/
+
+int gpio_set_value(struct gpio_device *gpio, int32_t number, bool value)
+{
+    uint32_t reg;
+
+    /* Read */
+    reg = rffe_csr_read();
+
+    /* Modify */
+    if (value) {
+        reg |= (1 << number);
+    } else {
+        reg &= ~(1 << number);
+    }
+
+    /* Write */
+    rffe_csr_write(reg);
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief udelay
+ ******************************************************************************/
+
+void udelay(unsigned long usecs)
+{
+    usleep(usecs);
+}
+
+/*******************************************************************************
+ * @brief mdelay
+ ******************************************************************************/
+
+void mdelay(unsigned long msecs)
+{
+    usleep(msecs * 1000);
+}
+
+/*******************************************************************************
+ * @brief msleep_interruptible
+ ******************************************************************************/
+
+unsigned long msleep_interruptible(unsigned int msecs)
+{
+    usleep(msecs * 1000);
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief axiadc_init
+ ******************************************************************************/
+
+int axiadc_init(struct ad9361_rf_phy *phy, void *userdata)
+{
+    int status;
+
+    phy->adc_state->userdata = userdata;
+
+    status = adc_init(phy);
+    if (status < 0) {
+        return status;
+    }
+
+    status = dac_init(phy, DATA_SEL_DMA, 0);
+    if (status < 0) {
+        return status;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief axiadc_post_setup
+ ******************************************************************************/
+
+int axiadc_post_setup(struct ad9361_rf_phy *phy)
+{
+    return ad9361_post_setup(phy);
+}
+
+/*******************************************************************************
+ * @brief axiadc_read
+ ******************************************************************************/
+
+int axiadc_read(struct axiadc_state *st, uint32_t addr, uint32_t *data)
+{
+    *data = adi_axi_read((uint16_t)addr);
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief axiadc_write
+ ******************************************************************************/
+
+int axiadc_write(struct axiadc_state *st, uint32_t addr, uint32_t data)
+{
+    adi_axi_write((uint16_t)addr, data);
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief axiadc_set_pnsel
+ ******************************************************************************/
+
+int axiadc_set_pnsel(struct axiadc_state *st,
+                     unsigned int channel,
+                     enum adc_pn_sel sel)
+{
+    int status;
+    uint32_t reg;
+
+    if (PCORE_VERSION_MAJOR(st->pcore_version) > 7) {
+        status = axiadc_read(st, ADI_REG_CHAN_CNTRL_3(channel), &reg);
+        if (status != 0)
+            return status;
+
+        reg &= ~ADI_ADC_PN_SEL(~0);
+        reg |= ADI_ADC_PN_SEL(sel);
+
+        status = axiadc_write(st, ADI_REG_CHAN_CNTRL_3(channel), reg);
+        if (status != 0)
+            return status;
+    } else {
+        status = axiadc_read(st, ADI_REG_CHAN_CNTRL(channel), &reg);
+        if (status != 0)
+            return status;
+
+        if (sel == ADC_PN_CUSTOM) {
+            reg |= ADI_PN_SEL;
+        } else if (sel == ADC_PN9) {
+            reg &= ~ADI_PN23_TYPE;
+            reg &= ~ADI_PN_SEL;
+        } else {
+            reg |= ADI_PN23_TYPE;
+            reg &= ~ADI_PN_SEL;
+        }
+
+        status = axiadc_write(st, ADI_REG_CHAN_CNTRL(channel), reg);
+        if (status != 0)
+            return status;
+    }
+
+    return 0;
+}
+
+/*******************************************************************************
+ * @brief axiadc_idelay_set
+ ******************************************************************************/
+
+int axiadc_idelay_set(struct axiadc_state *st,
+                      unsigned int lane,
+                      unsigned int val)
+{
+    int status;
+
+    if (PCORE_VERSION_MAJOR(st->pcore_version) > 8) {
+        status = axiadc_write(st, ADI_REG_DELAY(lane), val);
+        if (status != 0)
+            return status;
+    } else {
+        status = axiadc_write(st, ADI_REG_DELAY_CNTRL, 0);
+        if (status != 0)
+            return status;
+
+        status = axiadc_write(st, ADI_REG_DELAY_CNTRL,
+                              ADI_DELAY_ADDRESS(lane) | ADI_DELAY_WDATA(val) |
+                                  ADI_DELAY_SEL);
+        if (status != 0)
+            return status;
+    }
+
+    return 0;
+}

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/platform.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2_headless/platform.h
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ *   @file   platform.h
+ *   @brief  Header file of Platform driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+ *******************************************************************************
+ * Copyright 2014(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef PLATFORM_H_
+#define PLATFORM_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "config.h"
+#include "stdint.h"
+#include "util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define ADI_REG_VERSION 0x0000
+
+#define ADI_REG_ID 0x0004
+
+#define ADI_REG_RSTN 0x0040
+#define ADI_RSTN (1 << 0)
+#define ADI_MMCM_RSTN (1 << 1)
+
+#define ADI_REG_CNTRL 0x0044
+#define ADI_R1_MODE (1 << 2)
+#define ADI_DDR_EDGESEL (1 << 1)
+#define ADI_PIN_MODE (1 << 0)
+
+#define ADI_REG_STATUS 0x005C
+#define ADI_MUX_PN_ERR (1 << 3)
+#define ADI_MUX_PN_OOS (1 << 2)
+#define ADI_MUX_OVER_RANGE (1 << 1)
+#define ADI_STATUS (1 << 0)
+
+#define ADI_REG_DELAY_CNTRL 0x0060 /* <= v8.0 */
+#define ADI_DELAY_SEL (1 << 17)
+#define ADI_DELAY_RWN (1 << 16)
+#define ADI_DELAY_ADDRESS(x) (((x)&0xFF) << 8)
+#define ADI_TO_DELAY_ADDRESS(x) (((x) >> 8) & 0xFF)
+#define ADI_DELAY_WDATA(x) (((x)&0x1F) << 0)
+#define ADI_TO_DELAY_WDATA(x) (((x) >> 0) & 0x1F)
+
+#define ADI_REG_CHAN_CNTRL(c) (0x0400 + (c)*0x40)
+#define ADI_PN_SEL (1 << 10) /* !v8.0 */
+#define ADI_IQCOR_ENB (1 << 9)
+#define ADI_DCFILT_ENB (1 << 8)
+#define ADI_FORMAT_SIGNEXT (1 << 6)
+#define ADI_FORMAT_TYPE (1 << 5)
+#define ADI_FORMAT_ENABLE (1 << 4)
+#define ADI_PN23_TYPE (1 << 1) /* !v8.0 */
+#define ADI_ENABLE (1 << 0)
+
+#define ADI_REG_CHAN_STATUS(c) (0x0404 + (c)*0x40)
+#define ADI_PN_ERR (1 << 2)
+#define ADI_PN_OOS (1 << 1)
+#define ADI_OVER_RANGE (1 << 0)
+
+#define ADI_REG_CHAN_CNTRL_1(c) (0x0410 + (c)*0x40)
+#define ADI_DCFILT_OFFSET(x) (((x)&0xFFFF) << 16)
+#define ADI_TO_DCFILT_OFFSET(x) (((x) >> 16) & 0xFFFF)
+#define ADI_DCFILT_COEFF(x) (((x)&0xFFFF) << 0)
+#define ADI_TO_DCFILT_COEFF(x) (((x) >> 0) & 0xFFFF)
+
+#define ADI_REG_CHAN_CNTRL_2(c) (0x0414 + (c)*0x40)
+#define ADI_IQCOR_COEFF_1(x) (((x)&0xFFFF) << 16)
+#define ADI_TO_IQCOR_COEFF_1(x) (((x) >> 16) & 0xFFFF)
+#define ADI_IQCOR_COEFF_2(x) (((x)&0xFFFF) << 0)
+#define ADI_TO_IQCOR_COEFF_2(x) (((x) >> 0) & 0xFFFF)
+
+#define PCORE_VERSION(major, minor, letter) \
+    ((major << 16) | (minor << 8) | letter)
+#define PCORE_VERSION_MAJOR(version) (version >> 16)
+#define PCORE_VERSION_MINOR(version) ((version >> 8) & 0xff)
+#define PCORE_VERSION_LETTER(version) (version & 0xff)
+
+#define ADI_REG_CHAN_CNTRL_3(c) (0x0418 + (c)*0x40) /* v8.0 */
+#define ADI_ADC_PN_SEL(x) (((x)&0xF) << 16)
+#define ADI_TO_ADC_PN_SEL(x) (((x) >> 16) & 0xF)
+#define ADI_ADC_DATA_SEL(x) (((x)&0xF) << 0)
+#define ADI_TO_ADC_DATA_SEL(x) (((x) >> 0) & 0xF)
+
+/* PCORE Version > 8.00 */
+#define ADI_REG_DELAY(l) (0x0800 + (l)*0x4)
+
+enum adc_pn_sel {
+    ADC_PN9       = 0,
+    ADC_PN23A     = 1,
+    ADC_PN7       = 4,
+    ADC_PN15      = 5,
+    ADC_PN23      = 6,
+    ADC_PN31      = 7,
+    ADC_PN_CUSTOM = 9,
+    ADC_PN_END    = 10,
+};
+
+enum adc_data_sel {
+    ADC_DATA_SEL_NORM,
+    ADC_DATA_SEL_LB,   /* DAC loopback */
+    ADC_DATA_SEL_RAMP, /* TBD */
+};
+
+/* Bitwise positions of GPOs in RFFE control register */
+#define RFFE_CONTROL_RESET_N 0
+#define RFFE_CONTROL_SYNC_IN 4
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int spi_init(struct ad9361_rf_phy *phy, void *userdata);
+int spi_write(struct spi_device *spi,
+              uint16_t cmd,
+              const uint8_t *buf,
+              unsigned int len);
+int spi_read(struct spi_device *spi,
+             uint16_t cmd,
+             uint8_t *buf,
+             unsigned int len);
+
+int gpio_init(struct ad9361_rf_phy *phy, void *userdata);
+bool gpio_is_valid(struct gpio_device *gpio, int32_t number);
+int gpio_set_value(struct gpio_device *gpio, int32_t number, bool value);
+
+void udelay(unsigned long usecs);
+void mdelay(unsigned long msecs);
+unsigned long msleep_interruptible(unsigned int msecs);
+
+#ifndef AXI_ADC_NOT_PRESENT
+int axiadc_init(struct ad9361_rf_phy *phy, void *userdata);
+int axiadc_post_setup(struct ad9361_rf_phy *phy);
+int axiadc_read(struct axiadc_state *st, uint32_t addr, uint32_t *data);
+int axiadc_write(struct axiadc_state *st, uint32_t addr, uint32_t data);
+int axiadc_set_pnsel(struct axiadc_state *st,
+                     unsigned int channel,
+                     enum adc_pn_sel sel);
+int axiadc_idelay_set(struct axiadc_state *st,
+                      unsigned int lane,
+                      unsigned int val);
+#endif
+
+#endif


### PR DESCRIPTION
This PR implements FPGA-based control of the AD936x RFIC on the bladeRF 2.0 micro.  It is the FPGA side of #712.

It adds a new packet target to 16x64, and dispatches those to a queuing handler in devices_rfic.c.

Initially, this is a faster method of doing RFIC control (albeit with some loss of rarely-used features), but it should be possible to implement headless/standalone systems based around this.

Note: this expands the Nios RAM footprint from 32 kB to 128 kB.