### PR TITLE
hdl: nios: devices_rfic: add rfic_command_{write,read}_immed() commands

### DIFF
--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices.h
@@ -592,10 +592,12 @@ void rfic_command_init(void);
 void rfic_command_work(void);
 
 /**
- * RFIC command write
+ * RFIC command write (queuing)
  *
- * @param   addr    Address
- * @param   data    Value
+ * @param[in]  addr  The address value from the packet
+ * @param[in]  data  The data value from the packet
+ *
+ * @see rfic_command_write_immed()
  *
  * @return bool (true = success)
  */
@@ -604,8 +606,10 @@ bool rfic_command_write(uint16_t addr, uint64_t data);
 /**
  * RFIC command read
  *
- * @param   addr    Address
- * @param   data    Value (out)
+ * @param[in]  addr  The address value from the packet
+ * @param[out] data  Return payload
+ *
+ * @see rfic_command_read_immed()
  *
  * @return bool (true = success)
  */

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.c
@@ -1258,14 +1258,6 @@ static void rfic_command_work_wq(struct rfic_queue *q)
     }
 }
 
-/**
- * @brief      Write command dispatcher
- *
- * @param[in]  addr  The address value from the packet
- * @param[in]  data  The data value from the packet
- *
- * @return     True if successfully enqueued, False otherwise.
- */
 bool rfic_command_write(uint16_t addr, uint64_t data)
 {
     uint8_t cmd                      = _rfic_unpack_cmd(addr);
@@ -1285,18 +1277,38 @@ bool rfic_command_write(uint16_t addr, uint64_t data)
     return rv;
 }
 
-/**
- * @brief      Read command dispatcher
- *
- * @param[in]  addr  The address value from the packet
- * @param[out] data  Return payload
- *
- * @return     True if read was successful and data is valid, False otherwise.
- */
+bool rfic_command_write_immed(bladerf_rfic_command cmd,
+                              bladerf_channel ch,
+                              uint64_t data)
+{
+    struct rfic_command_fns const *f = _get_cmd_ptr(cmd);
+
+    bool rv = false;
+
+    if (NULL == f || !_check_validity(f, ch)) {
+        rv = false;
+    } else if (NULL != f->write64) {
+        rv = f->write64(ch, data);
+    } else if (NULL != f->write32) {
+        rv = f->write32(ch, (uint32_t)data);
+    }
+
+    RFIC_DBG("WR!", _rfic_cmdstr(cmd), _rfic_chanstr(ch), rv ? "OK " : "BAD",
+             addr, data);
+
+    return rv;
+}
+
 bool rfic_command_read(uint16_t addr, uint64_t *data)
 {
-    uint8_t cmd                      = _rfic_unpack_cmd(addr);
-    uint8_t ch                       = _rfic_unpack_chan(addr);
+    return rfic_command_read_immed(_rfic_unpack_cmd(addr),
+                                   _rfic_unpack_chan(addr), data);
+}
+
+bool rfic_command_read_immed(bladerf_rfic_command cmd,
+                             bladerf_channel ch,
+                             uint64_t *data)
+{
     struct rfic_command_fns const *f = _get_cmd_ptr(cmd);
     bool rv                          = false;
 
@@ -1317,7 +1329,7 @@ bool rfic_command_read(uint16_t addr, uint64_t *data)
         }
     }
 
-    RFIC_DBG("RD ", _rfic_cmdstr(cmd), _rfic_chanstr(ch), rv ? "OK " : "BAD",
+    RFIC_DBG("RD!", _rfic_cmdstr(cmd), _rfic_chanstr(ch), rv ? "OK " : "BAD",
              addr, *data);
 
     return rv;

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic.h
@@ -140,6 +140,43 @@ struct rfic_queue_entry *rfic_queue_peek(struct rfic_queue *q);
 
 void rfic_queue_reset(struct rfic_queue *q);
 
+/**
+ * RFIC command read (immediate)
+ *
+ * @param   command     Command to execute
+ * @param   channel     Channel to apply command to
+ * @param   data        Response from command
+ *
+ * @return bool (true = success)
+ */
+bool rfic_command_read_immed(bladerf_rfic_command command,
+                             bladerf_channel channel,
+                             uint64_t *data);
+
+/**
+ * RFIC command write (immediate)
+ *
+ * @param   command     Command to execute
+ * @param   channel     Channel to apply command to
+ * @param   data        Argument for command
+ *
+ * @return bool (true = success)
+ */
+bool rfic_command_write_immed(bladerf_rfic_command command,
+                              bladerf_channel channel,
+                              uint64_t data);
+
+/**
+ * Invalidate the LO frequency state for a given module
+ *
+ * If anything affecting the tuning frequency of the RFIC is performed
+ * without using the ad9361_* functions, call this function to indicate
+ * that the state is invalid. Attempts to get the LO frequency will fail,
+ * until the LO frequency is set with a BLADERF_RFIC_COMMAND_FREQUENCY
+ * command.
+ *
+ * @param[in]  module  The module
+ */
 void rfic_invalidate_frequency(bladerf_module module);
 
 static inline bool _rfic_chan_is_system(uint8_t ch)


### PR DESCRIPTION
These are intended for use within headless applications, where queuing is unnecessary, and where the command/channel aren't simply packed into the address.