### PR TITLE
bladerf2: leave AD9361 fastlock after an immediate quick tune

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1533,9 +1533,44 @@ static int bladerf2_schedule_retune(struct bladerf *dev,
         return BLADERF_ERR_UNSUPPORTED;
     }
 
-    return dev->backend->retune2(dev, ch, timestamp, quick_tune->nios_profile,
-                                 quick_tune->rffe_profile, quick_tune->port,
-                                 quick_tune->spdt);
+    CHECK_STATUS(dev->backend->retune2(dev, ch, timestamp,
+                                       quick_tune->nios_profile,
+                                       quick_tune->rffe_profile,
+                                       quick_tune->port, quick_tune->spdt));
+
+    /* The Nios recalls the profile by writing the RFIC directly, which
+     * leaves the part in fastlock mode with FORCE_ALC_ENABLE asserted.
+     * ad9361_fastlock_prepare() cannot undo that: it is gated on
+     * phy->fastlock.current_profile, which a recall performed by the FPGA
+     * never touches. Ownership of the RFPLL therefore returns to host
+     * tuning with forced controls still active, and the next
+     * bladerf_set_frequency() programs the synthesiser as if ALC were
+     * automatic.
+     *
+     * Measured on a bladeRF 2.0 micro xA4, interleaving a quick tune
+     * capture plus an immediate recall with ordinary tuning every fifth
+     * stop of a 242-point sweep across 82-5988 MHz:
+     *
+     *   before   55 lock failures in 706 tunes, first at tune 280
+     *   after     2 lock failures in 758 tunes, first at tune 495
+     *
+     * The shape matters more than the rate. Before, the failures form a
+     * series that never recovers: 44 consecutive failures with no
+     * successful tune inside them, and 0x247 reading 0x40 throughout,
+     * meaning the RX charge pump has saturated low. After, there are no
+     * consecutive failures at all. Both reproduced across three runs
+     * each, identical to the tune.
+     *
+     * Only immediate retunes are handled here. One scheduled for a future
+     * timestamp completes inside the FPGA long after this call returns,
+     * so the exit would have to happen there instead.
+     */
+    if (BLADERF_RETUNE_NOW == timestamp) {
+        CHECK_AD936X(ad9361_fastlock_exit_foreign(
+            board_data->phy, BLADERF_CHANNEL_IS_TX(ch)));
+    }
+
+    return 0;
 }
 
 static int bladerf2_cancel_scheduled_retunes(struct bladerf *dev,

--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -448,6 +448,17 @@ static int _rfic_host_set_frequency(struct bladerf *dev,
         return BLADERF_ERR_RANGE;
     }
 
+    /* A quick tune scheduled for a future timestamp is recalled by the
+     * FPGA's Nios core, which writes REG_(RX|TX)_FAST_LOCK_SETUP directly
+     * and leaves the part in fastlock mode behind the driver's back. The
+     * exit in bladerf2_schedule_retune() only covers BLADERF_RETUNE_NOW,
+     * because a deferred recall completes long after that call returns.
+     * Tuning ordinarily while the leaked state is in place pins the RF PLL
+     * charge pump (0x247 reads 0x80 during the failed tune, 0x40 after),
+     * so leave fastlock here before touching the synthesizer. The call
+     * reads first and writes nothing when not in fastlock mode. */
+    CHECK_AD936X(ad9361_fastlock_exit_foreign(phy, BLADERF_CHANNEL_IS_TX(ch)));
+
     /* Set up band selection */
     CHECK_STATUS(rfic->select_band(dev, ch, frequency));
 


### PR DESCRIPTION
The Nios recalls a quick tune profile by writing the RFIC directly. That leaves the part in fastlock mode with `FORCE_ALC_ENABLE` asserted, and the AD9361 driver cannot undo it on its own: its exit path is gated on `phy->fastlock.current_profile`, which a recall performed by the FPGA never touches.

Ownership of the RFPLL therefore returns to host tuning with forced controls still active, and the next `bladerf_set_frequency()` programs the synthesiser as if ALC were automatic.

## Measurement

bladeRF 2.0 micro xA4, interleaving `bladerf_get_quick_tune()` plus an immediate `bladerf_schedule_retune()` with ordinary tuning every fifth stop of a 242-point sweep across 82-5988 MHz, 65536 samples per stop:

| | lock failures | first failure | consecutive failures |
|---|---|---|---|
| before | 55 / 706 tunes | tune 280 | 44 |
| after | 2 / 758 tunes | tune 495 | 0 |

The shape matters more than the rate. Before, the failures form a series that never recovers: no successful tune inside it, and `0x247` reading `0x40` the whole time, meaning the RX charge pump has saturated low. After, there are no consecutive failures at all. Both figures reproduced across three runs each, identical to the tune.

Leaked controls at the end of a run:

    0x236  0xD3 (FORCE_ALC set)  ->  0x50-0x5B (clear)
    0x25A  0x01-0xA1 (mode set)  ->  0x00

The leak was present on **every** recall rather than occasionally: 145 of 145, 146 of 146, 146 of 146 across three runs.

## Notes

This is the same condition the existing comment in `bladerf2_get_quick_tune()` refers to — "the RFIC can end up in a bad state after fastlock use" — but handled where ownership actually returns, rather than deferred to `rfic_reset_on_close`. A process that holds the device open indefinitely never reaches that reset.

Only immediate retunes are handled here. One scheduled for a future timestamp completes inside the FPGA long after the call returns, so the exit would have to happen there instead; that case is left alone rather than guessed at.

Depends on `ad9361_fastlock_exit_foreign()`: analogdevicesinc/no-OS#3290