### PR TITLE
Windows and macOS support for installing python bindings

### DIFF
--- a/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
@@ -33,6 +33,8 @@ ffi.cdef(header)
 
 if platform == "win32":
     libbladeRF = ffi.dlopen("bladerf.dll")
+elif platform == "darwin":
+    libbladeRF = ffi.dlopen("libbladeRF.dylib")
 else:
     libbladeRF = ffi.dlopen("libbladeRF.so")
 

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
@@ -24,13 +24,17 @@ import collections
 
 import cffi
 
+from sys import platform
 from ._cdef import header
 
 ffi = cffi.FFI()
 
 ffi.cdef(header)
 
-libbladeRF = ffi.dlopen("libbladeRF.so")
+if platform == "win32":
+    libbladeRF = ffi.dlopen("bladerf.dll")
+else:
+    libbladeRF = ffi.dlopen("libbladeRF.so")
 
 
 ###############################################################################


### PR DESCRIPTION
Currently installing the python bindings crashes on Windows, because it cannot find the library distribution "libbladerf.so" requested at line 33 in ./host/libraries/libbladeRF_bindings/_bladerf.py. When building the Bladerf library on windows the distribution is named "bladerf.dll". I used bladeRF-win-installer-2021.03.exe for installing the library, and after that run `python setup.py install`.

I simply added an operating system check for Windows and changed the name of the library distribution accordingly.

For reference the error message this pull request is meant to fix arises when importing bladerf in python after installation: 
`OSError: cannot load library 'libbladeRF.so': error 0x7e.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libbladeRF.so'`

This error has been reported at the forum: [https://nuand.com/forums/viewtopic.php?t=9409](https://nuand.com/forums/viewtopic.php?t=9409).



