### PR TITLE
Fix compile error with gcc14

### DIFF
--- a/host/utilities/bladeRF-fsk/c/src/fir_filter.c
+++ b/host/utilities/bladeRF-fsk/c/src/fir_filter.c
@@ -213,18 +213,18 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    inbuf = calloc(2*sizeof(int16_t), chunk_size);
+    inbuf = calloc(chunk_size, 2*sizeof(int16_t));
     if (!inbuf) {
         perror("calloc");
         goto out;
     }
-    tempbuf = calloc(2*sizeof(int16_t), chunk_size);
+    tempbuf = calloc(chunk_size, 2*sizeof(int16_t));
     if (!tempbuf) {
         perror("calloc");
         goto out;
     }
 
-    outbuf = calloc(sizeof(struct complex_sample), chunk_size);
+    outbuf = calloc(chunk_size, sizeof(struct complex_sample));
     if (!outbuf) {
         perror("calloc");
         goto out;


### PR DESCRIPTION
This fixes a compile error with gcc14:
.../host/utilities/bladeRF-fsk/c/src/fir_filter.c:227:28: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  227 |     outbuf = calloc(sizeof(struct complex_sample), chunk_size);

because the arguments of some callocs are inverted..


This fixes [!972](https://github.com/Nuand/bladeRF/issues/972)