### PR TITLE
fir_filter: fix transposed calloc args

### DIFF
--- a/host/utilities/bladeRF-fsk/c/src/fir_filter.c
+++ b/host/utilities/bladeRF-fsk/c/src/fir_filter.c
@@ -213,18 +213,18 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    inbuf = calloc(2*sizeof(int16_t), chunk_size);
+    inbuf = calloc(chunk_size, 2*sizeof(int16_t));
     if (!inbuf) {
         perror("calloc");
         goto out;
     }
-    tempbuf = calloc(2*sizeof(int16_t), chunk_size);
+    tempbuf = calloc(chunk_size, 2*sizeof(int16_t));
     if (!tempbuf) {
         perror("calloc");
         goto out;
     }
 
-    outbuf = calloc(sizeof(struct complex_sample), chunk_size);
+    outbuf = calloc(chunk_size, sizeof(struct complex_sample));
     if (!outbuf) {
         perror("calloc");
         goto out;


### PR DESCRIPTION
fix build for gcc-14

> host/utilities/bladeRF-fsk/c/src/fir_filter.c:227:28:
error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument 
  227 |     outbuf = calloc(sizeof(struct complex_sample), chunk_size);

https://cache.nixos.org/log/hsg1v3cl1hk9ca77rgkng6n6dabz1bi3-libbladeRF-2.5.0.drv