### PR TITLE
libbladerf: correctly report num_samples for SC8_Q7 in async api

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1116,7 +1116,7 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
             /* Call user callback requesting more data to transmit */
             next_buffer = stream->cb(
                 stream->dev, stream, &metadata, transfer->buffer,
-                bytes_to_sc16q11(transfer->actual_length), stream->user_data);
+                bytes_to_samples(stream->format, transfer->actual_length), stream->user_data);
         }
 
         if (next_buffer == BLADERF_STREAM_SHUTDOWN) {


### PR DESCRIPTION
The async API has two codepaths for reporting samples to a user-provided callback depending on whether packet metadata is requested. In the path where it is requested, the code correctly uses bytes_to_samples() to report num_samples. In the path where no metadata is requested, the code uses the previously hardcoded call to bytes_to_sc16q11(), which underreports num_samples by half for SC8_Q7 format samples. This appears to have been an oversight, and this patch corrects the non-metadata path to match the metadata path.