### PR TITLE
libbladeRF: unlock the device mutex on the 8-bit format error path

### DIFF
--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -1117,6 +1117,7 @@ int bladerf_init_stream(struct bladerf_stream **stream,
     if (format == BLADERF_FORMAT_SC8_Q7 || format == BLADERF_FORMAT_SC8_Q7_META) {
         if (strcmp(bladerf_get_board_name(dev), "bladerf2") != 0) {
             log_error("bladeRF 2.0 required for 8bit format\n");
+            MUTEX_UNLOCK(&dev->lock);
             return BLADERF_ERR_UNSUPPORTED;
         }
     }
@@ -1216,6 +1217,7 @@ int bladerf_sync_config(struct bladerf *dev,
     if (format == BLADERF_FORMAT_SC8_Q7 || format == BLADERF_FORMAT_SC8_Q7_META) {
         if (strcmp(bladerf_get_board_name(dev), "bladerf2") != 0) {
             log_error("bladeRF 2.0 required for 8bit format\n");
+            MUTEX_UNLOCK(&dev->lock);
             return BLADERF_ERR_UNSUPPORTED;
         }
     }


### PR DESCRIPTION
bladerf_sync_config() and bladerf_init_stream() take dev->lock, then return BLADERF_ERR_UNSUPPORTED without releasing it when an SC8_Q7 format is requested on a bladeRF1.

The device is left locked, so every subsequent API call on that handle blocks forever. The caller sees a hang rather than the error that was actually returned.

Both call sites are in `bladerf.c`; the fix adds the missing `MUTEX_UNLOCK` before each early return.

Found while auditing the 2.6.0 changes against a bladeRF 2.0 micro xA4.