### PR TITLE
typo: libbladerf/CMakeLists.txt typo in libusb

### DIFF
--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -121,7 +121,7 @@ if(NOT ENABLE_BACKEND_LIBUSB
    AND NOT ENABLE_BACKEND_DUMMY)
     message(FATAL_ERROR
             "Cannot enable any libbladeRF backends due to missing library support. "
-            "Consider installing lisusb dev package (libusb-1.0-0-dev on Ubuntu). "
+            "Consider installing libusb dev package (libusb-1.0-0-dev on Ubuntu). "
             "No libbladeRF backends are enabled. "
             "Please enable one or more backends." )
 endif()


### PR DESCRIPTION
In `host/libraries/libbladerf/CMakeLists.txt` there was typo in the diagnostic instructing a user to install "libusb" and instead said "lisusb"