### PR TITLE
libbladeRF: let a TX worker see a STOP request when nothing is completing

### DIFF
--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1398,6 +1398,25 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
                         "%d: %s\n", status, libusb_error_name(status));
             status = error_conv(status);
         }
+
+        /* Finish a shutdown that has nothing left to complete.
+         *
+         * The SHUTTING_DOWN -> DONE transition normally happens in
+         * lusb_stream_cb(), so it needs a transfer to come back. When a
+         * shutdown is requested while nothing is in flight - a stopped TX
+         * feed, for instance - no callback ever runs and this loop would spin
+         * until the worker is cancelled. Cancel here and settle it once every
+         * transfer is accounted for.
+         */
+        MUTEX_LOCK(&stream->lock);
+        if (stream->state == STREAM_SHUTTING_DOWN) {
+            if (stream_data->num_avail == stream_data->num_transfers) {
+                stream->state = STREAM_DONE;
+            } else {
+                cancel_all_transfers(stream);
+            }
+        }
+        MUTEX_UNLOCK(&stream->lock);
     }
 
     return status;

--- a/host/libraries/libbladeRF/src/streaming/sync_worker.c
+++ b/host/libraries/libbladeRF/src/streaming/sync_worker.c
@@ -437,6 +437,26 @@ void sync_worker_submit_request(struct sync_worker *w, unsigned int request)
     w->requests |= request;
     COND_SIGNAL(&w->requests_pending);
     MUTEX_UNLOCK(&w->request_lock);
+
+    /* A TX worker only inspects requests from inside its transfer callback,
+     * and that callback only runs when a transfer completes. With the feed
+     * stopped nothing completes, so a STOP request is never seen and the
+     * worker stays in RUNNING until sync_worker_deinit() gives up waiting and
+     * cancels the thread.
+     *
+     * Nudge the stream into SHUTTING_DOWN so the backend event loop, which
+     * spins on "state != STREAM_DONE", leaves on its own. The loop then
+     * cancels whatever is outstanding and reaches STREAM_DONE without needing
+     * a completion to arrive first.
+     */
+    if ((request & SYNC_WORKER_STOP) && w->stream != NULL &&
+        (w->stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX) {
+        MUTEX_LOCK(&w->stream->lock);
+        if (w->stream->state == STREAM_RUNNING) {
+            w->stream->state = STREAM_SHUTTING_DOWN;
+        }
+        MUTEX_UNLOCK(&w->stream->lock);
+    }
 }
 
 int sync_worker_wait_for_state(struct sync_worker *w, sync_worker_state state,


### PR DESCRIPTION
A TX worker only inspects requests from inside its transfer callback, and that callback runs when a transfer completes. With the feed stopped nothing completes, so a `SYNC_WORKER_STOP` request is never seen: the worker stays in `RUNNING` until `sync_worker_deinit()` gives up waiting after 3 s and cancels the thread.

Cancelling a thread parked in `libusb_handle_events_timeout()` is not something to rely on, and the 3 s shows up as a stall in every teardown that follows a stopped feed.

Two parts:

- `sync_worker_submit_request()` nudges a TX stream into `STREAM_SHUTTING_DOWN` alongside the request, so the backend event loop has something to act on.
- `lusb_stream()` finishes a shutdown that has nothing left to complete. The `SHUTTING_DOWN` -> `DONE` transition normally happens in the transfer callback, which needs a transfer to come back; when none can, the loop now cancels and settles it once every transfer is accounted for.

Found while chasing a TX feed stall on a bladeRF 2.0 micro xA4 with RX and TX streaming concurrently at 61.44 Msps. With this in place `THREAD_CANCEL` no longer fires at all in that test - measured zero occurrences of "Timed out while stopping worker" across full runs, where it had been routine. It does not fix the stall itself (see #1084).