### PR TITLE
libbladeRF: Fix return value in error path

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/common.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/common.c
@@ -153,7 +153,7 @@ bool is_valid_fpga_size(struct bladerf *dev, bladerf_fpga_size fpga, size_t len)
 
     status = dev->board->get_fpga_bytes(dev, &expected);
     if (status < 0) {
-        return status;
+        return false;
     }
 
     /* Provide a means to override this check. This is intended to allow


### PR DESCRIPTION
Returning a negative value from a function with bool as return value
is the same as returning true. Change to false to indicate error.