### PR TITLE
use file(GLOB) instead of just globbing

### DIFF
--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -540,13 +540,17 @@ if(BUILD_LIBBLADERF_DOCUMENTATION)
 
         set(LOGO_IMAGE "${CMAKE_CURRENT_SOURCE_DIR}/doc/images/logo.png")
 
+        file(GLOB INCLUDE_H ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
+        file(GLOB DOC_DOX ${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/*.dox)
+        file(GLOB DOC_EXAMPLES ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples/*)
+        file(GLOB DOC_IMAGES ${CMAKE_CURRENT_SOURCE_DIR}/doc/images/*)
         set(DOXYGEN_SOURCE_FILES
             ${CMAKE_CURRENT_BINARY_DIR}/doc/doxygen/Doxyfile
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/*.dox
+            ${INCLUDE_H}
+            ${DOC_DOX}
             ${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/layout.xml
-            ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples/*
-            ${CMAKE_CURRENT_SOURCE_DIR}/doc/images/*
+            ${DOC_EXAMPLES}
+            ${DOC_IMAGES}
         )
 
         configure_file(


### PR DESCRIPTION
While *.h works for make, it fails when using ninja.  This fixes the bug using cmake's file(GLOB) as suggested by DarthGandalf in gentoo-dev-help on irc

https://bugs.gentoo.org/800791