### PR TITLE
host: fix FPGA flash region erase block count on xA9

### DIFF
--- a/host/libraries/libbladeRF/include/bladeRF1.h
+++ b/host/libraries/libbladeRF/include/bladeRF1.h
@@ -121,9 +121,6 @@
  */
 #define BLADERF_FLASH_ADDR_FPGA 0x00040000
 
-/** Length of entire FPGA region, including both metadata and bitstream. */
-#define BLADERF_FLASH_BYTE_LEN_FPGA 0x00370000
-
 /** @} (End of BLADERF_FLASH_CONSTANTS) */
 
 /**

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -483,6 +483,18 @@ int CALL_CONV bladerf_get_fpga_size(struct bladerf *dev,
                                     bladerf_fpga_size *size);
 
 /**
+ * Query a device's expected FPGA bitstream length, in bytes
+ *
+ * @param       dev     Device handle
+ * @param[out]  size    Will be updated with expected bitstream length. If an
+ *                      error occurs, no data will be written to this pointer.
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_fpga_bytes(struct bladerf *dev, size_t *size);
+
+/**
  * Query a device's Flash size
  *
  * @param       dev      Device handle
@@ -2241,19 +2253,19 @@ typedef enum {
  * This flag is asserted in bladerf_metadata.status by the hardware when an
  * underflow is detected in the sample buffering system on the device.
  */
-#define BLADERF_META_FLAG_RX_HW_UNDERFLOW       (1 << 0)
+#define BLADERF_META_FLAG_RX_HW_UNDERFLOW (1 << 0)
 
 /**
  * This flag is asserted in bladerf_metadata.status by the hardware if mini
  * expansion IO pin 1 is asserted.
  */
-#define BLADERF_META_FLAG_RX_HW_MINIEXP1        (1 << 16)
+#define BLADERF_META_FLAG_RX_HW_MINIEXP1 (1 << 16)
 
 /**
  * This flag is asserted in bladerf_metadata.status by the hardware if mini
  * expansion IO pin 2 is asserted.
  */
-#define BLADERF_META_FLAG_RX_HW_MINIEXP2        (1 << 17)
+#define BLADERF_META_FLAG_RX_HW_MINIEXP2 (1 << 17)
 
 /**
  * Sample metadata
@@ -3207,9 +3219,8 @@ struct bladerf_image *CALL_CONV bladerf_alloc_image(struct bladerf *dev,
  *         `NULL` on memory allocation failure
  */
 API_EXPORT
-struct bladerf_image *CALL_CONV
-    bladerf_alloc_cal_image(struct bladerf *dev,
-                            bladerf_fpga_size fpga_size, uint16_t vctcxo_trim);
+struct bladerf_image *CALL_CONV bladerf_alloc_cal_image(
+    struct bladerf *dev, bladerf_fpga_size fpga_size, uint16_t vctcxo_trim);
 
 /**
  * Free a bladerf_image previously obtained via bladerf_alloc_image.

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -369,6 +369,17 @@ int bladerf_get_fpga_size(struct bladerf *dev, bladerf_fpga_size *size)
     return status;
 }
 
+int bladerf_get_fpga_bytes(struct bladerf *dev, size_t *size)
+{
+    int status;
+    MUTEX_LOCK(&dev->lock);
+
+    status = dev->board->get_fpga_bytes(dev, size);
+
+    MUTEX_UNLOCK(&dev->lock);
+    return status;
+}
+
 int bladerf_get_flash_size(struct bladerf *dev, uint32_t *size, bool *is_guess)
 {
     int status;

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -593,6 +593,30 @@ static int bladerf2_get_fpga_size(struct bladerf *dev, bladerf_fpga_size *size)
     return 0;
 }
 
+static int bladerf2_get_fpga_bytes(struct bladerf *dev, size_t *size)
+{
+    CHECK_BOARD_STATE(STATE_FIRMWARE_LOADED);
+    NULL_CHECK(size);
+
+    struct bladerf2_board_data *board_data = dev->board_data;
+
+    switch (board_data->fpga_size) {
+        case BLADERF_FPGA_A4:
+            *size = 2632660;
+            break;
+
+        case BLADERF_FPGA_A9:
+            *size = 12858972;
+            break;
+
+        default:
+            log_debug("%s: unknown fpga_size: %x\n", board_data->fpga_size);
+            return BLADERF_ERR_INVAL;
+    }
+
+    return 0;
+}
+
 static int bladerf2_get_flash_size(struct bladerf *dev,
                                    uint32_t *size,
                                    bool *is_guess)
@@ -2124,7 +2148,7 @@ static int bladerf2_load_fpga(struct bladerf *dev,
 
     struct bladerf2_board_data *board_data = dev->board_data;
 
-    if (!is_valid_fpga_size(board_data->fpga_size, length)) {
+    if (!is_valid_fpga_size(dev, board_data->fpga_size, length)) {
         RETURN_INVAL("fpga file", "incorrect file size");
     }
 
@@ -2147,7 +2171,7 @@ static int bladerf2_flash_fpga(struct bladerf *dev,
 
     struct bladerf2_board_data *board_data = dev->board_data;
 
-    if (!is_valid_fpga_size(board_data->fpga_size, length)) {
+    if (!is_valid_fpga_size(dev, board_data->fpga_size, length)) {
         RETURN_INVAL("fpga file", "incorrect file size");
     }
 
@@ -2744,6 +2768,7 @@ struct board_fns const bladerf2_board_fns = {
     FIELD_INIT(.device_speed, bladerf2_device_speed),
     FIELD_INIT(.get_serial, bladerf2_get_serial),
     FIELD_INIT(.get_fpga_size, bladerf2_get_fpga_size),
+    FIELD_INIT(.get_fpga_bytes, bladerf2_get_fpga_bytes),
     FIELD_INIT(.get_flash_size, bladerf2_get_flash_size),
     FIELD_INIT(.is_fpga_configured, bladerf2_is_fpga_configured),
     FIELD_INIT(.get_fpga_source, bladerf2_get_fpga_source),

--- a/host/libraries/libbladeRF/src/board/bladerf2/common.h
+++ b/host/libraries/libbladeRF/src/board/bladerf2/common.h
@@ -451,7 +451,9 @@ int perform_format_config(struct bladerf *dev,
  */
 int perform_format_deconfig(struct bladerf *dev, bladerf_direction dir);
 
-bool is_valid_fpga_size(bladerf_fpga_size fpga, size_t len);
+bool is_valid_fpga_size(struct bladerf *dev,
+                        bladerf_fpga_size fpga,
+                        size_t len);
 
 bool is_valid_fw_size(size_t len);
 

--- a/host/libraries/libbladeRF/src/board/board.h
+++ b/host/libraries/libbladeRF/src/board/board.h
@@ -187,6 +187,7 @@ struct board_fns {
     bladerf_dev_speed (*device_speed)(struct bladerf *dev);
     int (*get_serial)(struct bladerf *dev, char *serial);
     int (*get_fpga_size)(struct bladerf *dev, bladerf_fpga_size *size);
+    int (*get_fpga_bytes)(struct bladerf *dev, size_t *size);
     int (*get_flash_size)(struct bladerf *dev, uint32_t *size, bool *is_guess);
     int (*is_fpga_configured)(struct bladerf *dev);
     int (*get_fpga_source)(struct bladerf *dev, bladerf_fpga_source *source);

--- a/host/utilities/bladeRF-cli/src/cmd/flash_backup.c
+++ b/host/utilities/bladeRF-cli/src/cmd/flash_backup.c
@@ -31,6 +31,9 @@
 #include "conversions.h"
 #include "rel_assert.h"
 
+/* Previously BLADERF_FLASH_BYTE_LEN_FPGA. TODO: don't hardcode this */
+static size_t const LEGACY_FLASH_BYTE_LEN_FPGA = 0x00370000;
+
 #define lib_error(status, ...) do { \
     state->last_lib_error = (status); \
     cli_err(state, argv[0], __VA_ARGS__); \
@@ -68,11 +71,11 @@ int cmd_flash_backup(struct cli_state *state, int argc, char **argv)
         } else if (!strcasecmp(argv[2], "fpga40")) {
             image_type = BLADERF_IMAGE_TYPE_FPGA_40KLE;
             address = BLADERF_FLASH_ADDR_FPGA;
-            length = BLADERF_FLASH_BYTE_LEN_FPGA;
+            length = LEGACY_FLASH_BYTE_LEN_FPGA;
         } else if (!strcasecmp(argv[2], "fpga115")) {
             image_type = BLADERF_IMAGE_TYPE_FPGA_115KLE;
             address = BLADERF_FLASH_ADDR_FPGA;
-            length = BLADERF_FLASH_BYTE_LEN_FPGA;
+            length = LEGACY_FLASH_BYTE_LEN_FPGA;
         } else {
             cli_err(state, argv[0], "Invalid image type provided.\n");
             status = CLI_RET_INVPARAM;

--- a/host/utilities/bladeRF-cli/src/cmd/flash_image.c
+++ b/host/utilities/bladeRF-cli/src/cmd/flash_image.c
@@ -34,6 +34,9 @@
 #include "rel_assert.h"
 #include "input.h"
 
+/* Previously BLADERF_FLASH_BYTE_LEN_FPGA. TODO: don't hardcode this */
+static size_t const LEGACY_FLASH_BYTE_LEN_FPGA = 0x00370000;
+
 struct params
 {
     char *img_file;
@@ -104,7 +107,7 @@ static int handle_param(const char *param, char *val,
                 p->address = BLADERF_FLASH_ADDR_FPGA;
             }
 
-            p->max_length = BLADERF_FLASH_BYTE_LEN_FPGA;
+            p->max_length = LEGACY_FLASH_BYTE_LEN_FPGA;
 
             if (!strcasecmp("fpga40", val)) {
                 p->type = BLADERF_IMAGE_TYPE_FPGA_40KLE;

--- a/host/utilities/bladeRF-cli/src/cmd/flash_restore.c
+++ b/host/utilities/bladeRF-cli/src/cmd/flash_restore.c
@@ -31,6 +31,9 @@
 #include "minmax.h"
 #include "conversions.h"
 
+/* Previously BLADERF_FLASH_BYTE_LEN_FPGA. TODO: don't hardcode this */
+static size_t const LEGACY_FLASH_BYTE_LEN_FPGA = 0x00370000;
+
 struct options {
     char *file;
     uint32_t address, len;
@@ -77,7 +80,7 @@ static int parse_argv(struct cli_state *state, int argc, char **argv,
 }
 
 static inline int erase_region(struct bladerf *dev, struct bladerf_image *img,
-                                uint32_t addr, uint32_t len)
+                               uint32_t addr, uint32_t len)
 {
     switch (img->type) {
         case BLADERF_IMAGE_TYPE_FIRMWARE:
@@ -87,7 +90,7 @@ static inline int erase_region(struct bladerf *dev, struct bladerf_image *img,
         case BLADERF_IMAGE_TYPE_FPGA_40KLE:
         case BLADERF_IMAGE_TYPE_FPGA_115KLE:
             return bladerf_erase_flash_bytes(dev, BLADERF_FLASH_ADDR_FPGA,
-                                             BLADERF_FLASH_BYTE_LEN_FPGA);
+                                             LEGACY_FLASH_BYTE_LEN_FPGA);
 
         case BLADERF_IMAGE_TYPE_CALIBRATION:
             return bladerf_erase_flash_bytes(dev, BLADERF_FLASH_ADDR_CAL,


### PR DESCRIPTION
Write page counts were updated for 128 Mbit flash chips, but erase block counts were not.  This resulted in FPGA bitstream verification failing on bladeRF 2.0 micro xA9 boards, as flash writes can only turn 1s into 0s, but can't turn 0s into 1s.

Implement a bladerf_get_fpga_bytes() library call to return the expected FPGA image size.

Use the actual bitstream length to compute the number of blocks to erase.

Update bladeRF-cli flash-related functionality.