### PR TITLE
fixed conditional logic issue causing build failure in clang

### DIFF
--- a/host/utilities/bladeRF-cli/src/cmd/flash_image.c
+++ b/host/utilities/bladeRF-cli/src/cmd/flash_image.c
@@ -68,7 +68,7 @@ static int handle_param(const char *param, char *val,
             status = CLI_RET_INVPARAM;
         } else {
             for (i = 0; i < len && status == 0; i++) {
-                if (val[i] >= 'a' || val[i] <= 'f') {
+                if ('a' <= val[i] && val[i] <= 'f') {
                     val[i] -= 'a' - 'A';
                 } else if (!((val[i] >= '0' && val[i] <= '9') ||
                              (val[i] >= 'A' && val[i] <= 'F'))) {


### PR DESCRIPTION
Fixes a build failure in clang with the flash_image utility that was caused by a logic bug always evaluating to true.