### PR TITLE
[ConfigFile] Fix parsing of vctcxo_tamer key

### DIFF
--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -211,7 +211,7 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
         }
 
         status = bladerf_dac_write(dev, val);
-    } else if (!strcasecmp(opt.value, "vctcxo_tamer")) {
+    } else if (!strcasecmp(opt.key, "vctcxo_tamer")) {
         if (!strcasecmp(opt.value, "disabled") ||
             !strcasecmp(opt.value, "off")) {
             tamer_mode = BLADERF_VCTCXO_TAMER_DISABLED;


### PR DESCRIPTION
Minor fix parsing the vctcxo_tamer key from the config file.

Unfortunately this key is not supported by BladeRF 2.0 but at least it will make it usable for the original BladeRF.