### PR TITLE
libbladeRF: do not reset the TX consumer index to 0 on worker restart

### DIFF
--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -559,8 +559,22 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
             case SYNC_STATE_RESET_BUF_MGMT:
                 MUTEX_LOCK(&b->lock);
                 /* When the RX stream starts up, it will submit the first T
-                 * transfers, so the consumer index must be reset to 0 */
-                b->cons_i = 0;
+                 * transfers, so the consumer index must be reset to 0.
+                 *
+                 * For TX the consumer index means the opposite thing: it names
+                 * the buffer the callback should ship out next, and
+                 * BUFFER_MGMT_INVALID_INDEX is how sync_init() says "nothing
+                 * is deferred yet". Resetting it to 0 here makes a restarted
+                 * TX worker believe buffer 0 is a deferred, full buffer, so
+                 * tx_callback submits a buffer the producer has not filled and
+                 * the ring accounting drifts from that point on.
+                 */
+                if ((s->stream_config.layout & BLADERF_DIRECTION_MASK) ==
+                    BLADERF_TX) {
+                    b->cons_i = BUFFER_MGMT_INVALID_INDEX;
+                } else {
+                    b->cons_i = 0;
+                }
                 MUTEX_UNLOCK(&b->lock);
                 log_debug("%s: Reset buf_mgmt consumer index\n", __FUNCTION__);
                 s->state = SYNC_STATE_START_WORKER;


### PR DESCRIPTION
`SYNC_STATE_RESET_BUF_MGMT` sets `cons_i = 0`. For RX that is the right starting point. For TX the same field means the opposite thing: it names the buffer the worker callback should ship next, and `BUFFER_MGMT_INVALID_INDEX` is what says 'nothing deferred'.

Setting it to 0 on a TX worker restart therefore points the callback at buffer 0 whether or not that buffer holds anything, so the first deferred submission after a restart can ship a buffer the caller has not filled.

Found while chasing a TX feed stall on a bladeRF 2.0 micro xA4 with RX and TX streaming concurrently at 61.44 Msps. Measured separately: it does not fix that stall (see #1084), and is filed on its own for that reason.