### PR TITLE
libbladeRF: hdl: allow quicktune to control XB gpio register

### DIFF
--- a/fpga_common/include/lms.h
+++ b/fpga_common/include/lms.h
@@ -61,6 +61,39 @@
 #define LMS_FREQ_FLAGS_FORCE_VCOCAP   (1 << 1)
 
 /**
+ * This bit indicates whether the quicktune needs to set XB-200 parameters
+ */
+#define LMS_FREQ_XB_200_ENABLE              (1 << 7)
+
+/*
+ * This bit indicates the quicktune is for the RX module, not setting this bit
+ * indicates the quicktune is for the TX module.
+ */
+#define LMS_FREQ_XB_200_MODULE_RX           (1 << 6)
+
+/**
+ * This is the bit mask for the filter switch configuration for the XB-200.
+ */
+#define LMS_FREQ_XB_200_FILTER_SW           (3 << 4)
+
+/**
+ * Macro that indicates the number of bitshifts necessary to get to the filter
+ * switch field
+ */
+#define LMS_FREQ_XB_200_FILTER_SW_SHIFT     (4)
+
+/**
+ * This is the bit mask for the path configuration for the XB-200.
+ */
+#define LMS_FREQ_XB_200_PATH                (3 << 2)
+
+/**
+ * Macro that indicates the number of bitshifts necessary to get to the path
+ * field
+ */
+#define LMS_FREQ_XB_200_PATH_SHIFT          (2)
+
+/**
  * Information about the frequency calculation for the LMS6002D PLL
  * Calculation taken from the LMS6002D Programming and Calibration Guide
  * version 1.1r1.
@@ -72,6 +105,7 @@ struct lms_freq {
     uint32_t    nfrac;      /**< Fractional portion of f_LO given nint and f_REF */
     uint8_t     flags;      /**< Additional parameters defining the tuning
                                  configuration. See LMFS_FREQ_FLAGS_* values */
+    uint8_t     xb_gpio;    /**< Store XB-200 switch settings */
 
 #ifndef BLADERF_NIOS_BUILD
     uint8_t     x;         /**< VCO division ratio */

--- a/fpga_common/include/nios_pkt_retune.h
+++ b/fpga_common/include/nios_pkt_retune.h
@@ -130,6 +130,7 @@ static inline void nios_pkt_retune_pack(uint8_t *buf,
                                         uint8_t  freqsel,
                                         uint8_t  vcocap,
                                         bool     low_band,
+                                        uint8_t  xb_gpio,
                                         bool     quick_tune)
 {
     buf[NIOS_PKT_RETUNE_IDX_MAGIC] = NIOS_PKT_RETUNE_MAGIC;
@@ -177,7 +178,7 @@ static inline void nios_pkt_retune_pack(uint8_t *buf,
 
     buf[NIOS_PKT_RETUNE_IDX_BANDSEL] |= vcocap;
 
-    buf[NIOS_PKT_RETUNE_IDX_RESV]     = 0x00;
+    buf[NIOS_PKT_RETUNE_IDX_RESV]     = xb_gpio;
 }
 
 /* Unpack a retune request */
@@ -189,6 +190,7 @@ static inline void nios_pkt_retune_unpack(const uint8_t *buf,
                                           uint8_t  *freqsel,
                                           uint8_t  *vcocap,
                                           bool     *low_band,
+                                          uint8_t  *xb_gpio,
                                           bool     *quick_tune)
 {
     *timestamp  = ( ((uint64_t) buf[NIOS_PKT_RETUNE_IDX_TIME + 0]) <<  0);
@@ -220,6 +222,7 @@ static inline void nios_pkt_retune_unpack(const uint8_t *buf,
     *low_band = (buf[NIOS_PKT_RETUNE_IDX_BANDSEL] & FLAG_LOW_BAND) != 0;
     *quick_tune = (buf[NIOS_PKT_RETUNE_IDX_BANDSEL] & FLAG_QUICK_TUNE) != 0;
     *vcocap = buf[NIOS_PKT_RETUNE_IDX_BANDSEL] & 0x3f;
+    *xb_gpio = buf[NIOS_PKT_RETUNE_IDX_RESV];
 }
 
 

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -1816,6 +1816,7 @@ struct bladerf_quick_tune {
             uint16_t nint;   /**< Integer portion of LO frequency value */
             uint32_t nfrac;  /**< Fractional portion of LO frequency value */
             uint8_t flags;   /**< Flag bits used internally by libbladeRF */
+            uint8_t xb_gpio;   /**< Flag bits used to configure XB */
         };
         /* bladeRF2 quick tune parameters */
         struct {

--- a/host/libraries/libbladeRF/src/backend/backend.h
+++ b/host/libraries/libbladeRF/src/backend/backend.h
@@ -257,6 +257,7 @@ struct backend_fns {
                   uint8_t freqsel,
                   uint8_t vcocap,
                   bool low_band,
+                  uint8_t xb_gpio,
                   bool quick_tune);
 
     /* Schedule a frequency retune2 operation */

--- a/host/libraries/libbladeRF/src/backend/usb/nios_access.c
+++ b/host/libraries/libbladeRF/src/backend/usb/nios_access.c
@@ -1078,7 +1078,7 @@ int nios_expansion_gpio_dir_write(struct bladerf *dev,
 int nios_retune(struct bladerf *dev, bladerf_channel ch,
                 uint64_t timestamp, uint16_t nint, uint32_t nfrac,
                 uint8_t freqsel, uint8_t vcocap, bool low_band,
-                bool quick_tune)
+                uint8_t xb_gpio, bool quick_tune)
 {
     int status;
     uint8_t buf[NIOS_PKT_LEN];
@@ -1096,7 +1096,8 @@ int nios_retune(struct bladerf *dev, bladerf_channel ch,
     }
 
     nios_pkt_retune_pack(buf, ch, timestamp,
-                         nint, nfrac, freqsel, vcocap, low_band, quick_tune);
+                         nint, nfrac, freqsel, vcocap, low_band,
+                         xb_gpio, quick_tune);
 
     status = nios_access(dev, buf);
     if (status != 0) {

--- a/host/libraries/libbladeRF/src/backend/usb/nios_access.h
+++ b/host/libraries/libbladeRF/src/backend/usb/nios_access.h
@@ -480,6 +480,7 @@ int nios_expansion_gpio_dir_write(struct bladerf *dev,
  * @param[in]   nfrac       Fractional portion of frequency multiplier
  * @param[in]   freqsel     VCO and divider selection
  * @param[in]   low_band    High vs low band selection
+ * @param[in]   xb_gpio     XB configuration bits
  * @param[in]   quick_tune  Denotes quick tune should be used instead of
  *                          tuning algorithm
  *
@@ -493,6 +494,7 @@ int nios_retune(struct bladerf *dev,
                 uint8_t freqsel,
                 uint8_t vcocap,
                 bool low_band,
+                uint8_t xb_gpio,
                 bool quick_tune);
 
 /**


### PR DESCRIPTION
This commit uses the reserved field of the pkt_retune NiOS packet to encode
xb_gpio register configuration data.