### PR TITLE
Fix broken memcpy

### DIFF
--- a/host/libraries/libbladeRF_test/test_repeater/src/repeater.c
+++ b/host/libraries/libbladeRF_test/test_repeater/src/repeater.c
@@ -112,7 +112,7 @@ static int term_init()
         return status;
     }
 
-    memcpy(&termios_new, &termios_backup, sizeof(termios_new));
+    memcpy(&termios_new, termios_backup, sizeof(termios_new));
 
     termios_new.c_cc[VMIN] = 1;
     termios_new.c_cc[VTIME] = 0;


### PR DESCRIPTION
Code copies data from pointer location instead from pointer target - resulting in invalid copied data and overreading from the pointer pointr position.