### PR TITLE
Udev rules update

### DIFF
--- a/host/misc/udev/60-nuand-bladerf1.rules.in
+++ b/host/misc/udev/60-nuand-bladerf1.rules.in
@@ -1,5 +1,5 @@
 # Nuand bladeRF
-ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5246", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"
+SUBSYSTEM=="usb", ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5246", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"
 
 # Nuand bladeRF, legacy VID/PID
-ATTR{idVendor}=="1d50", ATTR{idProduct}=="6066", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6066", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"

--- a/host/misc/udev/60-nuand-bladerf1.rules.in
+++ b/host/misc/udev/60-nuand-bladerf1.rules.in
@@ -1,0 +1,5 @@
+# Nuand bladeRF
+ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5246", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"
+
+# Nuand bladeRF, legacy VID/PID
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="6066", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"

--- a/host/misc/udev/60-nuand-bladerf2.rules.in
+++ b/host/misc/udev/60-nuand-bladerf2.rules.in
@@ -1,0 +1,2 @@
+# Nuand bladeRF 2.0 micro
+ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5250", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"

--- a/host/misc/udev/60-nuand-bladerf2.rules.in
+++ b/host/misc/udev/60-nuand-bladerf2.rules.in
@@ -1,2 +1,2 @@
 # Nuand bladeRF 2.0 micro
-ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5250", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"
+SUBSYSTEM=="usb", ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5250", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"

--- a/host/misc/udev/60-nuand-bootloader.rules.in
+++ b/host/misc/udev/60-nuand-bootloader.rules.in
@@ -1,2 +1,2 @@
 # Cypress FX3 Bootloader, used by bladeRF in recovery mode
-ATTR{idVendor}=="04b4", ATTR{idProduct}=="00f3", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="00f3", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"

--- a/host/misc/udev/60-nuand-bootloader.rules.in
+++ b/host/misc/udev/60-nuand-bootloader.rules.in
@@ -1,0 +1,2 @@
+# Cypress FX3 Bootloader, used by bladeRF in recovery mode
+ATTR{idVendor}=="04b4", ATTR{idProduct}=="00f3", MODE="660", GROUP="@BLADERF_GROUP@", ENV{ID_SOFTWARE_RADIO}="1"

--- a/host/misc/udev/88-nuand-bladerf1.rules.in
+++ b/host/misc/udev/88-nuand-bladerf1.rules.in
@@ -1,5 +1,0 @@
-# Nuand bladeRF
-ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5246", MODE="660", GROUP="@BLADERF_GROUP@"
-
-# Nuand bladeRF, legacy VID/PID
-ATTR{idVendor}=="1d50", ATTR{idProduct}=="6066", MODE="660", GROUP="@BLADERF_GROUP@"

--- a/host/misc/udev/88-nuand-bladerf2.rules.in
+++ b/host/misc/udev/88-nuand-bladerf2.rules.in
@@ -1,2 +1,0 @@
-# Nuand bladeRF 2.0 micro
-ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5250", MODE="660", GROUP="@BLADERF_GROUP@"

--- a/host/misc/udev/88-nuand-bootloader.rules.in
+++ b/host/misc/udev/88-nuand-bootloader.rules.in
@@ -1,2 +1,0 @@
-# Cypress FX3 Bootloader, used by bladeRF in recovery mode
-ATTR{idVendor}=="04b4", ATTR{idProduct}=="00f3", MODE="660", GROUP="@BLADERF_GROUP@"

--- a/host/misc/udev/CMakeLists.txt
+++ b/host/misc/udev/CMakeLists.txt
@@ -22,9 +22,9 @@ set(UDEV_RULES_PATH
 set(BLADERF_GROUP "plugdev" CACHE STRING "Group to associate bladeRF devices with in udev rules")
 
 set(BLADERF_UDEV_FILES
-    88-nuand-bladerf1.rules
-    88-nuand-bladerf2.rules
-    88-nuand-bootloader.rules
+    60-nuand-bladerf1.rules
+    60-nuand-bladerf2.rules
+    60-nuand-bootloader.rules
 )
 
 if(SYSTEM_IS_LINUX)


### PR DESCRIPTION
Hello,

This PR updates the udev rules. With recent systemd systems there is no need to be in the plugdev group anymore as long as you are the locally logged in user.

For this to work
- i added the `ENV{ID_SOFTWARE_RADIO}="1"` tag
- i had to rename the rules form `88-nuand-xxx` to `60-nuand-xxx` for the tag to be honored
This way the systemd build-in mechanism will automatically grant the rights to the locally logged in user. This won't harm on older system not supporting this.

I also restricted the rules to the `usb` SUBSYSTEM to prevent potential id collisions.