### PR TITLE
Fix bladeRF-cli default binary format

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/rxtx.c
+++ b/host/utilities/bladeRF-cli/src/cmd/rxtx.c
@@ -504,6 +504,9 @@ int rxtx_handle_config_param(struct cli_state *s,
         return CLI_RET_MEM;
     }
 
+    /* Default is bin, update the sample size in case no format=bin configuration is indicated */
+    rxtx_set_file_format(rxtx, (s->sample_format == BLADERF_FORMAT_SC8_Q7) ? RXTX_FMT_BIN_SC8Q7 : RXTX_FMT_BIN_SC16Q11);
+
     *val = strchr(param, '=');
 
     if (!*val || strlen(&(*val)[1]) < 1) {


### PR DESCRIPTION
Doing:
```
bladeRF> set bitmode 8
bladeRF> rx config file=test_8bits.bin n=0
```
Does not configure the recording as 8 bits. That's because the file format is updated inside the `rxtx_str2fmt` function **only** if the _format_ option is provided on the rx/tx config command.

But _format=bin_ is already the default, so the user might not specify it. I think it makes sense to use SC8Q7 as the default if the user specifies 8 bits, rather than defaulting to SC16Q11.

I think it makes more sense to change it when the user specifies the command _set bitmode_, but that requires importing some extra headers in printset_impl, and I wasn't sure if that is something you want.