### PR TITLE
libbladeRF: reject stream configs that exceed the usbfs memory budget

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -2764,6 +2764,14 @@ int CALL_CONV bladerf_get_timestamp(struct bladerf *dev,
  * @param[in]   num_transfers   The number of active USB transfers that may be
  *                              in-flight at any given time. If unsure of what
  *                              to use here, try values of 4, 8, or 16.
+ *
+ *                              Each in-flight transfer is pinned by the
+ *                              kernel, so `num_transfers * buffer_size` must
+ *                              fit within the usbfs memory limit (16 MiB by
+ *                              default on Linux, see
+ *                              /sys/module/usbcore/parameters/usbfs_memory_mb).
+ *                              Configurations that exceed it are rejected
+ *                              with ::BLADERF_ERR_INVAL.
  * @param[in]   stream_timeout  Timeout (milliseconds) for transfers in the
  *                              underlying data stream.
  *

--- a/host/libraries/libbladeRF/src/streaming/async.c
+++ b/host/libraries/libbladeRF/src/streaming/async.c
@@ -32,6 +32,56 @@
 #include "helpers/timeout.h"
 #include "helpers/have_cap.h"
 
+/* Kernel default for /sys/module/usbcore/parameters/usbfs_memory_mb.
+ * Used when the sysfs entry cannot be read (non-Linux, restricted /sys). */
+#define USBFS_MEMORY_MB_DEFAULT 16
+
+/* Reserve part of the budget for other users of the bus: the limit is
+ * per-host, not per-device, and a bladeRF is rarely alone on it. */
+#define USBFS_BUDGET_FRACTION 0.9
+
+/**
+ * Verify that a stream configuration fits in the kernel's usbfs memory
+ * budget. Each in-flight transfer is pinned for its lifetime, so a stream
+ * needs num_transfers * buffer_size_bytes of it simultaneously.
+ *
+ * @return 0 if the configuration fits, BLADERF_ERR_INVAL otherwise.
+ */
+static int usbfs_budget_check(size_t num_transfers, size_t buffer_size_bytes)
+{
+    size_t limit_mb = USBFS_MEMORY_MB_DEFAULT;
+    size_t needed, budget;
+
+#if BLADERF_OS_LINUX
+    FILE *f = fopen("/sys/module/usbcore/parameters/usbfs_memory_mb", "r");
+    if (f != NULL) {
+        unsigned int v = 0;
+        if (fscanf(f, "%u", &v) == 1 && v > 0) {
+            limit_mb = v;
+        }
+        fclose(f);
+    }
+#endif
+
+    needed = num_transfers * buffer_size_bytes;
+    budget = (size_t)(limit_mb * 1024 * 1024 * USBFS_BUDGET_FRACTION);
+
+    if (needed > budget) {
+        size_t max_transfers = budget / buffer_size_bytes;
+
+        log_error("Stream needs %zu MiB of in-flight USB buffers "
+                  "(%zu transfers x %zu bytes), but usbfs_memory_mb is %zu. "
+                  "Use at most %zu transfers, or raise the limit with "
+                  "'echo <MiB> > /sys/module/usbcore/parameters/"
+                  "usbfs_memory_mb'.\n",
+                  needed / (1024 * 1024), num_transfers, buffer_size_bytes,
+                  limit_mb, max_transfers);
+        return BLADERF_ERR_INVAL;
+    }
+
+    return 0;
+}
+
 int async_init_stream(struct bladerf_stream **stream,
                       struct bladerf *dev,
                       bladerf_stream_cb callback,
@@ -75,6 +125,20 @@ int async_init_stream(struct bladerf_stream **stream,
         log_error("Samples_per_buffer must be multiples of %u\n",
                   bytes_to_samples(format, gpif_buffer_size));
         return BLADERF_ERR_INVAL;
+    }
+
+    /* Reject configurations that cannot fit in the kernel's usbfs memory
+     * budget. Every in-flight transfer is pinned by the kernel, so the
+     * stream needs num_transfers * buffer_size_bytes available at once.
+     *
+     * Without this check the failure is reported far from its cause:
+     * bladerf_sync_config() succeeds, submit_transfer() then fails
+     * asynchronously with LIBUSB_ERROR_NO_MEM, and the caller only sees
+     * BLADERF_ERR_MEM from the first bladerf_sync_rx().
+     */
+    status = usbfs_budget_check(num_transfers, buffer_size_bytes);
+    if (status != 0) {
+        return status;
     }
 
     /* Create a stream and populate it with the appropriate information */


### PR DESCRIPTION
Every in-flight USB transfer is pinned by the kernel, so a stream needs `num_transfers * buffer_size_bytes` of usbfs memory simultaneously. The default limit is 16 MiB.

Exceeding it fails far from its cause: `bladerf_sync_config()` returns success, `submit_transfer()` then fails asynchronously with `LIBUSB_ERROR_NO_MEM`, and the caller only sees `BLADERF_ERR_MEM` from the first `bladerf_sync_rx()` — with nothing pointing at the transfer count.

Measured on a bladeRF 2.0 micro xA4 (FX3 2.6.0, FPGA 0.16.0), `SC16_Q11_META` at 61.44 Msps with `buffer_size=131072` samples:

```
num_transfers=31  ->  ok
num_transfers=32  ->  ERR_MEM from the first sync_rx
```

32 × 512 KiB is exactly the 16 MiB limit. The larger GPIF buffers in FX3 2.6.0 make this much easier to hit than before.

The check runs in `async_init_stream()` and returns `BLADERF_ERR_INVAL` with the numbers and the maximum transfer count that fits:

```
Stream needs 16 MiB of in-flight USB buffers (32 transfers x 524288 bytes),
but usbfs_memory_mb is 16. Use at most 28 transfers, or raise the limit with
'echo <MiB> > /sys/module/usbcore/parameters/usbfs_memory_mb'.
```

The limit is read from sysfs on Linux and falls back to the kernel default of 16 MiB elsewhere. A second commit documents the constraint on the `num_transfers` parameter.