### PR TITLE
gcc 14.2.1 flags calloc error and aborts

### DIFF
--- a/host/utilities/bladeRF-fsk/c/src/fir_filter.c
+++ b/host/utilities/bladeRF-fsk/c/src/fir_filter.c
@@ -213,18 +213,18 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    inbuf = calloc(2*sizeof(int16_t), chunk_size);
+    inbuf = calloc(chunk_size, 2*sizeof(int16_t));
     if (!inbuf) {
         perror("calloc");
         goto out;
     }
-    tempbuf = calloc(2*sizeof(int16_t), chunk_size);
+    tempbuf = calloc(chunk_size, 2*sizeof(int16_t));
     if (!tempbuf) {
         perror("calloc");
         goto out;
     }
 
-    outbuf = calloc(sizeof(struct complex_sample), chunk_size);
+    outbuf = calloc(chunk_size, sizeof(struct complex_sample));
     if (!outbuf) {
         perror("calloc");
         goto out;


### PR DESCRIPTION
(from the commit comment)
gcc 14.2.1, shipping with fedora 40, complains about
 `   
    calloc(sizeof(foo), count)
`
since the definition of calloc calls for the count argument to be first and the datawidget argument to be second.  Like it or not, the difference causes gcc to error-out.

This change makes it possible to build under Fedora 40 and later.
 
I am unable to test this at runtime, so this change should be viewed with caution. But the modification should be benign to less finicky compilers, and is necessary for gcc 14.2.1 (and likely, beyond).
