### PR TITLE
Fix posix_cond_timedwait return value

### DIFF
--- a/host/common/include/thread.h
+++ b/host/common/include/thread.h
@@ -116,7 +116,7 @@ static inline int posix_cond_timedwait(pthread_cond_t *c,
         ts.tv_sec++;
         ts.tv_nsec -= 1000000000;
     }
-    return pthread_cond_timedwait(c, m, &ts) == ETIMEDOUT ? -1 : 0;
+    return pthread_cond_timedwait(c, m, &ts);
 }
 #define COND_TIMED_WAIT(c, m, t) posix_cond_timedwait(c, m, t)
 


### PR DESCRIPTION
When using the bladeRF-cli I saw that the _tx/rx wait Xs_ command was not returning.

After further inspection, I believe it is because `posix_cond_timedwait()` is returning -1 instead of `ETIMEDOUT`.

In the bladeRF-cli code, the comparison is done with `THREAD_TIMEOUT`, which is mapped to `ETIMEDOUT`.

At a quick look, I have not seen any part of the codebase where the comparison is with -1 instead of  `THREAD_TIMEOUT `or similar. I might be wrong, then the change should be in the bladeRF-cli code to compare with -1.

#1025