### PR TITLE
[ConfigFile] Extend keywords to BladeRF2.0 clocking

### DIFF
--- a/host/libraries/libbladeRF/doc/doxygen/configfile.dox
+++ b/host/libraries/libbladeRF/doc/doxygen/configfile.dox
@@ -179,6 +179,36 @@ will be applied more than once; e.g. specifying `frequency 2.4G` and then
         A true value (e.g. `on`) turns the DC bias on, while a false value
         (e.g. `off`) turns the DC bias off.
 
+    <li><b>`clock_ref <bool>`</b></li>
+
+        Enables or disables taming by an external clock reference for
+        BladeRF 2.0 via bladerf_set_pll_enable().
+
+        A true value (e.g. `on`) turns the taming on, while a false value
+        (e.g. `off`) turns the taming off.
+
+    <li><b>`refin_freq <Hz>`</b></li>
+
+        Sets the frequency of the external clock reference for BladeRF 2.0 in Hz
+        via bladerf_set_pll_refclk().
+        Suffixes are supported.
+
+    <li><b>`clock_sel  <onboard|external>`</b></li>
+
+        Selects the 38.4MHz clock source for BladeRF 2.0 via
+        bladerf_set_clock_select().
+
+        Possible values are `onboard` for the internal clock or `external` for
+        and external 38.4MHz clock supplied on the clk_in connector.
+
+    <li><b>`clock_out <bool>`</b></li>
+
+        Enables or disables 38.4MHz clock on the clk_out connector for
+        BladeRF 2.0 via bladerf_set_clock_output().
+
+        A true value (e.g. `on`) turns the clock out on, while a false value
+        (e.g. `off`) turns the clock out off.
+
 </ul>
 
 <h3>Suffixes</h3>

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -211,7 +211,7 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
         }
 
         status = bladerf_dac_write(dev, val);
-    } else if (!strcasecmp(opt.value, "vctcxo_tamer")) {
+    } else if (!strcasecmp(opt.key, "vctcxo_tamer")) {
         if (!strcasecmp(opt.value, "disabled") ||
             !strcasecmp(opt.value, "off")) {
             tamer_mode = BLADERF_VCTCXO_TAMER_DISABLED;

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -263,6 +263,15 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
         }
 
         status = bladerf_set_clock_select(dev, clock_sel);
+    } else if (!strcasecmp(opt.key, "clock_out")) {
+        bool enable = false;
+
+        status = str2bool(opt.value, &enable);
+        if (status != 0) {
+            return BLADERF_ERR_INVAL;
+        }
+
+        status = bladerf_set_clock_output(dev, enable);
     } else {
         log_warning("Invalid key `%s' on line %d\n", opt.key, opt.lineno);
     }

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -237,6 +237,19 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
         }
 
         status = bladerf_set_pll_enable(dev, enable);
+    } else if (!strcasecmp(opt.key, "refin_freq")) {
+        status = bladerf_get_pll_refclk_range(dev, &rx_range);
+        if (status < 0) {
+            return status;
+        }
+
+        freq = str2uint64_suffix(opt.value, rx_range->min, rx_range->max,
+                                 freq_suffixes, NUM_FREQ_SUFFIXES, &ok);
+        if (!ok) {
+            return BLADERF_ERR_INVAL;
+        }
+
+        status = bladerf_set_pll_refclk(dev, freq);
     } else {
         log_warning("Invalid key `%s' on line %d\n", opt.key, opt.lineno);
     }

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -228,6 +228,15 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
         }
 
         status = bladerf_set_vctcxo_tamer_mode(dev, tamer_mode);
+    } else if (!strcasecmp(opt.key, "clock_ref")) {
+        bool enable = false;
+
+        status = str2bool(opt.value, &enable);
+        if (status != 0) {
+            return BLADERF_ERR_INVAL;
+        }
+
+        status = bladerf_set_pll_enable(dev, enable);
     } else {
         log_warning("Invalid key `%s' on line %d\n", opt.key, opt.lineno);
     }

--- a/host/libraries/libbladeRF/src/helpers/configfile.c
+++ b/host/libraries/libbladeRF/src/helpers/configfile.c
@@ -250,6 +250,19 @@ static int apply_config_options(struct bladerf *dev, struct config_options opt)
         }
 
         status = bladerf_set_pll_refclk(dev, freq);
+    } else if (!strcasecmp(opt.key, "clock_sel")) {
+        bladerf_clock_select clock_sel = CLOCK_SELECT_ONBOARD;
+
+        if (!strcasecmp(opt.value, "onboard") ||
+            !strcasecmp(opt.value, "internal")) {
+            clock_sel = CLOCK_SELECT_ONBOARD;
+        } else if (!strcasecmp(opt.value, "external")) {
+            clock_sel =  CLOCK_SELECT_EXTERNAL;
+        } else {
+            return BLADERF_ERR_INVAL;
+        }
+
+        status = bladerf_set_clock_select(dev, clock_sel);
     } else {
         log_warning("Invalid key `%s' on line %d\n", opt.key, opt.lineno);
     }


### PR DESCRIPTION
This PR adds the `clock_ref`, `refin_freq`, `clock_sel` and `clock_out` keywords to the config file to control a BladeRF 2.0's clocking.
It also includes PR #821 which fixes a minor typo.

I also tried to extend the `vctcxo_tamer` keyword to make it work both for BladeRF and BladeRF 2.0, it worked fine for 'disabled' and '10MHz' settings, but the '1 PPS' couldn't be implemented as not within the 5MHz-300MHz ref clock range supported by the 2.0. So it is not part of this PR.