### PR TITLE
libbladeRF: Use mutex around stream config/deconfig

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -2034,11 +2034,17 @@ static int bladerf2_stream(struct bladerf_stream *stream,
             return -EINVAL;
     }
 
-    CHECK_STATUS(perform_format_config(stream->dev, dir, stream->format));
+    WITH_MUTEX(&stream->dev->lock, {
+        CHECK_STATUS_LOCKED(
+            perform_format_config(stream->dev, dir, stream->format));
+    });
 
     rv = async_run_stream(stream, layout);
 
-    CHECK_STATUS(perform_format_deconfig(stream->dev, dir));
+    WITH_MUTEX(&stream->dev->lock, {
+        CHECK_STATUS_LOCKED(
+            perform_format_deconfig(stream->dev, dir));
+    });
 
     return rv;
 }


### PR DESCRIPTION
Running test_digital_loopback on bladeRF A4, the TX/RX threads cause timeout in nios_access.c with 'Failed to receive NIOS II response'.

Using libusb backend in docker Ubuntu 22.04 container. bladeRF A4 firmware v0.14.0, bladeRF latest or post release v2021.2. 

To reproduce the timeout issue:
- Run `test_digital_loopback` on bladeRF A4 using firmware "2021-10-04 - v0.14.0", multiple times.

After adding the mutex guards, timeouts did not occur. Looking at bladerf1, it is similar but I did not have the hardware to run tests to confirm if the issue is/was present and if the fix applied here would work.

Some bladeRF issues I came across while looking for a fix that appeared related:
- https://github.com/Nuand/bladeRF/issues/813
- https://github.com/Nuand/bladeRF/issues/849
- https://github.com/BatchDrake/SigDigger/issues/167