### PR TITLE
 default rxtx binary mode configuration reflects bitmode value

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/rx.c
+++ b/host/utilities/bladeRF-cli/src/cmd/rx.c
@@ -517,6 +517,10 @@ static int rx_cmd_config(struct cli_state *s, int argc, char **argv)
         return 0;
     }
 
+    enum rxtx_fmt fmt;
+    fmt = (s->bit_mode_8bit) ? RXTX_FMT_BIN_SC8Q7 : RXTX_FMT_BIN_SC16Q11;
+    rxtx_set_file_format(s->rx, fmt);
+
     for (i = 2; i < argc; i++) {
         status = rxtx_handle_config_param(s, s->rx, argv[0], argv[i], &val);
 

--- a/host/utilities/bladeRF-cli/src/cmd/tx.c
+++ b/host/utilities/bladeRF-cli/src/cmd/tx.c
@@ -576,6 +576,10 @@ static int tx_config(struct cli_state *s, int argc, char **argv)
         return 0;
     }
 
+    enum rxtx_fmt fmt;
+    fmt = (s->bit_mode_8bit) ? RXTX_FMT_BIN_SC8Q7 : RXTX_FMT_BIN_SC16Q11;
+    rxtx_set_file_format(s->tx, fmt);
+
     for (i = 2; i < argc; i++) {
         status = rxtx_handle_config_param(s, s->tx, argv[0], argv[i], &val);
 


### PR DESCRIPTION
Doing:
```
bladeRF> set frequency rx 1575.42M
bladeRF> set bandwidth rx 20M
bladeRF> set samplerate rx 20M
bladeRF> set bitmode 8
bladeRF> rx config file=test_8bits.bin n=1200M timeout=60000
```
Does not set the file format to 8 bits:
```
bladeRF> rx

  State: Idle
  Channels: RX1
  Last error: None
  File: test_8bits.bin
  File format: SC16 Q11, Binary
  # Samples: 1258291200
  # Buffers: 32
  # Samples per buffer: 32768
  # Transfers: 16
  Timeout (ms): 60000
```

That's because the file format is updated inside the `rxtx_str2fmt` function **only** if the `format` option is provided on the `rx config` command. I think it makes sense to use as default SC8Q7 if the user specifies 8 bits instead of the default SC16Q11.

My idea was to update the default mode when the `set bitmode` command is processed, but when looking at how the code is organized I thought this was a better idea. Let me know if you are ok with it or would prefer another approach.

Thanks!


