### PR TITLE
flash_image.c: fix `clang` build

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/flash_image.c
+++ b/host/utilities/bladeRF-cli/src/cmd/flash_image.c
@@ -68,7 +68,7 @@ static int handle_param(const char *param, char *val,
             status = CLI_RET_INVPARAM;
         } else {
             for (i = 0; i < len && status == 0; i++) {
-                if (val[i] >= 'a' || val[i] <= 'f') {
+                if (val[i] >= 'a' && val[i] <= 'f') {
                     val[i] -= 'a' - 'A';
                 } else if (!((val[i] >= '0' && val[i] <= '9') ||
                              (val[i] >= 'A' && val[i] <= 'F'))) {


### PR DESCRIPTION
Without the change the build fails on `clang as:

    /build/bladeRF/host/utilities/bladeRF-cli/src/cmd/flash_image.c:71:35:
      error: overlapping comparisons always evaluate to true [-Werror,-Wtautological-overlap-compare]
       71 |                 if (val[i] >= 'a' || val[i] <= 'f') {
          |                     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

I think it flags real error. Let's use `&&` to catch the range.