### PR TITLE
bladerf2: wrap quick tune profile indices instead of running out

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1439,19 +1439,34 @@ static int bladerf2_get_quick_tune(struct bladerf *dev,
     pm = _get_band_port_map_by_freq(ch, freq);
 
     if (BLADERF_CHANNEL_IS_TX(ch)) {
-        if (board_data->quick_tune_tx_profile < NUM_BBP_FASTLOCK_PROFILES) {
-            /* Assign Nios and RFFE profile numbers */
-            quick_tune->nios_profile = board_data->quick_tune_tx_profile++;
-            log_verbose("Quick tune assigned Nios TX fast lock index: %u\n",
-                        quick_tune->nios_profile);
-            quick_tune->rffe_profile =
-                quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
-            log_verbose("Quick tune assigned RFFE TX fast lock index: %u\n",
-                        quick_tune->rffe_profile);
-        } else {
-            log_error("Reached maximum number of TX quick tune profiles.");
-            return BLADERF_ERR_UNEXPECTED;
-        }
+        /* Profile indices wrap instead of running out.
+         *
+         * The counter only ever incremented, and was reset in exactly one
+         * place: board initialisation. An application that keeps asking for
+         * quick tunes therefore had a hard budget of 256 for the lifetime of
+         * the device handle, after which every further call failed with
+         * BLADERF_ERR_UNEXPECTED and no way to recover short of reopening.
+         *
+         * That budget is not a hardware limit on how many retune targets may
+         * exist over time. The RFIC holds NUM_RFFE_FASTLOCK_PROFILES slots
+         * and the Nios holds NUM_BBP_FASTLOCK_PROFILES; both are caches that
+         * the code already overwrites - the RFFE index is assigned modulo the
+         * slot count, so profile 8 has always overwritten profile 0. Letting
+         * the Nios index wrap in the same way makes the two consistent and
+         * keeps a long-running sweep working.
+         *
+         * Measured on a bladeRF 2.0 micro xA4 sweeping 70 MHz - 6 GHz with
+         * 4700 stops: the counter reached 256 after roughly 165-229 s and
+         * every subsequent retune to a new frequency failed.
+         */
+        quick_tune->nios_profile =
+            board_data->quick_tune_tx_profile++ % NUM_BBP_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned Nios TX fast lock index: %u\n",
+                    quick_tune->nios_profile);
+        quick_tune->rffe_profile =
+            quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned RFFE TX fast lock index: %u\n",
+                    quick_tune->rffe_profile);
 
         /* Create a fast lock profile in the RFIC */
         CHECK_STATUS(
@@ -1468,19 +1483,15 @@ static int bladerf2_get_quick_tune(struct bladerf *dev,
         quick_tune->spdt = (pm->spdt << 6) | (pm->spdt << 4);
 
     } else {
-        if (board_data->quick_tune_rx_profile < NUM_BBP_FASTLOCK_PROFILES) {
-            /* Assign Nios and RFFE profile numbers */
-            quick_tune->nios_profile = board_data->quick_tune_rx_profile++;
-            log_verbose("Quick tune assigned Nios RX fast lock index: %u\n",
-                        quick_tune->nios_profile);
-            quick_tune->rffe_profile =
-                quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
-            log_verbose("Quick tune assigned RFFE RX fast lock index: %u\n",
-                        quick_tune->rffe_profile);
-        } else {
-            log_error("Reached maximum number of RX quick tune profiles.");
-            return BLADERF_ERR_UNEXPECTED;
-        }
+        /* Profile indices wrap instead of running out; see the TX branch. */
+        quick_tune->nios_profile =
+            board_data->quick_tune_rx_profile++ % NUM_BBP_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned Nios RX fast lock index: %u\n",
+                    quick_tune->nios_profile);
+        quick_tune->rffe_profile =
+            quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned RFFE RX fast lock index: %u\n",
+                    quick_tune->rffe_profile);
 
         /* Create a fast lock profile in the RFIC */
         CHECK_STATUS(


### PR DESCRIPTION
## Problem

The Nios quick tune profile counter (`quick_tune_rx_profile` / `quick_tune_tx_profile`) only ever increments, and is reset in exactly one place: board initialisation. An application that keeps requesting quick tunes therefore has a hard budget of `NUM_BBP_FASTLOCK_PROFILES` (256) for the lifetime of the device handle.

Past that, every further `bladerf_get_quick_tune()` fails:

```
[ERROR] Reached maximum number of RX quick tune profiles.
```

and returns `BLADERF_ERR_UNEXPECTED`, with no way to recover short of closing and reopening the device.

This is easy to hit with a wideband sweep that takes a profile on first visit to each stop: 4700 distinct stops over 70 MHz – 6 GHz exhausts the budget within the first few minutes of operation.

## Why wrapping is the right fix

The 256 budget is not a hardware limit on how many retune targets may exist over time. Both the RFIC and the Nios hold caches that this code already overwrites — the RFFE index is assigned modulo `NUM_RFFE_FASTLOCK_PROFILES`, so profile 8 has always overwritten profile 0.

Letting the Nios index wrap the same way makes the two consistent and keeps long-running sweeps working. Applications that need a stable profile for a specific frequency already have to re-request it, since the RFFE slot underneath may have been reused.

## Measured

bladeRF 2.0 micro xA4, FPGA 0.15.0, sweeping 70 MHz – 6 GHz with 4700 distinct stops, taking a quick tune profile on first visit to each:

| | before | after |
|---|---|---|
| 320 stops | counter stuck at 256, every later stop logged the error | 320 profiles, no errors |
| 600 stops | — | 600 profiles, no errors |
| 3392 stops in 90 s | — | 3392 profiles, no errors |

The counter is `uint16_t` and 65536 is a multiple of 256, so wrapping does not disturb the modulo alignment used for the RFFE index.