### PR TITLE
hdl: nios: d_r_cmds: remove unnecessary shift again

### DIFF
--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic_cmds.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic_cmds.c
@@ -171,9 +171,6 @@ static bool _rfic_initialize(struct rfic_state *state)
                 init_samprate = init_param->rx_path_clock_frequencies[5];
             }
 
-            /* Why this shift? I don't know. */
-            init_freq >>= 32;
-
             /* Switching the frequency twice seems essential for calibration
              * to be successful. */
             CHECK_BOOL(_rfic_cmd_wr_frequency(state, ch, RESET_FREQUENCY));


### PR DESCRIPTION
This shift was excised in 9f235dd but it came back during the refactoring in 9601bcc.

h/t @skyhighwings