### PR TITLE
bladerf2: read the layout of the direction being enabled

### DIFF
--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -245,7 +245,11 @@ static int _rfic_host_enable_module(struct bladerf *dev,
     CHECK_STATUS(dev->backend->rffe_control_read(dev, &reg));
     reg_old    = reg;
     ch_pending = _rffe_ch_enabled(reg, ch) != enable;
-    layout = board_data->sync->stream_config.layout;
+    /* board_data->sync is indexed by direction. Plain sync-> is sync[0],
+     * which is always the RX stream, so enabling or disabling a TX
+     * channel read the RX layout here and decided the MIMO question from
+     * the wrong stream. */
+    layout = board_data->sync[dir].stream_config.layout;
     mimo_enabled = layout == BLADERF_RX_X2 || layout == BLADERF_TX_X2;
 
     if (layout == BLADERF_TX_X2) {


### PR DESCRIPTION
Repeating `bladerf_sync_config()` on TX intermittently and **permanently** wedges sample submission on the bladeRF 2.0 micro. Transfers go out, the FX3 accepts zero bytes, and every completion returns `LIBUSB_TRANSFER_TIMED_OUT` with `actual_length == 0`. The host ring fills to `num_buffers + 2` and `sync_tx()` then refuses buffers for the rest of the session. Only `bladerf_close()` + `bladerf_open()` cleared it.

The trigger is repeating `sync_config()` on TX **by itself** — no RF change, no retune, no `enable_module` required. `enable_module(TX, false)` only participates because `rfic_host.c` calls `sync_deinit()` on it, which forces the caller to configure the stream again. RX never wedges.

## Two commits

1. **`sync: clear the wedged TX sample path when a TX stream is created`** — `sync_init()` cycles the TX direction through the board layer once the worker is up, which clears the latched path.
2. **`bladerf2: read the layout of the direction being enabled`** — `board_data->sync` is indexed by direction, so a plain `sync->` is `sync[0]`, always RX. Enabling or disabling a TX channel read the RX layout and answered the MIMO question from the wrong stream. That is a bug on its own terms, and it also makes the first commit far more effective, since the cycle runs through that function.

## Measured, bladeRF 2.0 micro xA4, 11 `sync_config` repeats per run

| configuration | result |
|---|---|
| baseline | **7 of 8 runs wedged**, at repeat 1, 2, 3, 3, 4, 6, 7 |
| commit 1 alone | 9 of 10 runs clean |
| both commits | **35 of 36 runs clean** |

One run in 36 still wedged, so this is not airtight — but the failure rate drops from roughly 7-in-8 to 1-in-36.

## Alternatives measured and rejected

Each against a do-nothing control in the same run:

| attempt | result |
|---|---|
| FX3 `RF_TX` vendor command alone, `backend->enable_module()` | 0 of 5 |
| same cycle **before** `sync_init()` instead of after | 0 of 6 |
| same cycle in `bladerf2_sync_config()` after `sync_init()` | 0 of 6 |
| disable without re-enable | 17/60 buffers |
| re-setting gain, or frequency | 15/60 |
| `change_setting(USB_IF_RF_LINK)` alt-setting change | no effect |
| `libusb_clear_halt()` on the OUT endpoint | returns 0, wedges anyway |

The board-layer placement fails because `enable_module(TX, false)` re-enters `sync_deinit()` and destroys the stream that was just built. `clear_halt` succeeding while the wedge persists says the endpoint is not halted — the DMA channel is.

Also tried in the `BLADERF_STREAM_SHUTDOWN` path of `lusb_submit_stream_buffer()`: calling `cancel_all_transfers()` before the `STREAM_DONE` shortcut only delays the wedge (repeat 1-2 becomes repeat 4; 3 of 5 still wedge). Taking `STREAM_SHUTTING_DOWN` unconditionally is worse — the worker never stops and `THREAD_CANCEL` fires, because the `SHUTTING_DOWN -> DONE` transition lives in `lusb_stream_cb()` and with nothing in flight no completion is left to run it. That is presumably why the shortcut exists.

## On placement

Commit 1 sits in `sync_init()` rather than the board layer for the two measured reasons above: the cycle must act on the stream that will actually be used, and the board-layer call re-enters `sync_deinit()`. It is a no-op there only because `sync->initialized` is still false at that point, which I agree is fragile. The placements I tried are listed above with their numbers.

## Not the AD9361

Every RFIC register reads bit-identical between wedged and healthy states (`0x017` ENSM, `0x05E`, `0x002`, `0x003`, `0x001`, `0x004`, `0x073` TX attenuation), and the failure is visible purely as zero-byte USB completions. The control plane is fine; this is the sample transport.

