### PR TITLE
libbladeRF: follow libusb's event-lock protocol when two streams share a context

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -73,7 +73,29 @@ struct lusb_stream_data {
     * libusb 1.0.19 for Windows. Further investigation required...
     */
     bool out_of_order_event;
+
+    /* Completion flag for libusb_handle_events_timeout_completed(). libusb
+     * re-checks it under its own event lock, which is what makes the wait safe
+     * when RX and TX both handle events on one context. Set wherever the
+     * stream reaches STREAM_DONE. */
+    int done_flag;
 };
+
+/* Finish a stream and wake anyone waiting on libusb events for it.
+ *
+ * The state and the completion flag have to move together: a waiter inside
+ * libusb only re-checks the flag, so setting the state alone leaves it
+ * sleeping until its timeout expires.
+ */
+static inline void mark_stream_done(struct bladerf_stream *stream)
+{
+    struct lusb_stream_data *stream_data = stream->backend_data;
+
+    stream->state = STREAM_DONE;
+    if (stream_data != NULL) {
+        stream_data->done_flag = 1;
+    }
+}
 
 static inline struct bladerf_lusb * lusb_backend(struct bladerf *dev)
 {
@@ -1145,7 +1167,7 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
         /* We know we're done when all of our transfers have returned to their
          * "available" states */
         if (stream_data->num_avail == stream_data->num_transfers) {
-            stream->state = STREAM_DONE;
+            mark_stream_done(stream);
         } else {
             cancel_all_transfers(stream);
         }
@@ -1267,6 +1289,7 @@ static int lusb_init_stream(void *driver, struct bladerf_stream *stream,
     stream_data->num_avail = 0;
     stream_data->i = 0;
     stream_data->out_of_order_event = false;
+    stream_data->done_flag = 0;
 
     stream_data->transfers =
         malloc(num_transfers * sizeof(struct libusb_transfer *));
@@ -1359,7 +1382,7 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
                 } else {
                     /* No transfers have been shipped out yet so we can
                      * simply enter our "done" state */
-                    stream->state = STREAM_DONE;
+                    mark_stream_done(stream);
                 }
 
                 /* In either of the above we don't want to attempt to
@@ -1389,9 +1412,23 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
     }
     MUTEX_UNLOCK(&stream->lock);
 
-    /* This loop is required so libusb can do callbacks and whatnot */
+    /* This loop is required so libusb can do callbacks and whatnot.
+     *
+     * RX and TX each run this loop on the same libusb context, so two threads
+     * compete for event handling. libusb allows that, but only one thread
+     * actually handles events while the others wait inside it, and a waiter
+     * that entered the wait before the state it is waiting on changed keeps
+     * waiting until its timeout expires. Checking stream->state outside the
+     * event lock, which a plain handle_events_timeout() call forces, is
+     * exactly the lost-wakeup pattern that
+     * libusb_handle_events_timeout_completed() exists to close.
+     *
+     * Pass the completion flag instead: libusb re-checks it under its own
+     * event lock and returns immediately if it is already set.
+     */
     while (stream->state != STREAM_DONE) {
-        status = libusb_handle_events_timeout(lusb->context, &tv);
+        status = libusb_handle_events_timeout_completed(
+            lusb->context, &tv, &stream_data->done_flag);
 
         if (status < 0 && status != LIBUSB_ERROR_INTERRUPTED) {
             log_warning("unexpected value from events processing: "
@@ -1413,7 +1450,7 @@ int lusb_submit_stream_buffer(void *driver, struct bladerf_stream *stream,
 
     if (buffer == BLADERF_STREAM_SHUTDOWN) {
         if (stream_data->num_avail == stream_data->num_transfers) {
-            stream->state = STREAM_DONE;
+            mark_stream_done(stream);
         } else {
             stream->state = STREAM_SHUTTING_DOWN;
         }


### PR DESCRIPTION
RX and TX each run their own `lusb_stream()` loop calling `libusb_handle_events_timeout()` on the same libusb context. libusb permits that, but only one thread actually handles events while the others wait inside it, and a waiter that entered the wait before the state it is waiting on changed keeps waiting until its timeout expires.

Checking `stream->state` outside the event lock - which a plain `handle_events_timeout()` call forces you to do - is exactly the lost-wakeup pattern that `libusb_handle_events_timeout_completed()` exists to close. None of `libusb_lock_events`, `libusb_wait_for_event` or the `_completed` variants appear anywhere in libbladeRF today.

The loop now passes a completion flag that libusb re-checks under its own event lock, and every transition to `STREAM_DONE` goes through `mark_stream_done()` so the state and the flag always move together.

This is protocol correctness rather than a fix for a specific symptom: with the timeout at 15 ms the window is small, and I could not attribute any measured behaviour to it on my own hardware. It matters more the longer that timeout gets, and on a context with more streams.

Tested on a bladeRF 2.0 micro xA4 (FX3 2.6.0-git-09c82087, FPGA 0.16.0, SuperSpeed) with RX and TX streaming concurrently at 61.44 Msps: no change in feed rate, roughly 19k buffers submitted across ~680 stream teardown/setup cycles in 10 s, and no change in stream shutdown behaviour.

See also #1084, which fixes a TX feed stall on the same code path.
