### PR TITLE
libbladeRF: fix buffer overflows and a missing NULL check in gain calibration

### DIFF
--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -2234,6 +2234,12 @@ int bladerf_load_gain_calibration(struct bladerf *dev, bladerf_channel ch, const
     }
 
     if (cal_file_loc != NULL) {
+        if (strlen(cal_file_loc) >= filename_len) {
+            log_error("Gain calibration path is too long (%zu >= %zu)\n",
+                      strlen(cal_file_loc), filename_len);
+            status = BLADERF_ERR_INVAL;
+            goto error;
+        }
         strcpy(filename, cal_file_loc);
     } else {
         log_debug("No calibration file specified, using serial number\n");
@@ -2256,6 +2262,10 @@ int bladerf_load_gain_calibration(struct bladerf *dev, bladerf_channel ch, const
 
     /** Convert to binary format if CSV */
     full_path_bin = (char*)malloc(strlen(full_path) + 1);
+    if (full_path_bin == NULL) {
+        status = BLADERF_ERR_MEM;
+        goto error;
+    }
     strcpy(full_path_bin, full_path);
     ext = strstr(full_path_bin, ".csv");
     if (ext) {

--- a/host/libraries/libbladeRF/src/device_calibration.c
+++ b/host/libraries/libbladeRF/src/device_calibration.c
@@ -115,9 +115,13 @@ int gain_cal_csv_to_bin(struct bladerf *dev, const char *csv_path, const char *b
     if (!csvFile || !binaryFile) {
         status = BLADERF_ERR_NO_FILE;
         if (getcwd(current_dir, sizeof(current_dir)) != NULL) {
-            log_error("Error opening calibration file: %s\n", strcat(current_dir, csv_path));
+            /* strcat() here appends a caller-supplied path of arbitrary
+             * length to a buffer already holding the working directory,
+             * overflowing it for long paths. Print the two parts instead. */
+            log_error("Error opening calibration file: %s/%s\n",
+                      current_dir, csv_path);
         } else {
-            log_error("Error opening calibration file\n");
+            log_error("Error opening calibration file: %s\n", csv_path);
         }
         goto error;
     }


### PR DESCRIPTION
Three issues in the gain calibration paths added in 2.6.0, all reachable through `bladerf_load_gain_calibration()` with a caller-controlled path:

**`device_calibration.c`** — `strcat()` appends a caller-supplied CSV path of arbitrary length to a 1000-byte buffer that already holds the working directory. Long paths overflow the stack buffer. Fixed by printing both parts with a format specifier instead of concatenating in place.

**`bladerf.c`** — `strcpy()` copies a caller-supplied calibration path into a `PATH_MAX` buffer without a length check. Fixed by rejecting paths that do not fit.

**`bladerf.c`** — `malloc()` result passed to `strcpy()` without a NULL check.

Found while auditing the 2.6.0 changes against a bladeRF 2.0 micro xA4.