### PR TITLE
libbladeRF: Return error code instead of asserting in version_check

### DIFF
--- a/host/libraries/libbladeRF/src/helpers/version.c
+++ b/host/libraries/libbladeRF/src/helpers/version.c
@@ -146,11 +146,11 @@ int version_check(const struct version_compat_table *fw_compat_table,
     if (fw_compat == NULL) {
         log_debug("%s is missing FW version compat table entry?\n",
                   __FUNCTION__);
-        assert(!"BUG!");
+        return BLADERF_ERR_UPDATE_FW;
     } else if (fpga_compat == NULL) {
         log_debug("%s is missing FPGA version compat table entry?\n",
                   __FUNCTION__);
-        assert(!"BUG!");
+        return BLADERF_ERR_UPDATE_FPGA;
     }
 
     if (required_fw_version) {


### PR DESCRIPTION
Specifically, when there's a missing compat table entry. All callers specify that they want to be forgiving of version mismatches, so this seems in the spirit of the call tree.

Ran into this error when playing with a custom-loaded FPGA; if I had flashed the FPGA instead of simply loading it, this could have bricked the blade (or at least forced me into a very involved recovery process).