### PR TITLE
libbladeRF: do not cancel a TX transfer in the middle of a buffer

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -36,6 +36,7 @@
 #include "backend/usb/usb.h"
 #include "streaming/async.h"
 #include "helpers/timeout.h"
+#include "helpers/wallclock.h"
 
 #include "bladeRF.h"
 
@@ -73,6 +74,10 @@ struct lusb_stream_data {
     * libusb 1.0.19 for Windows. Further investigation required...
     */
     bool out_of_order_event;
+
+    /* When an in-flight TX transfer may no longer be given time to finish on
+     * its own. Zero until a shutdown starts. */
+    uint64_t cancel_deadline_ns;
 };
 
 static inline struct bladerf_lusb * lusb_backend(struct bladerf *dev)
@@ -1003,6 +1008,41 @@ static inline void cancel_all_transfers(struct bladerf_stream *stream)
     int status;
     struct lusb_stream_data *stream_data = stream->backend_data;
 
+    /* Cancelling a TX transfer that is already moving ends it wherever it
+     * happens to be, and the device cannot use a partial buffer.
+     *
+     * Measured on the wire against a bladeRF 2.0 micro: cancelled OUT
+     * transfers come back having moved 1024, 3072, 5120, 6144, 8192, 13312
+     * and 27648 bytes - all multiples of the 1024-byte SuperSpeed packet,
+     * none a multiple of the 32768-byte buffer. The FX3 TX channel is
+     * CY_U3P_DMA_TYPE_AUTO over 8192-byte buffers, so it assembles whole
+     * buffers; the cut leaves it holding an unfinished one and later
+     * submissions have nowhere to complete. What follows is every transfer
+     * sitting for a full stream timeout while the RX endpoint keeps
+     * completing normally.
+     *
+     * So let an in-flight TX transfer finish on its own. The event loop calls
+     * this on every iteration while shutting down, so returning here means
+     * trying again shortly; each transfer carries its own timeout, which
+     * bounds the wait. Cancel once that deadline has passed, since by then
+     * the transfer is not going to complete anyway.
+     *
+     * Transfers that never started are unaffected: they complete immediately
+     * either way.
+     */
+    if ((stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX &&
+        stream->transfer_timeout != 0) {
+        const uint64_t now = wallclock_get_current_nsec();
+
+        if (stream_data->cancel_deadline_ns == 0) {
+            stream_data->cancel_deadline_ns =
+                now + (uint64_t)stream->transfer_timeout * 1000000u;
+        }
+        if (now < stream_data->cancel_deadline_ns) {
+            return;
+        }
+    }
+
     for (i = 0; i < stream_data->num_transfers; i++) {
         if (stream_data->transfer_status[i] == TRANSFER_IN_FLIGHT) {
             status = libusb_cancel_transfer(stream_data->transfers[i]);
@@ -1267,6 +1307,7 @@ static int lusb_init_stream(void *driver, struct bladerf_stream *stream,
     stream_data->num_avail = 0;
     stream_data->i = 0;
     stream_data->out_of_order_event = false;
+    stream_data->cancel_deadline_ns = 0;
 
     stream_data->transfers =
         malloc(num_transfers * sizeof(struct libusb_transfer *));


### PR DESCRIPTION
Cancelling an in-flight TX transfer ends it wherever it happens to be, and the device cannot use a partial buffer.

Measured on the wire with usbmon against a bladeRF 2.0 micro xA4 (FX3 2.6.0-git-09c82087, FPGA 0.16.0, SuperSpeed, 61.44 Msps, SC16_Q11_META): cancelled OUT transfers come back having moved 1024, 3072, 5120, 6144, 8192, 13312 and 27648 bytes. All are multiples of the 1024-byte SuperSpeed packet; none is a multiple of the 32768-byte buffer.

The FX3 TX channel is `CY_U3P_DMA_TYPE_AUTO` over 8192-byte buffers (`fx3_firmware/src/rf.c`), so it assembles whole buffers. A cut leaves it holding an unfinished one, and later submissions have nowhere to complete. What follows on the wire is every TX transfer sitting for a full stream timeout - one 1002 ms gap in submissions against a configured 1000 ms - while the RX endpoint completes 942 transfers normally in the same window. `sync_tx()` then returns `BLADERF_ERR_TIMEOUT` and only rebuilding the stream gets the feed moving again.

That is the "TX feed stops after repeating `bladerf_sync_config()` for TX while RX is being read" behaviour. Note the device is not refusing data: successful 32768-byte OUT completions are right there in the same trace.

### The change

An in-flight TX transfer is now given until its own timeout to finish by itself, and is cancelled only after that deadline - by which point it was not going to complete anyway. The event loop calls `cancel_all_transfers()` on every iteration while shutting down, so this is a retry a few milliseconds later rather than a new wait. Transfers that never started are unaffected: they complete immediately either way. RX behaviour is unchanged.

### Measurements

10 s of continuous load with the TX stream rebuilt in a tight loop and RX read throughout, both builds in the same session, same device:

| build | result |
| --- | --- |
| before | feed died at round 2, 5, 3 (3 of 3 runs) |
| after | survived 681, 676, 679 rounds (3 of 3 runs) |

Feed rate is unchanged: roughly 19k buffers submitted across ~680 stream teardown/setup cycles in 10 s.

The reproducer used is `tools/repro/tx_wedge_soak.py` in our own tree, not part of this PR: it drives `sync_config(TX)` in a loop while a second thread reads RX, and exits on the first round where `sync_tx()` stops accepting buffers or returns an error.

### What this does not cover

The `1002 ms` gap and the partial-length cancellations are the only direct evidence for the mechanism; I have not instrumented the FX3 side to observe its DMA channel holding the unfinished buffer, since that needs the Cypress SDK. Single unit here, so a library regression cannot be told apart from a quirk of this board.
