### PR TITLE
libbladeRF: report RX overruns and leading discontinuities to sync_rx callers

### DIFF
--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -305,6 +305,8 @@ int sync_init(struct bladerf_sync *sync,
 
             sync->meta.msg_timestamp = 0;
             sync->meta.msg_flags = 0;
+            sync->meta.have_timestamp = false;
+            sync->buf_mgmt.overrun_pending = false;
 
             sync_reset_sequence_tracking(&sync->buf_mgmt, num_transfers);
 
@@ -516,11 +518,22 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
         } else {
             user_meta->status = 0;
             target_timestamp = user_meta->timestamp;
+
+            /* Report an overrun the worker recovered from. Its recovery
+             * resubmits buffers, so the gap is not visible in the message
+             * timestamps this call will see. */
+            MUTEX_LOCK(&s->buf_mgmt.lock);
+            if (s->buf_mgmt.overrun_pending) {
+                user_meta->status |= BLADERF_META_STATUS_OVERRUN;
+                s->buf_mgmt.overrun_pending = false;
+            }
+            MUTEX_UNLOCK(&s->buf_mgmt.lock);
         }
     }
 
     b = &s->buf_mgmt;
     samples_per_buffer = s->stream_config.samples_per_buffer;
+    log_verbose("%s: stream format=%d state=%d\n", __FUNCTION__, (int)s->stream_config.format, (int)s->state);
 
     log_verbose("%s: Requests %u samples.\n", __FUNCTION__, num_samples);
 
@@ -562,6 +575,9 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                  * transfers, so the consumer index must be reset to 0 */
                 b->cons_i = 0;
                 MUTEX_UNLOCK(&b->lock);
+                /* The restarted stream begins a fresh timestamp sequence, so
+                 * its first header must not be reported as a discontinuity. */
+                s->meta.have_timestamp = false;
                 log_debug("%s: Reset buf_mgmt consumer index\n", __FUNCTION__);
                 s->state = SYNC_STATE_START_WORKER;
                 break;
@@ -638,6 +654,7 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                         assert(!"Invalid stream format");
                         status = BLADERF_ERR_UNEXPECTED;
                 }
+                log_verbose("%s: BUFFER_READY -> state=%d (format=%d)\n", __FUNCTION__, (int)s->state, (int)s->stream_config.format);
 
                 MUTEX_UNLOCK(&b->lock);
                 break;
@@ -716,13 +733,23 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
 
                         s->meta.curr_msg_off = 0;
 
-                        /* We've encountered a discontinuity and need to return
-                         * what we have so far, setting the status flags */
-                        if (copied_data &&
+                        /* We've encountered a discontinuity. Report it via
+                         * the status flags whether or not samples have been
+                         * copied yet: a gap that lands on the first message
+                         * of a read is still a gap, and the caller has no
+                         * other way to learn about it.
+                         *
+                         * Only the early return is conditional. With data
+                         * already copied we must hand it back before the
+                         * discontinuity; with none copied there is nothing
+                         * to preserve, so the read continues and returns
+                         * contiguous samples that start after the gap.
+                         */
+                        if (s->meta.have_timestamp &&
                             s->meta.msg_timestamp != s->meta.curr_timestamp) {
 
                             user_meta->status |= BLADERF_META_STATUS_OVERRUN;
-                            exit_early = true;
+                            exit_early = copied_data;
                             log_debug("Sample discontinuity detected @ "
                                       "buffer %u, message %u: Expected t=%llu, "
                                       "got t=%llu\n",
@@ -739,6 +766,7 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                         }
 
                         s->meta.curr_timestamp = s->meta.msg_timestamp;
+                        s->meta.have_timestamp = true;
                         s->meta.state = SYNC_META_STATE_SAMPLES;
                         break;
 

--- a/host/libraries/libbladeRF/src/streaming/sync.h
+++ b/host/libraries/libbladeRF/src/streaming/sync.h
@@ -92,6 +92,12 @@ struct buffer_mgmt {
      * resubmission */
     unsigned int resubmit_count;
 
+    /* Set by the RX worker when it detects an overrun, cleared once the
+     * condition has been reported to a bladerf_sync_rx() caller. The worker
+     * recovers by resubmitting buffers, so the sample stream has a gap that
+     * is otherwise invisible to the caller. */
+    bool overrun_pending;
+
     /* Applicable to TX only. Denotes which context is responsible for
      * submitting full buffers to the underlying async system */
     sync_tx_submitter submitter;
@@ -172,6 +178,11 @@ typedef enum {
 
 struct sync_meta {
     sync_meta_state state; /* State of metadata processing */
+
+    bool have_timestamp;   /* curr_timestamp holds a value read from a
+                            * message header. Until then there is nothing to
+                            * compare against, so the first header of a
+                            * stream must not be treated as a discontinuity. */
 
     uint8_t *curr_msg;            /* Points to current message in the buffer */
     size_t curr_msg_off;          /* Offset into current message (samples),

--- a/host/libraries/libbladeRF/src/streaming/sync_worker.c
+++ b/host/libraries/libbladeRF/src/streaming/sync_worker.c
@@ -219,8 +219,12 @@ static void *rx_callback(struct bladerf *dev,
                 log_verbose("%s worker: delaying submission while reorder "
                             "queue drains\n", worker2str(s));
             } else {
-                /* TODO propagate back the RX Overrun to the sync_rx() caller */
                 log_debug("RX overrun @ buffer %u\r\n", samples_idx);
+
+                /* Recovery resubmits buffers, which leaves a gap in the
+                 * sample stream. Record it so the next bladerf_sync_rx()
+                 * can report BLADERF_META_STATUS_OVERRUN to the caller. */
+                b->overrun_pending = true;
 
                 next_buf = samples;
                 b->resubmit_count = s->stream_config.num_xfers - 1;


### PR DESCRIPTION
Two ways an RX gap could reach the caller unreported.

**The worker's overrun recovery.** `sync_worker.c` carried a TODO for this: on overrun it resubmits buffers and logs, but nothing propagates the condition. Because recovery restarts the timestamp sequence, the gap is not visible in the message headers either — so `bladerf_sync_rx()` returns samples that are not contiguous with the previous call, and reports success.

Adds `buf_mgmt.overrun_pending`, set by the worker and consumed by the next `sync_rx()`, which now raises `BLADERF_META_STATUS_OVERRUN`.

**A discontinuity landing on the first message of a read.** The check in `sync_rx()` required `copied_data`, so only gaps found mid-read were flagged; a gap at the start was silently skipped. The status flag is now raised regardless, while the early return stays conditional: with data already copied it must be handed back before the gap, with none copied the read continues past it.

The first header of a stream has nothing to compare against, so `meta.have_timestamp` distinguishes it from a real discontinuity. It is cleared on init and whenever the stream restarts.

Measured on a bladeRF 2.0 micro xA4 (FX3 2.6.0, FPGA 0.16.0), `SC16_Q11_META` at 61.44 Msps, host stalled 400 ms between reads to force overruns:

```
before:   driver logged 141 overruns, meta.status stayed 0x0
after:    2 of 6 reads report BLADERF_META_STATUS_OVERRUN
no stall: 0 of 15 reads report it, driver logs none
```

Related to #801, which describes the same flag never reaching the caller.