### PR TITLE
load_sc16q11 python function introduced for multiple channels

### DIFF
--- a/host/misc/python/bin2csv.py
+++ b/host/misc/python/bin2csv.py
@@ -6,37 +6,40 @@
 import csv
 import struct
 import sys
-from   pathlib import Path
+from pathlib import Path
 
-def chunked_read( fobj, chunk_bytes = 4*1024 ):
+
+def chunked_read(fobj, chunk_bytes=4 * 1024):
     while True:
         data = fobj.read(chunk_bytes)
-        if( not data ):
+        if not data:
             break
         else:
             yield data
 
-def bin2csv( binfile = None, csvfile = None, chunk_bytes = 4*1024 ):
+
+def bin2csv(binfile=None, csvfile=None, chunk_bytes=4 * 1024):
     with open(binfile, 'rb') as b:
         with open(csvfile, 'w') as c:
             csvwriter = csv.writer(c, delimiter=',')
             count = 0
-            for data in chunked_read(b, chunk_bytes = chunk_bytes):
+            for data in chunked_read(b, chunk_bytes=chunk_bytes):
                 count += len(data)
                 for i in range(0, len(data), 4):
-                    sig_i, = struct.unpack('<h', data[i:i+2])
-                    sig_q, = struct.unpack('<h', data[i+2:i+4])
-                    csvwriter.writerow( [sig_i, sig_q] )
-    print( "Processed", str(count//2//2), "samples." )
+                    sig_i, = struct.unpack('<h', data[i:i + 2])
+                    sig_q, = struct.unpack('<h', data[i + 2:i + 4])
+                    csvwriter.writerow([sig_i, sig_q])
+    print("Processed", str(count // 2 // 2), "samples.")
 
-if( len(sys.argv) != 3 ):
-    print( "Usage:", sys.argv[0], "in.bin out.csv" )
+
+if len(sys.argv) != 3:
+    print("Usage:", sys.argv[0], "in.bin out.csv")
     sys.exit(-1)
 else:
     binfile = sys.argv[1]
     csvfile = sys.argv[2]
-    if( Path(binfile).is_file() ):
-        bin2csv( binfile, csvfile )
+    if Path(binfile).is_file():
+        bin2csv(binfile, csvfile)
     else:
-        print( "File does not exist:", binfile )
+        print("File does not exist:", binfile)
         sys.exit(-1)

--- a/host/misc/python/csv2bin.py
+++ b/host/misc/python/csv2bin.py
@@ -6,9 +6,10 @@
 import csv
 import struct
 import sys
-from   pathlib import Path
+from pathlib import Path
 
-def csv2bin( csvfile = None, binfile = None ):
+
+def csv2bin(csvfile=None, binfile=None):
     with open(csvfile, 'r') as c:
         with open(binfile, 'wb') as b:
             csvreader = csv.reader(c, delimiter=',')
@@ -16,18 +17,19 @@ def csv2bin( csvfile = None, binfile = None ):
             for row in csvreader:
                 for col in row:
                     # Little endian 16-bit integers (shorts)
-                    b.write( struct.pack("<h", int(col.strip())) )
+                    b.write(struct.pack("<h", int(col.strip())))
                 count += 1
-            print( "Processed", str(count), "samples." )
+            print("Processed", str(count), "samples.")
 
-if( len(sys.argv) != 3 ):
-    print( "Usage:", sys.argv[0], "in.csv out.bin" )
+
+if len(sys.argv) != 3:
+    print("Usage:", sys.argv[0], "in.csv out.bin")
     sys.exit(-1)
 else:
     csvfile = sys.argv[1]
     binfile = sys.argv[2]
-    if( Path(csvfile).is_file() ):
-        csv2bin( csvfile, binfile )
+    if Path(csvfile).is_file():
+        csv2bin(csvfile, binfile)
     else:
-        print( "File does not exist:", csvfile )
+        print("File does not exist:", csvfile)
         sys.exit(-1)

--- a/host/misc/python/load_sc16q11.py
+++ b/host/misc/python/load_sc16q11.py
@@ -1,0 +1,30 @@
+import math
+import numpy as np
+
+
+SC16Q11_DTYPE = np.int16
+
+
+def load_sc16q11(file_name: str, n_channels: int = 1, iq_dtype=np.complex128) -> np.ndarray:
+    """
+    Load SC16Q11 binary file into numpy array
+
+    Args:
+        file_name: file name to a SC16Q11 binary file
+        n_channels: number of channels
+        iq_dtype: dtype for the output IQ samples
+
+    Returns:
+        numpy.ndarray of shape (n_channels, n_iq_samples_per_channel) where n_iq_samples_per_channel
+        is the number of complex iq samples corresponding to each channel
+
+    """
+    with open(file_name, 'rb') as f:
+        samples = np.fromfile(f, dtype=SC16Q11_DTYPE)
+        n_iq_samples_per_channel = math.floor(len(samples) / n_channels / 2)
+        iq = np.empty((n_channels, n_iq_samples_per_channel), dtype=iq_dtype)
+
+        for channel in range(n_channels):
+            iq[channel, :] = (samples[channel + 0::n_channels * 2] + 1j * samples[channel + 1::n_channels * 2]) / 2048.
+
+    return iq

--- a/host/utilities/bladeRF-cli/src/main.c
+++ b/host/utilities/bladeRF-cli/src/main.c
@@ -358,6 +358,8 @@ static int open_device(struct rc_config *rc,
             status = bladerf_get_fpga_size(state->dev, &state->dev_info.fpga_size);
 
             if (status != 0) {
+                fprintf(stderr, "Could not determine FPGA size.\n");
+            } else {
                 if (state->dev_info.fpga_size == BLADERF_FPGA_40KLE ||
                         state->dev_info.fpga_size == BLADERF_FPGA_115KLE) {
                     state->dev_info.is_bladerf_x40_x115 = true;


### PR DESCRIPTION
load_sc16q11 python function introduced to read sc16q11 as a numpy.ndarray. Multiple channels are supported. Additionally other two python files are slightly refactored to better correspond to PEP8 specification. sc16q11 is assumed to store sample for multiple channels in form of pairs such as (for X and Y channels): ``Xi_1, Xq_1, Yi_1, Yq_1, Xi_2, Xq_2, Yi_2, Yq_2, ... Xi_N, Xq_N, Yi_N, Yq_N``