### PR TITLE
libbladeRF: keep the caller's gain mode across bladerf_set_gain

### DIFF
--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -552,12 +552,18 @@ int bladerf_enable_module(struct bladerf *dev, bladerf_channel ch, bool enable)
 int bladerf_set_gain(struct bladerf *dev, bladerf_channel ch, int gain)
 {
     int status;
-    bladerf_gain_mode gain_mode;
+    bladerf_gain_mode gain_mode  = BLADERF_GAIN_MGC;
+    bladerf_gain_mode restore_to = BLADERF_GAIN_MGC;
+    bool restore_gain_mode       = false;
     bladerf_frequency freq;
     bladerf_gain assigned_gain = gain;
     MUTEX_LOCK(&dev->lock);
 
-    /* Change gain mode to manual if ch = RX */
+    /* The RFIC only accepts a manual gain value while it is in MGC: the
+     * AD936x driver rejects the write outright otherwise. Borrow MGC for the
+     * duration of the write and hand the channel back in the mode the caller
+     * chose, rather than silently leaving AGC switched off behind them.
+     */
     if (BLADERF_CHANNEL_IS_TX(ch) == false) {
         status = dev->board->get_gain_mode(dev, ch, &gain_mode);
         if (status != 0) {
@@ -566,12 +572,14 @@ int bladerf_set_gain(struct bladerf *dev, bladerf_channel ch, int gain)
         }
 
         if (gain_mode != BLADERF_GAIN_MGC) {
-            log_warning("Setting gain mode to manual\n");
             status = dev->board->set_gain_mode(dev, ch, BLADERF_GAIN_MGC);
             if (status != 0) {
                 log_error("Failed to set gain mode\n");
                 goto error;
             }
+
+            restore_to         = gain_mode;
+            restore_gain_mode  = true;
         }
     }
 
@@ -585,7 +593,16 @@ int bladerf_set_gain(struct bladerf *dev, bladerf_channel ch, int gain)
     status = dev->board->set_gain(dev, ch, assigned_gain);
     if (status != 0) {
         log_error("Failed to set gain\n");
-        goto error;
+    }
+
+    if (restore_gain_mode) {
+        int restore_status = dev->board->set_gain_mode(dev, ch, restore_to);
+        if (restore_status != 0) {
+            log_error("Failed to restore gain mode\n");
+            if (status == 0) {
+                status = restore_status;
+            }
+        }
     }
 
 error:


### PR DESCRIPTION
`bladerf_set_gain()` on an RX channel has to borrow MGC, because
`ad9361_set_rx_gain()` refuses a manual write in any other mode, but it leaves
the channel in MGC afterwards and only says so at INFO — so a program that
configured AGC loses it silently, and a later `bladerf_get_gain_mode()` reports
MGC as if the earlier `bladerf_set_gain_mode()` had been ignored.

Measured on an xA4, `set_gain_mode(X)` then `set_gain(30)` then
`get_gain_mode()`: FASTATTACK/SLOWATTACK/HYBRID all became MGC before, all
preserved after.