### PR TITLE
libbladeRF: fix spurious timeout warnings in USB event loop

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1393,7 +1393,8 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
     while (stream->state != STREAM_DONE) {
         status = libusb_handle_events_timeout(lusb->context, &tv);
 
-        if (status < 0 && status != LIBUSB_ERROR_INTERRUPTED) {
+        if (status < 0 && status != LIBUSB_ERROR_INTERRUPTED &&
+            status != LIBUSB_ERROR_TIMEOUT) {
             log_warning("unexpected value from events processing: "
                         "%d: %s\n", status, libusb_error_name(status));
             status = error_conv(status);


### PR DESCRIPTION
libusb_handle_events_timeout() legitimately returns LIBUSB_ERROR_TIMEOUT when no events occur within the timeout period. This is expected behavior, not an error condition worth warning about.

FreeBSD's libusb implementation correctly returns this value per the API specification, causing spurious log warnings during normal streaming.