### PR TITLE
added project() line to CMakeLists.txt to get rid of cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-
+project(bladeRF CXX C)
 # Indicate that this is a top-level build
 set(BLADERF_TOP_LEVEL_BUILD ON)
 


### PR DESCRIPTION
Adding a [cmake project line](https://cmake.org/cmake/help/latest/command/project.html) to CMakeLists.txt gets rid of following error:
I set the name to bladeRF which of course is easily changeable if requested

Cheers!

```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.
```