### PR TITLE
libbladeRF: fix unit mix-up in ts_remaining() for X2 layouts

### DIFF
--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -442,10 +442,20 @@ int sync_prime_stream(struct bladerf_sync *sync, unsigned int timeout_ms)
     return status;
 }
 
-/* Returns # of timestamps (or time steps) left in a message */
+/* Returns # of timestamps (or time steps) left in a message.
+ *
+ * curr_msg_off counts SAMPLES (it is advanced by samples_to_copy and
+ * compared against samples_per_msg), so it has to be subtracted before
+ * converting to time steps. Subtracting it from samples_per_msg /
+ * samples_per_ts mixed the units: correct for single-channel layouts
+ * where samples_per_ts == 1, but in X2 mode the unsigned subtraction
+ * underflowed once the offset passed half a message, and the huge
+ * result sent the seek logic down the wrong branch. */
 static inline unsigned int ts_remaining(struct bladerf_sync *s)
 {
-    size_t ret = s->meta.samples_per_msg / s->meta.samples_per_ts - s->meta.curr_msg_off;
+    size_t ret = (s->meta.samples_per_msg - s->meta.curr_msg_off) /
+                 s->meta.samples_per_ts;
+    assert(s->meta.curr_msg_off <= s->meta.samples_per_msg);
     assert(ret <= UINT_MAX);
 
     return (unsigned int) ret;


### PR DESCRIPTION
`curr_msg_off` counts **samples**: it is advanced by `samples_to_copy` and compared against `samples_per_msg`. `ts_remaining()` subtracted it from `samples_per_msg / samples_per_ts`, which counts **time steps** per message. The units only coincide for single-channel layouts, where `samples_per_ts == 1`.

In X2 mode the unsigned subtraction underflows as soon as the offset passes half a message:

- with assertions enabled, a `bladerf_sync_rx()` call that seeks to a timestamp inside the current message aborts the whole process: `sync.c:451: ts_remaining: Assertion 'ret <= UINT_MAX' failed.`
- with `NDEBUG`, the huge result sends the seek logic into the *fast forward within the current message* branch when the target actually lies beyond it, and `curr_msg_off` runs past the message boundary — the stream stalls instead of crashing. This looks like the dual-channel stall reported in #944.

Reproduced on a bladeRF 2.0 micro xA4 (FX3 2.6.0, FPGA 0.16.0) with an RX_X2 `SC16_Q11_META` stream reading back-to-back explicit timestamps: the abort fires within the first few reads. With the units fixed, the same sequence completes 3000/3000 contiguous reads with no timestamp drift (past the ~1794-buffer stall point reported in #944), and single-channel metadata reads are unaffected.

The fix subtracts the sample offset first and then converts to time steps; a new assertion documents the invariant (`curr_msg_off <= samples_per_msg`) the old expression silently assumed.