### PR TITLE
libbladeRF: retire the sync handle before destroying its mutexes

### DIFF
--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -342,6 +342,19 @@ error:
 void sync_deinit(struct bladerf_sync *sync)
 {
     if (sync->initialized) {
+        /* Retire the handle before tearing anything down.
+         *
+         * sync_rx() and sync_tx() test sync->initialized without holding any
+         * lock - they cannot, since the lock they would take is the one being
+         * destroyed here - and then go on to take buf_mgmt.lock. Clearing the
+         * flag last leaves a window where a concurrent reader passes the test
+         * and then locks a mutex that MUTEX_DESTROY has already reclaimed.
+         * Clearing it first closes that window: a reader either sees the
+         * handle as live and finishes with the still-valid mutex, or sees it
+         * retired and returns without touching it.
+         */
+        sync->initialized = false;
+
         if ((sync->stream_config.layout & BLADERF_DIRECTION_MASK) == BLADERF_TX) {
             async_submit_stream_buffer(sync->worker->stream,
                                        BLADERF_STREAM_SHUTDOWN, NULL, 0, false);
@@ -368,8 +381,6 @@ void sync_deinit(struct bladerf_sync *sync)
         }
 
         MUTEX_DESTROY(&sync->lock);
-
-        sync->initialized = false;
     }
 }
 


### PR DESCRIPTION
`sync_rx()` and `sync_tx()` test `sync->initialized` without holding a lock - they cannot, because the lock they would take is the one being destroyed - and then go on to take `buf_mgmt.lock`.

Clearing the flag last left a window where a concurrent reader passed the test and then locked a mutex `MUTEX_DESTROY` had already reclaimed. Clearing it first closes that window: a reader either sees the handle as live and finishes with the still-valid mutex, or sees it retired and returns without touching it.

This is a use-after-destroy on a mutex, reachable whenever one direction is reconfigured while the other is being read - which is what `bladerf_sync_config()` does, via `sync_deinit()`.

Found while chasing a TX feed stall on a bladeRF 2.0 micro xA4 with RX and TX streaming concurrently at 61.44 Msps. It is not the cause of that stall (see #1084) and is filed separately for that reason.