### PR TITLE
libbladeRF: fix set_sample_rate failure when leaving the 4x filter range

### DIFF
--- a/fpga_common/src/ad936x_helpers.c
+++ b/fpga_common/src/ad936x_helpers.c
@@ -124,8 +124,33 @@ int set_ad9361_port_by_freq(struct ad9361_rf_phy *phy,
     struct band_port_map const *port_map = NULL;
     int status;
 
+    /* Leave the RFIC port alone when the direction is being disabled.
+     *
+     * The shutdown entry in the band port map exists for the RF SPDT
+     * switches, which have a genuine "no connection" state
+     * (RFFE_CONTROL_SPDT_SHUTDOWN == 0x0). The RFIC port field has no such
+     * state: every value in that enum is a real input, and the 0 that the
+     * shutdown entry carries is AD936X_A_BALANCED, the high-band input.
+     *
+     * So disabling an RX channel tuned to, say, 915 MHz used to move the
+     * RFIC input from B_BALANCED to A_BALANCED, and re-enabling moved it
+     * back. That round trip is not free: measured on a TX1 -> 50 dB pad ->
+     * RX1 loopback at 915 MHz with manual gain control, the received level
+     * of an unchanged tone spread 0.48 dB (sigma 0.161) over 20
+     * disable/enable cycles, with REG_INPUT_SELECT observed toggling
+     * 0x43 <-> 0x4C each time and the reported gain staying at exactly
+     * 40.0 dB throughout.
+     *
+     * Keeping the port as-is costs nothing while disabled -- the direction
+     * is off and the SPDT is already disconnected -- and removes the
+     * level jitter on re-enable.
+     */
+    if (!enabled) {
+        return 0;
+    }
+
     /* Look up the port configuration for this frequency */
-    port_map = _get_band_port_map_by_freq(ch, enabled ? freq : 0);
+    port_map = _get_band_port_map_by_freq(ch, freq);
 
     if (NULL == port_map) {
         return BLADERF_ERR_INVAL;

--- a/fpga_common/src/ad936x_params.c
+++ b/fpga_common/src/ad936x_params.c
@@ -6,6 +6,7 @@
 #if !defined(BLADERF_NIOS_BUILD) || defined(BLADERF_NIOS_LIBAD936X)
 
 #include "ad9361_api.h"
+#include "axi_adc_core.h"
 #include "platform.h"
 
 /**
@@ -17,6 +18,17 @@
  */
 
 // clang-format off
+
+/* FPGA-side ADI AXI interface core (axi_ad9361). Flat address space over
+ * NIOS_PKT_32x32_TARGET_ADI_AXI: base 0, DAC-side registers at 0x4000+.
+ * axi_adc_init() deasserts the core's RSTN and enables the channels; without
+ * it the core stays in reset after power-up and no RX samples ever flow. */
+static struct axi_adc_init bladerf2_rx_adc_init = {
+    .name         = "bladerf2-axi-ad9361",
+    .base         = 0,
+    .num_channels = 4, // 2R2T, I+Q на канал
+};
+
 AD9361_InitParam bladerf2_rfic_init_params = {
     /* Device selection */
     .dev_sel = ID_AD9361,	// AD9361 RF Agile Transceiver                                      // dev_sel
@@ -302,6 +314,9 @@ AD9361_InitParam bladerf2_rfic_init_params = {
     /* SPI reaches the device through the accessor table in
      * platform_bladerf2; the handle goes into .extra at init time. */
     .spi_param = { .platform_ops = &bladerf2_spi_ops },
+
+    /* FPGA AXI interface core init (деасерт RSTN у axi_adc_init) */
+    .rx_adc_init = &bladerf2_rx_adc_init,
 
     .ad9361_rfpll_ext_recalc_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
     .ad9361_rfpll_ext_round_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()
@@ -596,6 +611,9 @@ AD9361_InitParam bladerf2_rfic_init_params_fastagc_burst = {
     /* SPI reaches the device through the accessor table in
      * platform_bladerf2; the handle goes into .extra at init time. */
     .spi_param = { .platform_ops = &bladerf2_spi_ops },
+
+    /* FPGA AXI interface core init (деасерт RSTN у axi_adc_init) */
+    .rx_adc_init = &bladerf2_rx_adc_init,
 
     .ad9361_rfpll_ext_recalc_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
     .ad9361_rfpll_ext_round_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()

--- a/fpga_common/src/ad936x_params.c
+++ b/fpga_common/src/ad936x_params.c
@@ -66,6 +66,13 @@ static struct axi_dac_init bladerf2_tx_dac_init = {
     .base         = 0x4000,
     .num_channels = 4,
     .channels     = bladerf2_tx_dac_channels,
+    /* AXI_DAC_REG_RATECNTRL. The old in-tree dac_init() picked this from the
+     * two mode bits it had at hand: DAC_RATE(1) for 2R2T without LVDS, which
+     * is this board (two_rx_two_tx_mode_enable = 1, CMOS port config). The
+     * current driver takes it from .rate instead, and an unset field wrote
+     * DAC_RATE(0) - the single-channel divisor - leaving the core clocking
+     * the interface at the wrong ratio for the mode the RFIC is actually in. */
+    .rate         = 1,
 };
 
 AD9361_InitParam bladerf2_rfic_init_params = {

--- a/fpga_common/src/ad936x_params.c
+++ b/fpga_common/src/ad936x_params.c
@@ -7,6 +7,7 @@
 
 #include "ad9361_api.h"
 #include "axi_adc_core.h"
+#include "axi_dac_core.h"
 #include "platform.h"
 
 /**
@@ -27,6 +28,44 @@ static struct axi_adc_init bladerf2_rx_adc_init = {
     .name         = "bladerf2-axi-ad9361",
     .base         = 0,
     .num_channels = 4, // 2R2T, I+Q на канал
+};
+
+/* TX side of the same core.
+ *
+ * The old in-tree ADI bundle initialized both directions from the platform:
+ * axiadc_init() called adc_init(phy) and then dac_init(phy, DATA_SEL_DMA, 0).
+ * The migration to the current driver dropped adc_core.c and dac_core.c from
+ * the build; the ADC path was restored, the DAC path was not, and the current
+ * driver only ever touches rx_adc - nothing initializes tx_dac.
+ *
+ * The consequence is silent: the control plane is fully alive, sync_tx()
+ * succeeds, USB transfers complete, and the TX LO leaks at the expected
+ * level, but no submitted sample ever reaches the air. The core comes out of
+ * power-up with its data source set to DDS, so the DAC plays its internal
+ * generator instead of the DMA stream.
+ *
+ * The channel table is what makes that explicit: with .channels left NULL,
+ * axi_dac_data_setup() programs DDS tones instead. Four channels for 2R2T,
+ * I and Q each. */
+static struct axi_dac_channel bladerf2_tx_dac_channels[4] = {
+    { .sel = AXI_DAC_DATA_SEL_DMA },
+    { .sel = AXI_DAC_DATA_SEL_DMA },
+    { .sel = AXI_DAC_DATA_SEL_DMA },
+    { .sel = AXI_DAC_DATA_SEL_DMA },
+};
+
+static struct axi_dac_init bladerf2_tx_dac_init = {
+    .name         = "bladerf2-axi-ad9361-tx",
+    /* DAC half of the core lives at +0x4000 in the same flat space - the
+     * old in-tree dac_core.c added that offset in dac_read/dac_write, while
+     * the current driver expects it in .base. With base 0 the DAC writes
+     * land on the ADC's registers instead: axi_dac_init()'s reset write to
+     * 0x40 hits AXI_ADC_REG_RSTN and takes the receiver down with it
+     * (measured: every RX bin reads -inf, including the TX LO leak that is
+     * always present otherwise). */
+    .base         = 0x4000,
+    .num_channels = 4,
+    .channels     = bladerf2_tx_dac_channels,
 };
 
 AD9361_InitParam bladerf2_rfic_init_params = {
@@ -317,6 +356,7 @@ AD9361_InitParam bladerf2_rfic_init_params = {
 
     /* FPGA AXI interface core init (деасерт RSTN у axi_adc_init) */
     .rx_adc_init = &bladerf2_rx_adc_init,
+    .tx_dac_init = &bladerf2_tx_dac_init,
 
     .ad9361_rfpll_ext_recalc_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
     .ad9361_rfpll_ext_round_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()
@@ -614,6 +654,7 @@ AD9361_InitParam bladerf2_rfic_init_params_fastagc_burst = {
 
     /* FPGA AXI interface core init (деасерт RSTN у axi_adc_init) */
     .rx_adc_init = &bladerf2_rx_adc_init,
+    .tx_dac_init = &bladerf2_tx_dac_init,
 
     .ad9361_rfpll_ext_recalc_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
     .ad9361_rfpll_ext_round_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()

--- a/fpga_common/src/ad936x_params.c
+++ b/fpga_common/src/ad936x_params.c
@@ -19,287 +19,293 @@
 // clang-format off
 AD9361_InitParam bladerf2_rfic_init_params = {
     /* Device selection */
-    ID_AD9361,      // AD9361 RF Agile Transceiver                                      // dev_sel
+    .dev_sel = ID_AD9361,	// AD9361 RF Agile Transceiver                                      // dev_sel
 
     /* Identification number */
-    0,              // Chip ID 0                                                        // id_no
 
     /* Reference Clock */
-    38400000UL,     // RefClk = 38.4 MHz                                                // reference_clk_rate
+    .reference_clk_rate = 38400000UL,	// RefClk = 38.4 MHz                                                // reference_clk_rate
 
     /* Base Configuration */
-    1,              // use 2Rx2Tx mode                                                  // two_rx_two_tx_mode_enable *** adi,2rx-2tx-mode-enable
-    1,              // N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_rx_num *** adi,1rx-1tx-mode-use-rx-num
-    1,              // N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_tx_num *** adi,1rx-1tx-mode-use-tx-num
-    1,              // use FDD mode                                                     // frequency_division_duplex_mode_enable *** adi,frequency-division-duplex-mode-enable
-    1,              // use independent FDD mode                                         // frequency_division_duplex_independent_mode_enable *** adi,frequency-division-duplex-independent-mode-enable
-    0,              // N/A when frequency_division_duplex_mode_enable = 1               // tdd_use_dual_synth_mode_enable *** adi,tdd-use-dual-synth-mode-enable
-    0,              // N/A when frequency_division_duplex_mode_enable = 1               // tdd_skip_vco_cal_enable *** adi,tdd-skip-vco-cal-enable
-    0,              // TX fastlock delay = 0 ns                                         // tx_fastlock_delay_ns *** adi,tx-fastlock-delay-ns
-    0,              // RX fastlock delay = 0 ns                                         // rx_fastlock_delay_ns *** adi,rx-fastlock-delay-ns
-    0,              // RX fastlock pin control disabled                                 // rx_fastlock_pincontrol_enable *** adi,rx-fastlock-pincontrol-enable
-    0,              // TX fastlock pin control disabled                                 // tx_fastlock_pincontrol_enable *** adi,tx-fastlock-pincontrol-enable
-    0,              // use internal RX LO                                               // external_rx_lo_enable *** adi,external-rx-lo-enable
-    0,              // use internal TX LO                                               // external_tx_lo_enable *** adi,external-tx-lo-enable
-    5,              // apply new tracking word: on gain change, after exiting RX state  // dc_offset_tracking_update_event_mask *** adi,dc-offset-tracking-update-event-mask
-    6,              // atten value for DC tracking, RX LO > 4 GHz                       // dc_offset_attenuation_high_range *** adi,dc-offset-attenuation-high-range
-    5,              // atten value for DC tracking, RX LO < 4 GHz                       // dc_offset_attenuation_low_range *** adi,dc-offset-attenuation-low-range
-    0x28,           // loop gain for DC tracking, RX LO > 4 GHz                         // dc_offset_count_high_range *** adi,dc-offset-count-high-range
-    0x32,           // loop gain for DC tracking, RX LO < 4 GHz                         // dc_offset_count_low_range *** adi,dc-offset-count-low-range
-    0,              // use full gain table                                              // split_gain_table_mode_enable *** adi,split-gain-table-mode-enable
-    MAX_SYNTH_FREF, // f_ref window 80 MHz                                              // trx_synthesizer_target_fref_overwrite_hz *** adi,trx-synthesizer-target-fref-overwrite-hz
-    0,              // don't use improved RX QEC tracking                               // qec_tracking_slow_mode_enable *** adi,qec-tracking-slow-mode-enable
+    .two_rx_two_tx_mode_enable = 1,	// use 2Rx2Tx mode                                                  // two_rx_two_tx_mode_enable *** adi,2rx-2tx-mode-enable
+    .one_rx_one_tx_mode_use_rx_num = 1,	// N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_rx_num *** adi,1rx-1tx-mode-use-rx-num
+    .one_rx_one_tx_mode_use_tx_num = 1,	// N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_tx_num *** adi,1rx-1tx-mode-use-tx-num
+    .frequency_division_duplex_mode_enable = 1,	// use FDD mode                                                     // frequency_division_duplex_mode_enable *** adi,frequency-division-duplex-mode-enable
+    .frequency_division_duplex_independent_mode_enable = 1,	// use independent FDD mode                                         // frequency_division_duplex_independent_mode_enable *** adi,frequency-division-duplex-independent-mode-enable
+    .tdd_use_dual_synth_mode_enable = 0,	// N/A when frequency_division_duplex_mode_enable = 1               // tdd_use_dual_synth_mode_enable *** adi,tdd-use-dual-synth-mode-enable
+    .tdd_skip_vco_cal_enable = 0,	// N/A when frequency_division_duplex_mode_enable = 1               // tdd_skip_vco_cal_enable *** adi,tdd-skip-vco-cal-enable
+    .tx_fastlock_delay_ns = 0,	// TX fastlock delay = 0 ns                                         // tx_fastlock_delay_ns *** adi,tx-fastlock-delay-ns
+    .rx_fastlock_delay_ns = 0,	// RX fastlock delay = 0 ns                                         // rx_fastlock_delay_ns *** adi,rx-fastlock-delay-ns
+    .rx_fastlock_pincontrol_enable = 0,	// RX fastlock pin control disabled                                 // rx_fastlock_pincontrol_enable *** adi,rx-fastlock-pincontrol-enable
+    .tx_fastlock_pincontrol_enable = 0,	// TX fastlock pin control disabled                                 // tx_fastlock_pincontrol_enable *** adi,tx-fastlock-pincontrol-enable
+    .external_rx_lo_enable = 0,	// use internal RX LO                                               // external_rx_lo_enable *** adi,external-rx-lo-enable
+    .external_tx_lo_enable = 0,	// use internal TX LO                                               // external_tx_lo_enable *** adi,external-tx-lo-enable
+    .dc_offset_tracking_update_event_mask = 5,	// apply new tracking word: on gain change, after exiting RX state  // dc_offset_tracking_update_event_mask *** adi,dc-offset-tracking-update-event-mask
+    .dc_offset_attenuation_high_range = 6,	// atten value for DC tracking, RX LO > 4 GHz                       // dc_offset_attenuation_high_range *** adi,dc-offset-attenuation-high-range
+    .dc_offset_attenuation_low_range = 5,	// atten value for DC tracking, RX LO < 4 GHz                       // dc_offset_attenuation_low_range *** adi,dc-offset-attenuation-low-range
+    .dc_offset_count_high_range = 0x28,	// loop gain for DC tracking, RX LO > 4 GHz                         // dc_offset_count_high_range *** adi,dc-offset-count-high-range
+    .dc_offset_count_low_range = 0x32,	// loop gain for DC tracking, RX LO < 4 GHz                         // dc_offset_count_low_range *** adi,dc-offset-count-low-range
+    .split_gain_table_mode_enable = 0,	// use full gain table                                              // split_gain_table_mode_enable *** adi,split-gain-table-mode-enable
+    .trx_synthesizer_target_fref_overwrite_hz = MAX_SYNTH_FREF,	// f_ref window 80 MHz                                              // trx_synthesizer_target_fref_overwrite_hz *** adi,trx-synthesizer-target-fref-overwrite-hz
+    .qec_tracking_slow_mode_enable = 0,	// don't use improved RX QEC tracking                               // qec_tracking_slow_mode_enable *** adi,qec-tracking-slow-mode-enable
 
     /* ENSM Control */
-    0,              // use level mode on ENABLE and TXNRX pins                          // ensm_enable_pin_pulse_mode_enable *** adi,ensm-enable-pin-pulse-mode-enable
-    0,              // use SPI writes for ENSM state, not ENABLE/TXNRX pins             // ensm_enable_txnrx_control_enable *** adi,ensm-enable-txnrx-control-enable
+    .ensm_enable_pin_pulse_mode_enable = 0,	// use level mode on ENABLE and TXNRX pins                          // ensm_enable_pin_pulse_mode_enable *** adi,ensm-enable-pin-pulse-mode-enable
+    .ensm_enable_txnrx_control_enable = 0,	// use SPI writes for ENSM state, not ENABLE/TXNRX pins             // ensm_enable_txnrx_control_enable *** adi,ensm-enable-txnrx-control-enable
 
     /* LO Control */
-    2400000000UL,   // DEFAULT                                                          // rx_synthesizer_frequency_hz *** adi,rx-synthesizer-frequency-hz
-    2400000000UL,   // DEFAULT                                                          // tx_synthesizer_frequency_hz *** adi,tx-synthesizer-frequency-hz
+    .rx_synthesizer_frequency_hz = 2400000000UL,	// DEFAULT                                                          // rx_synthesizer_frequency_hz *** adi,rx-synthesizer-frequency-hz
+    .tx_synthesizer_frequency_hz = 2400000000UL,	// DEFAULT                                                          // tx_synthesizer_frequency_hz *** adi,tx-synthesizer-frequency-hz
 
     /* Rate & BW Control */
-    { 983040000, 245760000, 122880000, 61440000, 30720000, 30720000 },  // DEFAULT      // uint32_t rx_path_clock_frequencies[6] *** adi,rx-path-clock-frequencies
-    { 983040000, 122880000, 122880000, 61440000, 30720000, 30720000 },  // DEFAULT      // uint32_t tx_path_clock_frequencies[6] *** adi,tx-path-clock-frequencies
-    18000000,       // DEFAULT                                                          // rf_rx_bandwidth_hz *** adi,rf-rx-bandwidth-hz
-    18000000,       // DEFAULT                                                          // rf_tx_bandwidth_hz *** adi,rf-tx-bandwidth-hz
+    .rx_path_clock_frequencies = { 983040000, 245760000, 122880000, 61440000, 30720000, 30720000 },	// DEFAULT      // uint32_t rx_path_clock_frequencies[6] *** adi,rx-path-clock-frequencies
+    .tx_path_clock_frequencies = { 983040000, 122880000, 122880000, 61440000, 30720000, 30720000 },	// DEFAULT      // uint32_t tx_path_clock_frequencies[6] *** adi,tx-path-clock-frequencies
+    .rf_rx_bandwidth_hz = 18000000,	// DEFAULT                                                          // rf_rx_bandwidth_hz *** adi,rf-rx-bandwidth-hz
+    .rf_tx_bandwidth_hz = 18000000,	// DEFAULT                                                          // rf_tx_bandwidth_hz *** adi,rf-tx-bandwidth-hz
 
     /* RF Port Control */
-    0,              // DEFAULT                                                          // rx_rf_port_input_select *** adi,rx-rf-port-input-select
-    0,              // DEFAULT                                                          // tx_rf_port_input_select *** adi,tx-rf-port-input-select
+    .rx_rf_port_input_select = 0,	// DEFAULT                                                          // rx_rf_port_input_select *** adi,rx-rf-port-input-select
+    .tx_rf_port_input_select = 0,	// DEFAULT                                                          // tx_rf_port_input_select *** adi,tx-rf-port-input-select
 
     /* TX Attenuation Control */
-    10000,          // DEFAULT                                                          // tx_attenuation_mdB *** adi,tx-attenuation-mdB
-    0,              // N/A when frequency_division_duplex_mode_enable = 1               // update_tx_gain_in_alert_enable *** adi,update-tx-gain-in-alert-enable
+    .tx_attenuation_mdB = 10000,	// DEFAULT                                                          // tx_attenuation_mdB *** adi,tx-attenuation-mdB
+    .update_tx_gain_in_alert_enable = 0,	// N/A when frequency_division_duplex_mode_enable = 1               // update_tx_gain_in_alert_enable *** adi,update-tx-gain-in-alert-enable
 
     /* Reference Clock Control */
-    1,              // Expect external clock into XTALN                                 // xo_disable_use_ext_refclk_enable *** adi,xo-disable-use-ext-refclk-enable
-    {3, 5920},      // ~0 ppm DCXO trim (N/A if ext clk)                                // dcxo_coarse_and_fine_tune[2] *** adi,dcxo-coarse-and-fine-tune
-    CLKOUT_DISABLE, // disable clkout pin (see enum ad9361_clkout)                      // clk_output_mode_select *** adi,clk-output-mode-select
+    .xo_disable_use_ext_refclk_enable = 1,	// Expect external clock into XTALN                                 // xo_disable_use_ext_refclk_enable *** adi,xo-disable-use-ext-refclk-enable
+    .dcxo_coarse_and_fine_tune = {3, 5920},	// ~0 ppm DCXO trim (N/A if ext clk)                                // dcxo_coarse_and_fine_tune[2] *** adi,dcxo-coarse-and-fine-tune
+    .clk_output_mode_select = CLKOUT_DISABLE,	// disable clkout pin (see enum ad9361_clkout)                      // clk_output_mode_select *** adi,clk-output-mode-select
 
     /* Gain Control */
-    RF_GAIN_SLOWATTACK_AGC, // RX1 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx1_mode *** adi,gc-rx1-mode
-    RF_GAIN_SLOWATTACK_AGC, // RX2 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx2_mode *** adi,gc-rx2-mode
-    58,             // magic AGC setting, see AD9361 docs                               // gc_adc_large_overload_thresh *** adi,gc-adc-large-overload-thresh
-    4,              // magic AGC setting, see AD9361 docs                               // gc_adc_ovr_sample_size *** adi,gc-adc-ovr-sample-size
-    47,             // magic AGC setting, see AD9361 docs                               // gc_adc_small_overload_thresh *** adi,gc-adc-small-overload-thresh
-    8192,           // magic AGC setting, see AD9361 docs                               // gc_dec_pow_measurement_duration *** adi,gc-dec-pow-measurement-duration
-    0,              // magic AGC setting, see AD9361 docs                               // gc_dig_gain_enable *** adi,gc-dig-gain-enable
-    800,            // magic AGC setting, see AD9361 docs                               // gc_lmt_overload_high_thresh *** adi,gc-lmt-overload-high-thresh
-    704,            // magic AGC setting, see AD9361 docs                               // gc_lmt_overload_low_thresh *** adi,gc-lmt-overload-low-thresh
-    24,             // magic AGC setting, see AD9361 docs                               // gc_low_power_thresh *** adi,gc-low-power-thresh
-    15,             // magic AGC setting, see AD9361 docs                               // gc_max_dig_gain *** adi,gc-max-dig-gain
+    .gc_rx1_mode = RF_GAIN_SLOWATTACK_AGC,	// RX1 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx1_mode *** adi,gc-rx1-mode
+    .gc_rx2_mode = RF_GAIN_SLOWATTACK_AGC,	// RX2 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx2_mode *** adi,gc-rx2-mode
+    .gc_adc_large_overload_thresh = 58,	// magic AGC setting, see AD9361 docs                               // gc_adc_large_overload_thresh *** adi,gc-adc-large-overload-thresh
+    .gc_adc_ovr_sample_size = 4,	// magic AGC setting, see AD9361 docs                               // gc_adc_ovr_sample_size *** adi,gc-adc-ovr-sample-size
+    .gc_adc_small_overload_thresh = 47,	// magic AGC setting, see AD9361 docs                               // gc_adc_small_overload_thresh *** adi,gc-adc-small-overload-thresh
+    .gc_dec_pow_measurement_duration = 8192,	// magic AGC setting, see AD9361 docs                               // gc_dec_pow_measurement_duration *** adi,gc-dec-pow-measurement-duration
+    .gc_dig_gain_enable = 0,	// magic AGC setting, see AD9361 docs                               // gc_dig_gain_enable *** adi,gc-dig-gain-enable
+    .gc_lmt_overload_high_thresh = 800,	// magic AGC setting, see AD9361 docs                               // gc_lmt_overload_high_thresh *** adi,gc-lmt-overload-high-thresh
+    .gc_lmt_overload_low_thresh = 704,	// magic AGC setting, see AD9361 docs                               // gc_lmt_overload_low_thresh *** adi,gc-lmt-overload-low-thresh
+    .gc_low_power_thresh = 24,	// magic AGC setting, see AD9361 docs                               // gc_low_power_thresh *** adi,gc-low-power-thresh
+    .gc_max_dig_gain = 15,	// magic AGC setting, see AD9361 docs                               // gc_max_dig_gain *** adi,gc-max-dig-gain
 
     /* Gain MGC Control */
-    2,              // N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_dec_gain_step *** adi,mgc-dec-gain-step
-    2,              // N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_inc_gain_step *** adi,mgc-inc-gain-step
-    0,              // don't use CTRL_IN for RX1 MGC stepping                           // mgc_rx1_ctrl_inp_enable *** adi,mgc-rx1-ctrl-inp-enable
-    0,              // don't use CTRL_IN for RX2 MGC stepping                           // mgc_rx2_ctrl_inp_enable *** adi,mgc-rx2-ctrl-inp-enable
-    0,              // N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_split_table_ctrl_inp_gain_mode *** adi,mgc-split-table-ctrl-inp-gain-mode
+    .mgc_dec_gain_step = 2,	// N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_dec_gain_step *** adi,mgc-dec-gain-step
+    .mgc_inc_gain_step = 2,	// N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_inc_gain_step *** adi,mgc-inc-gain-step
+    .mgc_rx1_ctrl_inp_enable = 0,	// don't use CTRL_IN for RX1 MGC stepping                           // mgc_rx1_ctrl_inp_enable *** adi,mgc-rx1-ctrl-inp-enable
+    .mgc_rx2_ctrl_inp_enable = 0,	// don't use CTRL_IN for RX2 MGC stepping                           // mgc_rx2_ctrl_inp_enable *** adi,mgc-rx2-ctrl-inp-enable
+    .mgc_split_table_ctrl_inp_gain_mode = 0,	// N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_split_table_ctrl_inp_gain_mode *** adi,mgc-split-table-ctrl-inp-gain-mode
 
     /* Gain AGC Control */
-    10,             // magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_exceed_counter *** adi,agc-adc-large-overload-exceed-counter
-    2,              // magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_inc_steps *** adi,agc-adc-large-overload-inc-steps
-    0,              // magic AGC setting, see AD9361 docs                               // agc_adc_lmt_small_overload_prevent_gain_inc_enable *** adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable
-    10,             // magic AGC setting, see AD9361 docs                               // agc_adc_small_overload_exceed_counter *** adi,agc-adc-small-overload-exceed-counter
-    4,              // magic AGC setting, see AD9361 docs                               // agc_dig_gain_step_size *** adi,agc-dig-gain-step-size
-    3,              // magic AGC setting, see AD9361 docs                               // agc_dig_saturation_exceed_counter *** adi,agc-dig-saturation-exceed-counter
-    1000,           // magic AGC setting, see AD9361 docs                               // agc_gain_update_interval_us *** adi,agc-gain-update-interval-us
-    0,              // magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_adc_overload_enable *** adi,agc-immed-gain-change-if-large-adc-overload-enable
-    0,              // magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_lmt_overload_enable *** adi,agc-immed-gain-change-if-large-lmt-overload-enable
-    10,             // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high *** adi,agc-inner-thresh-high
-    1,              // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high_dec_steps *** adi,agc-inner-thresh-high-dec-steps
-    12,             // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low *** adi,agc-inner-thresh-low
-    1,              // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low_inc_steps *** adi,agc-inner-thresh-low-inc-steps
-    10,             // magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_exceed_counter *** adi,agc-lmt-overload-large-exceed-counter
-    2,              // magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_inc_steps *** adi,agc-lmt-overload-large-inc-steps
-    10,             // magic AGC setting, see AD9361 docs                               // agc_lmt_overload_small_exceed_counter *** adi,agc-lmt-overload-small-exceed-counter
-    5,              // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high *** adi,agc-outer-thresh-high
-    2,              // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high_dec_steps *** adi,agc-outer-thresh-high-dec-steps
-    18,             // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low *** adi,agc-outer-thresh-low
-    2,              // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low_inc_steps *** adi,agc-outer-thresh-low-inc-steps
-    1,              // magic AGC setting, see AD9361 docs                               // agc_attack_delay_extra_margin_us; *** adi,agc-attack-delay-extra-margin-us
-    0,              // magic AGC setting, see AD9361 docs                               // agc_sync_for_gain_counter_enable *** adi,agc-sync-for-gain-counter-enable
+    .agc_adc_large_overload_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_exceed_counter *** adi,agc-adc-large-overload-exceed-counter
+    .agc_adc_large_overload_inc_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_inc_steps *** adi,agc-adc-large-overload-inc-steps
+    .agc_adc_lmt_small_overload_prevent_gain_inc_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_adc_lmt_small_overload_prevent_gain_inc_enable *** adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable
+    .agc_adc_small_overload_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_adc_small_overload_exceed_counter *** adi,agc-adc-small-overload-exceed-counter
+    .agc_dig_gain_step_size = 4,	// magic AGC setting, see AD9361 docs                               // agc_dig_gain_step_size *** adi,agc-dig-gain-step-size
+    .agc_dig_saturation_exceed_counter = 3,	// magic AGC setting, see AD9361 docs                               // agc_dig_saturation_exceed_counter *** adi,agc-dig-saturation-exceed-counter
+    .agc_gain_update_interval_us = 1000,	// magic AGC setting, see AD9361 docs                               // agc_gain_update_interval_us *** adi,agc-gain-update-interval-us
+    .agc_immed_gain_change_if_large_adc_overload_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_adc_overload_enable *** adi,agc-immed-gain-change-if-large-adc-overload-enable
+    .agc_immed_gain_change_if_large_lmt_overload_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_lmt_overload_enable *** adi,agc-immed-gain-change-if-large-lmt-overload-enable
+    .agc_inner_thresh_high = 10,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high *** adi,agc-inner-thresh-high
+    .agc_inner_thresh_high_dec_steps = 1,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high_dec_steps *** adi,agc-inner-thresh-high-dec-steps
+    .agc_inner_thresh_low = 12,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low *** adi,agc-inner-thresh-low
+    .agc_inner_thresh_low_inc_steps = 1,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low_inc_steps *** adi,agc-inner-thresh-low-inc-steps
+    .agc_lmt_overload_large_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_exceed_counter *** adi,agc-lmt-overload-large-exceed-counter
+    .agc_lmt_overload_large_inc_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_inc_steps *** adi,agc-lmt-overload-large-inc-steps
+    .agc_lmt_overload_small_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_lmt_overload_small_exceed_counter *** adi,agc-lmt-overload-small-exceed-counter
+    .agc_outer_thresh_high = 5,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high *** adi,agc-outer-thresh-high
+    .agc_outer_thresh_high_dec_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high_dec_steps *** adi,agc-outer-thresh-high-dec-steps
+    .agc_outer_thresh_low = 18,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low *** adi,agc-outer-thresh-low
+    .agc_outer_thresh_low_inc_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low_inc_steps *** adi,agc-outer-thresh-low-inc-steps
+    .agc_attack_delay_extra_margin_us = 1,	// magic AGC setting, see AD9361 docs                               // agc_attack_delay_extra_margin_us; *** adi,agc-attack-delay-extra-margin-us
+    .agc_sync_for_gain_counter_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_sync_for_gain_counter_enable *** adi,agc-sync-for-gain-counter-enable
 
     /* Fast AGC */
-    64,             // magic AGC setting, see AD9361 docs                               // fagc_dec_pow_measuremnt_duration ***  adi,fagc-dec-pow-measurement-duration
-    260,            // magic AGC setting, see AD9361 docs                               // fagc_state_wait_time_ns ***  adi,fagc-state-wait-time-ns
+    .fagc_dec_pow_measuremnt_duration = 64,	// magic AGC setting, see AD9361 docs                               // fagc_dec_pow_measuremnt_duration ***  adi,fagc-dec-pow-measurement-duration
+    .fagc_state_wait_time_ns = 260,	// magic AGC setting, see AD9361 docs                               // fagc_state_wait_time_ns ***  adi,fagc-state-wait-time-ns
 
     /* Fast AGC - Low Power */
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_allow_agc_gain_increase ***  adi,fagc-allow-agc-gain-increase-enable
-    5,              // magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_time ***  adi,fagc-lp-thresh-increment-time
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_steps ***  adi,fagc-lp-thresh-increment-steps
+    .fagc_allow_agc_gain_increase = 0,	// magic AGC setting, see AD9361 docs                               // fagc_allow_agc_gain_increase ***  adi,fagc-allow-agc-gain-increase-enable
+    .fagc_lp_thresh_increment_time = 5,	// magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_time ***  adi,fagc-lp-thresh-increment-time
+    .fagc_lp_thresh_increment_steps = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_steps ***  adi,fagc-lp-thresh-increment-steps
 
     /* Fast AGC - Lock Level */
-    10,             // magic AGC setting, see AD9361 docs                               // fagc_lock_level ***  adi,fagc-lock-level
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lock_level_lmt_gain_increase_en ***  adi,fagc-lock-level-lmt-gain-increase-enable
-    5,              // magic AGC setting, see AD9361 docs                               // fagc_lock_level_gain_increase_upper_limit ***  adi,fagc-lock-level-gain-increase-upper-limit
+    .fagc_lock_level_lmt_gain_increase_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lock_level_lmt_gain_increase_en ***  adi,fagc-lock-level-lmt-gain-increase-enable
+    .fagc_lock_level_gain_increase_upper_limit = 5,	// magic AGC setting, see AD9361 docs                               // fagc_lock_level_gain_increase_upper_limit ***  adi,fagc-lock-level-gain-increase-upper-limit
 
     /* Fast AGC - Peak Detectors and Final Settling */
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lpf_final_settling_steps ***  adi,fagc-lpf-final-settling-steps
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lmt_final_settling_steps ***  adi,fagc-lmt-final-settling-steps
-    3,              // magic AGC setting, see AD9361 docs                               // fagc_final_overrange_count ***  adi,fagc-final-overrange-count
+    .fagc_lpf_final_settling_steps = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lpf_final_settling_steps ***  adi,fagc-lpf-final-settling-steps
+    .fagc_lmt_final_settling_steps = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lmt_final_settling_steps ***  adi,fagc-lmt-final-settling-steps
+    .fagc_final_overrange_count = 3,	// magic AGC setting, see AD9361 docs                               // fagc_final_overrange_count ***  adi,fagc-final-overrange-count
 
     /* Fast AGC - Final Power Test */
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_gain_increase_after_gain_lock_en ***  adi,fagc-gain-increase-after-gain-lock-enable
+    .fagc_gain_increase_after_gain_lock_en = 0,	// magic AGC setting, see AD9361 docs                               // fagc_gain_increase_after_gain_lock_en ***  adi,fagc-gain-increase-after-gain-lock-enable
 
     /* Fast AGC - Unlocking the Gain */
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_gain_index_type_after_exit_rx_mode ***  adi,fagc-gain-index-type-after-exit-rx-mode
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_use_last_lock_level_for_set_gain_en ***  adi,fagc-use-last-lock-level-for-set-gain-enable
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-stronger-sig-thresh-exceeded-enable
-    5,              // magic AGC setting, see AD9361 docs                               // fagc_optimized_gain_offset ***  adi,fagc-optimized-gain-offset
-    10,             // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_above_ll ***  adi,fagc-rst-gla-stronger-sig-thresh-above-ll
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-exceeded-enable
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_goto_optim_gain_en ***  adi,fagc-rst-gla-engergy-lost-goto-optim-gain-enable
-    10,             // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_below_ll ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-below-ll
-    8,              // magic AGC setting, see AD9361 docs                               // fagc_energy_lost_stronger_sig_gain_lock_exit_cnt ***  adi,fagc-energy-lost-stronger-sig-gain-lock-exit-cnt
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_adc_overload_en ***  adi,fagc-rst-gla-large-adc-overload-enable
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_lmt_overload_en ***  adi,fagc-rst-gla-large-lmt-overload-enable
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_en_agc_pulled_high_en ***  adi,fagc-rst-gla-en-agc-pulled-high-enable
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_if_en_agc_pulled_high_mode ***  adi,fagc-rst-gla-if-en-agc-pulled-high-mode
-    64,             // magic AGC setting, see AD9361 docs                               // fagc_power_measurement_duration_in_state5 ***  adi,fagc-power-measurement-duration-in-state5
+    .fagc_gain_index_type_after_exit_rx_mode = 0,	// magic AGC setting, see AD9361 docs                               // fagc_gain_index_type_after_exit_rx_mode ***  adi,fagc-gain-index-type-after-exit-rx-mode
+    .fagc_use_last_lock_level_for_set_gain_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_use_last_lock_level_for_set_gain_en ***  adi,fagc-use-last-lock-level-for-set-gain-enable
+    .fagc_rst_gla_stronger_sig_thresh_exceeded_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-stronger-sig-thresh-exceeded-enable
+    .fagc_optimized_gain_offset = 5,	// magic AGC setting, see AD9361 docs                               // fagc_optimized_gain_offset ***  adi,fagc-optimized-gain-offset
+    .fagc_rst_gla_stronger_sig_thresh_above_ll = 10,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_above_ll ***  adi,fagc-rst-gla-stronger-sig-thresh-above-ll
+    .fagc_rst_gla_engergy_lost_sig_thresh_exceeded_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-exceeded-enable
+    .fagc_rst_gla_engergy_lost_goto_optim_gain_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_goto_optim_gain_en ***  adi,fagc-rst-gla-engergy-lost-goto-optim-gain-enable
+    .fagc_rst_gla_engergy_lost_sig_thresh_below_ll = 10,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_below_ll ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-below-ll
+    .fagc_energy_lost_stronger_sig_gain_lock_exit_cnt = 8,	// magic AGC setting, see AD9361 docs                               // fagc_energy_lost_stronger_sig_gain_lock_exit_cnt ***  adi,fagc-energy-lost-stronger-sig-gain-lock-exit-cnt
+    .fagc_rst_gla_large_adc_overload_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_adc_overload_en ***  adi,fagc-rst-gla-large-adc-overload-enable
+    .fagc_rst_gla_large_lmt_overload_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_lmt_overload_en ***  adi,fagc-rst-gla-large-lmt-overload-enable
+    .fagc_rst_gla_en_agc_pulled_high_en = 0,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_en_agc_pulled_high_en ***  adi,fagc-rst-gla-en-agc-pulled-high-enable
+    .fagc_rst_gla_if_en_agc_pulled_high_mode = 0,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_if_en_agc_pulled_high_mode ***  adi,fagc-rst-gla-if-en-agc-pulled-high-mode
+    .fagc_power_measurement_duration_in_state5 = 64,	// magic AGC setting, see AD9361 docs                               // fagc_power_measurement_duration_in_state5 ***  adi,fagc-power-measurement-duration-in-state5
 
     /* RSSI Control */
-    1,              // settling delay on RSSI algo restart = 1 μs                       // rssi_delay *** adi,rssi-delay
-    1000,           // total RSSI measurement duration = 1000 μs                        // rssi_duration *** adi,rssi-duration
-    GAIN_CHANGE_OCCURS, // reset RSSI accumulator on gain change event                  // rssi_restart_mode *** adi,rssi-restart-mode
-    0,              // RSSI control values are in microseconds                          // rssi_unit_is_rx_samples_enable *** adi,rssi-unit-is-rx-samples-enable
-    1,              // wait 1 μs between RSSI measurements                              // rssi_wait *** adi,rssi-wait
+    .rssi_delay = 1,	// settling delay on RSSI algo restart = 1 μs                       // rssi_delay *** adi,rssi-delay
+    .rssi_duration = 1000,	// total RSSI measurement duration = 1000 μs                        // rssi_duration *** adi,rssi-duration
+    .rssi_restart_mode = GAIN_CHANGE_OCCURS,	// reset RSSI accumulator on gain change event                  // rssi_restart_mode *** adi,rssi-restart-mode
+    .rssi_unit_is_rx_samples_enable = 0,	// RSSI control values are in microseconds                          // rssi_unit_is_rx_samples_enable *** adi,rssi-unit-is-rx-samples-enable
+    .rssi_wait = 1,	// wait 1 μs between RSSI measurements                              // rssi_wait *** adi,rssi-wait
 
     /* Aux ADC Control */
     /* bladeRF Micro: N/A, pin tied to GND */
-    256,            // AuxADC decimate by 256                                           // aux_adc_decimation *** adi,aux-adc-decimation
-    40000000UL,     // AuxADC sample rate 40 MHz                                        // aux_adc_rate *** adi,aux-adc-rate
+    .aux_adc_decimation = 256,	// AuxADC decimate by 256                                           // aux_adc_decimation *** adi,aux-adc-decimation
+    .aux_adc_rate = 40000000UL,	// AuxADC sample rate 40 MHz                                        // aux_adc_rate *** adi,aux-adc-rate
 
     /* AuxDAC Control */
     /* bladeRF Micro: AuxDAC1 is TP7 and AUXDAC_TRIM, AuxDAC2 is TP8 */
-    1,              // AuxDAC does not slave the ENSM                                   // aux_dac_manual_mode_enable ***  adi,aux-dac-manual-mode-enable
-    0,              // AuxDAC1 default value = 0 mV                                     // aux_dac1_default_value_mV ***  adi,aux-dac1-default-value-mV
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_rx_enable ***  adi,aux-dac1-active-in-rx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_tx_enable ***  adi,aux-dac1-active-in-tx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_alert_enable ***  adi,aux-dac1-active-in-alert-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_rx_delay_us ***  adi,aux-dac1-rx-delay-us
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_tx_delay_us ***  adi,aux-dac1-tx-delay-us
-    0,              // AuxDAC2 default value = 0 mV                                     // aux_dac2_default_value_mV ***  adi,aux-dac2-default-value-mV
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_rx_enable ***  adi,aux-dac2-active-in-rx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_tx_enable ***  adi,aux-dac2-active-in-tx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_alert_enable ***  adi,aux-dac2-active-in-alert-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_rx_delay_us ***  adi,aux-dac2-rx-delay-us
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_tx_delay_us ***  adi,aux-dac2-tx-delay-us
+    .aux_dac_manual_mode_enable = 1,	// AuxDAC does not slave the ENSM                                   // aux_dac_manual_mode_enable ***  adi,aux-dac-manual-mode-enable
+    .aux_dac1_default_value_mV = 0,	// AuxDAC1 default value = 0 mV                                     // aux_dac1_default_value_mV ***  adi,aux-dac1-default-value-mV
+    .aux_dac1_active_in_rx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_rx_enable ***  adi,aux-dac1-active-in-rx-enable
+    .aux_dac1_active_in_tx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_tx_enable ***  adi,aux-dac1-active-in-tx-enable
+    .aux_dac1_active_in_alert_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_alert_enable ***  adi,aux-dac1-active-in-alert-enable
+    .aux_dac1_rx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_rx_delay_us ***  adi,aux-dac1-rx-delay-us
+    .aux_dac1_tx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_tx_delay_us ***  adi,aux-dac1-tx-delay-us
+    .aux_dac2_default_value_mV = 0,	// AuxDAC2 default value = 0 mV                                     // aux_dac2_default_value_mV ***  adi,aux-dac2-default-value-mV
+    .aux_dac2_active_in_rx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_rx_enable ***  adi,aux-dac2-active-in-rx-enable
+    .aux_dac2_active_in_tx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_tx_enable ***  adi,aux-dac2-active-in-tx-enable
+    .aux_dac2_active_in_alert_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_alert_enable ***  adi,aux-dac2-active-in-alert-enable
+    .aux_dac2_rx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_rx_delay_us ***  adi,aux-dac2-rx-delay-us
+    .aux_dac2_tx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_tx_delay_us ***  adi,aux-dac2-tx-delay-us
 
     /* Temperature Sensor Control */
-    256,            // Temperature sensor decimate by 256                               // temp_sense_decimation *** adi,temp-sense-decimation
-    1000,           // Measure temperature every 1000 ms                                // temp_sense_measurement_interval_ms *** adi,temp-sense-measurement-interval-ms
-    206,            // Offset = +206 degrees C                                          // temp_sense_offset_signed *** adi,temp-sense-offset-signed
-    1,              // Periodic temperature measurements enabled                        // temp_sense_periodic_measurement_enable *** adi,temp-sense-periodic-measurement-enable
+    .temp_sense_decimation = 256,	// Temperature sensor decimate by 256                               // temp_sense_decimation *** adi,temp-sense-decimation
+    .temp_sense_measurement_interval_ms = 1000,	// Measure temperature every 1000 ms                                // temp_sense_measurement_interval_ms *** adi,temp-sense-measurement-interval-ms
+    .temp_sense_offset_signed = 206,	// Offset = +206 degrees C                                          // temp_sense_offset_signed *** adi,temp-sense-offset-signed
+    .temp_sense_periodic_measurement_enable = 1,	// Periodic temperature measurements enabled                        // temp_sense_periodic_measurement_enable *** adi,temp-sense-periodic-measurement-enable
 
     /* Control Out Setup */
     /* See https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361-customization#control_output_setup */
-    0xFF,           // Enable all CTRL_OUT bits                                         // ctrl_outs_enable_mask *** adi,ctrl-outs-enable-mask
-    0,              // CTRL_OUT index is 0                                              // ctrl_outs_index *** adi,ctrl-outs-index
+    .ctrl_outs_enable_mask = 0xFF,	// Enable all CTRL_OUT bits                                         // ctrl_outs_enable_mask *** adi,ctrl-outs-enable-mask
+    .ctrl_outs_index = 0,	// CTRL_OUT index is 0                                              // ctrl_outs_index *** adi,ctrl-outs-index
 
     /* External LNA Control */
     /* bladeRF Micro: GPO_0 is TP3, GPO_1 is TP4 */
-    0,              // N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_settling_delay_ns *** adi,elna-settling-delay-ns
-    0,              // MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_gain_mdB *** adi,elna-gain-mdB
-    0,              // MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_bypass_loss_mdB *** adi,elna-bypass-loss-mdB
-    0,              // Ext LNA Ctrl bit in Rx1 gain table does NOT set GPO0 state       // elna_rx1_gpo0_control_enable *** adi,elna-rx1-gpo0-control-enable
-    0,              // Ext LNA Ctrl bit in Rx2 gain table does NOT set GPO1 state       // elna_rx2_gpo1_control_enable *** adi,elna-rx2-gpo1-control-enable
-    0,              // N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_gaintable_all_index_enable *** adi,elna-gaintable-all-index-enable
+    .elna_settling_delay_ns = 0,	// N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_settling_delay_ns *** adi,elna-settling-delay-ns
+    .elna_gain_mdB = 0,	// MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_gain_mdB *** adi,elna-gain-mdB
+    .elna_bypass_loss_mdB = 0,	// MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_bypass_loss_mdB *** adi,elna-bypass-loss-mdB
+    .elna_rx1_gpo0_control_enable = 0,	// Ext LNA Ctrl bit in Rx1 gain table does NOT set GPO0 state       // elna_rx1_gpo0_control_enable *** adi,elna-rx1-gpo0-control-enable
+    .elna_rx2_gpo1_control_enable = 0,	// Ext LNA Ctrl bit in Rx2 gain table does NOT set GPO1 state       // elna_rx2_gpo1_control_enable *** adi,elna-rx2-gpo1-control-enable
+    .elna_gaintable_all_index_enable = 0,	// N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_gaintable_all_index_enable *** adi,elna-gaintable-all-index-enable
 
     /* Digital Interface Control */
 #ifdef ENABLE_AD9361_DIGITAL_INTERFACE_TIMING_VERIFICATION
     /* Calibrate the digital interface delay (hardware validation) */
-    0,              // Don't skip digital interface tuning                              // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
+    .digital_interface_tune_skip_mode = 0,	// Don't skip digital interface tuning                              // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
 #else
     /* Use hardcoded digital interface delay values (production) */
-    2,              // Skip RX and TX tuning; use hardcoded values below                // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
+    .digital_interface_tune_skip_mode = 2,	// Skip RX and TX tuning; use hardcoded values below                // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
 #endif // ENABLE_AD9361_DIGITAL_INTERFACE_TIMING_VERIFICATION
-    0,              // ?? UNDOCUMENTED ??                                               // digital_interface_tune_fir_disable *** adi,digital-interface-tune-fir-disable
-    1,              // Swap I and Q (spectral inversion)                                // pp_tx_swap_enable *** adi,pp-tx-swap-enable
-    1,              // Swap I and Q (spectral inversion)                                // pp_rx_swap_enable *** adi,pp-rx-swap-enable
-    0,              // Don't swap TX1 and TX2                                           // tx_channel_swap_enable *** adi,tx-channel-swap-enable
-    0,              // Don't swap RX1 and RX2                                           // rx_channel_swap_enable *** adi,rx-channel-swap-enable
-    1,              // Toggle RX_FRAME with 50% duty cycle                              // rx_frame_pulse_mode_enable *** adi,rx-frame-pulse-mode-enable
-    0,              // Data port timing reflects # of enabled signal paths              // two_t_two_r_timing_enable *** adi,2t2r-timing-enable
-    0,              // Don't invert data bus                                            // invert_data_bus_enable *** adi,invert-data-bus-enable
-    0,              // Don't invert data clock                                          // invert_data_clk_enable *** adi,invert-data-clk-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // fdd_alt_word_order_enable *** adi,fdd-alt-word-order-enable
-    0,              // Don't invert RX_FRAME                                            // invert_rx_frame_enable *** adi,invert-rx-frame-enable
-    0,              // Don't make RX sample rate 2x the TX sample rate                  // fdd_rx_rate_2tx_enable *** adi,fdd-rx-rate-2tx-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // swap_ports_enable *** adi,swap-ports-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // single_data_rate_enable *** adi,single-data-rate-enable
-    1,              // Use LVDS mode on data port                                       // lvds_mode_enable *** adi,lvds-mode-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // half_duplex_mode_enable *** adi,half-duplex-mode-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // single_port_mode_enable *** adi,single-port-mode-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // full_port_enable *** adi,full-port-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // full_duplex_swap_bits_enable *** adi,full-duplex-swap-bits-enable
-    0,              // RX_DATA delay rel to RX_FRAME = 0 DATA_CLK/2 cycles              // delay_rx_data *** adi,delay-rx-data
+    .digital_interface_tune_fir_disable = 0,	// ?? UNDOCUMENTED ??                                               // digital_interface_tune_fir_disable *** adi,digital-interface-tune-fir-disable
+    .pp_tx_swap_enable = 1,	// Swap I and Q (spectral inversion)                                // pp_tx_swap_enable *** adi,pp-tx-swap-enable
+    .pp_rx_swap_enable = 1,	// Swap I and Q (spectral inversion)                                // pp_rx_swap_enable *** adi,pp-rx-swap-enable
+    .tx_channel_swap_enable = 0,	// Don't swap TX1 and TX2                                           // tx_channel_swap_enable *** adi,tx-channel-swap-enable
+    .rx_channel_swap_enable = 0,	// Don't swap RX1 and RX2                                           // rx_channel_swap_enable *** adi,rx-channel-swap-enable
+    .rx_frame_pulse_mode_enable = 1,	// Toggle RX_FRAME with 50% duty cycle                              // rx_frame_pulse_mode_enable *** adi,rx-frame-pulse-mode-enable
+    .two_t_two_r_timing_enable = 0,	// Data port timing reflects # of enabled signal paths              // two_t_two_r_timing_enable *** adi,2t2r-timing-enable
+    .invert_data_bus_enable = 0,	// Don't invert data bus                                            // invert_data_bus_enable *** adi,invert-data-bus-enable
+    .invert_data_clk_enable = 0,	// Don't invert data clock                                          // invert_data_clk_enable *** adi,invert-data-clk-enable
+    .fdd_alt_word_order_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // fdd_alt_word_order_enable *** adi,fdd-alt-word-order-enable
+    .invert_rx_frame_enable = 0,	// Don't invert RX_FRAME                                            // invert_rx_frame_enable *** adi,invert-rx-frame-enable
+    .fdd_rx_rate_2tx_enable = 0,	// Don't make RX sample rate 2x the TX sample rate                  // fdd_rx_rate_2tx_enable *** adi,fdd-rx-rate-2tx-enable
+    .swap_ports_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // swap_ports_enable *** adi,swap-ports-enable
+    .single_data_rate_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // single_data_rate_enable *** adi,single-data-rate-enable
+    .lvds_mode_enable = 1,	// Use LVDS mode on data port                                       // lvds_mode_enable *** adi,lvds-mode-enable
+    .half_duplex_mode_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // half_duplex_mode_enable *** adi,half-duplex-mode-enable
+    .single_port_mode_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // single_port_mode_enable *** adi,single-port-mode-enable
+    .full_port_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // full_port_enable *** adi,full-port-enable
+    .full_duplex_swap_bits_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // full_duplex_swap_bits_enable *** adi,full-duplex-swap-bits-enable
+    .delay_rx_data = 0,	// RX_DATA delay rel to RX_FRAME = 0 DATA_CLK/2 cycles              // delay_rx_data *** adi,delay-rx-data
     // Approx 0.3 ns/LSB on next 4 values
-    5,              // DATA_CLK delay = 1.5 ns                                          // rx_data_clock_delay *** adi,rx-data-clock-delay
-    0,              // RX_DATA/RX_FRAME delay = 0 ns                                    // rx_data_delay *** adi,rx-data-delay
-    0,              // FB_CLK delay = 0 ns                                              // tx_fb_clock_delay *** adi,tx-fb-clock-delay
-    5,              // TX_DATA/TX_FRAME delay = 1.5 ns                                  // tx_data_delay *** adi,tx-data-delay
-    300,            // LVDS driver bias 300 mV                                          // lvds_bias_mV *** adi,lvds-bias-mV
-    1,              // Enable LVDS on-chip termination                                  // lvds_rx_onchip_termination_enable *** adi,lvds-rx-onchip-termination-enable
-    1,              // RX1 and RX2 are not phase-aligned                                // rx1rx2_phase_inversion_en *** adi,rx1-rx2-phase-inversion-enable
-    0xFF,           // Default signal inversion mappings                                // lvds_invert1_control *** adi,lvds-invert1-control
-    0x0F,           // Default signal inversion mappings                                // lvds_invert2_control *** adi,lvds-invert2-control
-    1,              // CLK_OUT drive increased by ~20%                                  // clk_out_drive
-    1,              // DATA_CLK drive increased by ~20%                                 // dataclk_drive
-    1,              // Data port drive increased by ~20%                                // data_port_drive
-    0,              // CLK_OUT minimum slew (fastest rise/fall)                         // clk_out_slew
-    0,              // DATA_CLK minimum slew (fastest rise/fall)                        // dataclk_slew
-    0,              // Data port minimum slew (fastest rise/fall)                       // data_port_slew
+    .rx_data_clock_delay = 5,	// DATA_CLK delay = 1.5 ns                                          // rx_data_clock_delay *** adi,rx-data-clock-delay
+    .rx_data_delay = 0,	// RX_DATA/RX_FRAME delay = 0 ns                                    // rx_data_delay *** adi,rx-data-delay
+    .tx_fb_clock_delay = 0,	// FB_CLK delay = 0 ns                                              // tx_fb_clock_delay *** adi,tx-fb-clock-delay
+    .tx_data_delay = 5,	// TX_DATA/TX_FRAME delay = 1.5 ns                                  // tx_data_delay *** adi,tx-data-delay
+    .lvds_bias_mV = 300,	// LVDS driver bias 300 mV                                          // lvds_bias_mV *** adi,lvds-bias-mV
+    .lvds_rx_onchip_termination_enable = 1,	// Enable LVDS on-chip termination                                  // lvds_rx_onchip_termination_enable *** adi,lvds-rx-onchip-termination-enable
+    .rx1rx2_phase_inversion_en = 1,	// RX1 and RX2 are not phase-aligned                                // rx1rx2_phase_inversion_en *** adi,rx1-rx2-phase-inversion-enable
+    .lvds_invert1_control = 0xFF,	// Default signal inversion mappings                                // lvds_invert1_control *** adi,lvds-invert1-control
+    .lvds_invert2_control = 0x0F,	// Default signal inversion mappings                                // lvds_invert2_control *** adi,lvds-invert2-control
+    .clk_out_drive = 1,	// CLK_OUT drive increased by ~20%                                  // clk_out_drive
+    .dataclk_drive = 1,	// DATA_CLK drive increased by ~20%                                 // dataclk_drive
+    .data_port_drive = 1,	// Data port drive increased by ~20%                                // data_port_drive
+    .clk_out_slew = 0,	// CLK_OUT minimum slew (fastest rise/fall)                         // clk_out_slew
+    .dataclk_slew = 0,	// DATA_CLK minimum slew (fastest rise/fall)                        // dataclk_slew
+    .data_port_slew = 0,	// Data port minimum slew (fastest rise/fall)                       // data_port_slew
 
     /* GPO Control */
-    0,              // GPO0 is LOW in Sleep/Wait/Alert states                           // gpo0_inactive_state_high_enable *** adi,gpo0-inactive-state-high-enable
-    0,              // GPO1 is LOW in Sleep/Wait/Alert states                           // gpo1_inactive_state_high_enable *** adi,gpo1-inactive-state-high-enable
-    0,              // GPO2 is LOW in Sleep/Wait/Alert states                           // gpo2_inactive_state_high_enable *** adi,gpo2-inactive-state-high-enable
-    0,              // GPO3 is LOW in Sleep/Wait/Alert states                           // gpo3_inactive_state_high_enable *** adi,gpo3-inactive-state-high-enable
-    0,              // GPO0 does not change state when entering RX state                // gpo0_slave_rx_enable *** adi,gpo0-slave-rx-enable
-    0,              // GPO0 does not change state when entering TX state                // gpo0_slave_tx_enable *** adi,gpo0-slave-tx-enable
-    0,              // GPO1 does not change state when entering RX state                // gpo1_slave_rx_enable *** adi,gpo1-slave-rx-enable
-    0,              // GPO1 does not change state when entering TX state                // gpo1_slave_tx_enable *** adi,gpo1-slave-tx-enable
-    0,              // GPO2 does not change state when entering RX state                // gpo2_slave_rx_enable *** adi,gpo2-slave-rx-enable
-    0,              // GPO2 does not change state when entering TX state                // gpo2_slave_tx_enable *** adi,gpo2-slave-tx-enable
-    0,              // GPO3 does not change state when entering RX state                // gpo3_slave_rx_enable *** adi,gpo3-slave-rx-enable
-    0,              // GPO3 does not change state when entering TX state                // gpo3_slave_tx_enable *** adi,gpo3-slave-tx-enable
-    0,              // N/A when gpo0_slave_rx_enable = 0                                // gpo0_rx_delay_us *** adi,gpo0-rx-delay-us
-    0,              // N/A when gpo0_slave_tx_enable = 0                                // gpo0_tx_delay_us *** adi,gpo0-tx-delay-us
-    0,              // N/A when gpo1_slave_rx_enable = 0                                // gpo1_rx_delay_us *** adi,gpo1-rx-delay-us
-    0,              // N/A when gpo1_slave_tx_enable = 0                                // gpo1_tx_delay_us *** adi,gpo1-tx-delay-us
-    0,              // N/A when gpo2_slave_rx_enable = 0                                // gpo2_rx_delay_us *** adi,gpo2-rx-delay-us
-    0,              // N/A when gpo2_slave_tx_enable = 0                                // gpo2_tx_delay_us *** adi,gpo2-tx-delay-us
-    0,              // N/A when gpo3_slave_rx_enable = 0                                // gpo3_rx_delay_us *** adi,gpo3-rx-delay-us
-    0,              // N/A when gpo3_slave_tx_enable = 0                                // gpo3_tx_delay_us *** adi,gpo3-tx-delay-us
+    .gpo0_inactive_state_high_enable = 0,	// GPO0 is LOW in Sleep/Wait/Alert states                           // gpo0_inactive_state_high_enable *** adi,gpo0-inactive-state-high-enable
+    .gpo1_inactive_state_high_enable = 0,	// GPO1 is LOW in Sleep/Wait/Alert states                           // gpo1_inactive_state_high_enable *** adi,gpo1-inactive-state-high-enable
+    .gpo2_inactive_state_high_enable = 0,	// GPO2 is LOW in Sleep/Wait/Alert states                           // gpo2_inactive_state_high_enable *** adi,gpo2-inactive-state-high-enable
+    .gpo3_inactive_state_high_enable = 0,	// GPO3 is LOW in Sleep/Wait/Alert states                           // gpo3_inactive_state_high_enable *** adi,gpo3-inactive-state-high-enable
+    .gpo0_slave_rx_enable = 0,	// GPO0 does not change state when entering RX state                // gpo0_slave_rx_enable *** adi,gpo0-slave-rx-enable
+    .gpo0_slave_tx_enable = 0,	// GPO0 does not change state when entering TX state                // gpo0_slave_tx_enable *** adi,gpo0-slave-tx-enable
+    .gpo1_slave_rx_enable = 0,	// GPO1 does not change state when entering RX state                // gpo1_slave_rx_enable *** adi,gpo1-slave-rx-enable
+    .gpo1_slave_tx_enable = 0,	// GPO1 does not change state when entering TX state                // gpo1_slave_tx_enable *** adi,gpo1-slave-tx-enable
+    .gpo2_slave_rx_enable = 0,	// GPO2 does not change state when entering RX state                // gpo2_slave_rx_enable *** adi,gpo2-slave-rx-enable
+    .gpo2_slave_tx_enable = 0,	// GPO2 does not change state when entering TX state                // gpo2_slave_tx_enable *** adi,gpo2-slave-tx-enable
+    .gpo3_slave_rx_enable = 0,	// GPO3 does not change state when entering RX state                // gpo3_slave_rx_enable *** adi,gpo3-slave-rx-enable
+    .gpo3_slave_tx_enable = 0,	// GPO3 does not change state when entering TX state                // gpo3_slave_tx_enable *** adi,gpo3-slave-tx-enable
+    .gpo0_rx_delay_us = 0,	// N/A when gpo0_slave_rx_enable = 0                                // gpo0_rx_delay_us *** adi,gpo0-rx-delay-us
+    .gpo0_tx_delay_us = 0,	// N/A when gpo0_slave_tx_enable = 0                                // gpo0_tx_delay_us *** adi,gpo0-tx-delay-us
+    .gpo1_rx_delay_us = 0,	// N/A when gpo1_slave_rx_enable = 0                                // gpo1_rx_delay_us *** adi,gpo1-rx-delay-us
+    .gpo1_tx_delay_us = 0,	// N/A when gpo1_slave_tx_enable = 0                                // gpo1_tx_delay_us *** adi,gpo1-tx-delay-us
+    .gpo2_rx_delay_us = 0,	// N/A when gpo2_slave_rx_enable = 0                                // gpo2_rx_delay_us *** adi,gpo2-rx-delay-us
+    .gpo2_tx_delay_us = 0,	// N/A when gpo2_slave_tx_enable = 0                                // gpo2_tx_delay_us *** adi,gpo2-tx-delay-us
+    .gpo3_rx_delay_us = 0,	// N/A when gpo3_slave_rx_enable = 0                                // gpo3_rx_delay_us *** adi,gpo3-rx-delay-us
+    .gpo3_tx_delay_us = 0,	// N/A when gpo3_slave_tx_enable = 0                                // gpo3_tx_delay_us *** adi,gpo3-tx-delay-us
 
     /* Tx Monitor Control */
     /* bladeRF Micro: N/A, TX_MON1 and TX_MON2 tied to GND */
-    37000,          // N/A                                                              // low_high_gain_threshold_mdB *** adi,txmon-low-high-thresh
-    0,              // N/A                                                              // low_gain_dB *** adi,txmon-low-gain
-    24,             // N/A                                                              // high_gain_dB *** adi,txmon-high-gain
-    0,              // N/A                                                              // tx_mon_track_en *** adi,txmon-dc-tracking-enable
-    0,              // N/A                                                              // one_shot_mode_en *** adi,txmon-one-shot-mode-enable
-    511,            // N/A                                                              // tx_mon_delay *** adi,txmon-delay
-    8192,           // N/A                                                              // tx_mon_duration *** adi,txmon-duration
-    2,              // N/A                                                              // tx1_mon_front_end_gain *** adi,txmon-1-front-end-gain
-    2,              // N/A                                                              // tx2_mon_front_end_gain *** adi,txmon-2-front-end-gain
-    48,             // N/A                                                              // tx1_mon_lo_cm *** adi,txmon-1-lo-cm
-    48,             // N/A                                                              // tx2_mon_lo_cm *** adi,txmon-2-lo-cm
+    .low_high_gain_threshold_mdB = 37000,	// N/A                                                              // low_high_gain_threshold_mdB *** adi,txmon-low-high-thresh
+    .low_gain_dB = 0,	// N/A                                                              // low_gain_dB *** adi,txmon-low-gain
+    .high_gain_dB = 24,	// N/A                                                              // high_gain_dB *** adi,txmon-high-gain
+    .tx_mon_track_en = 0,	// N/A                                                              // tx_mon_track_en *** adi,txmon-dc-tracking-enable
+    .one_shot_mode_en = 0,	// N/A                                                              // one_shot_mode_en *** adi,txmon-one-shot-mode-enable
+    .tx_mon_delay = 511,	// N/A                                                              // tx_mon_delay *** adi,txmon-delay
+    .tx_mon_duration = 8192,	// N/A                                                              // tx_mon_duration *** adi,txmon-duration
+    .tx1_mon_front_end_gain = 2,	// N/A                                                              // tx1_mon_front_end_gain *** adi,txmon-1-front-end-gain
+    .tx2_mon_front_end_gain = 2,	// N/A                                                              // tx2_mon_front_end_gain *** adi,txmon-2-front-end-gain
+    .tx1_mon_lo_cm = 48,	// N/A                                                              // tx1_mon_lo_cm *** adi,txmon-1-lo-cm
+    .tx2_mon_lo_cm = 48,	// N/A                                                              // tx2_mon_lo_cm *** adi,txmon-2-lo-cm
 
     /* GPIO definitions */
-    RFFE_CONTROL_RESET_N,   // Reset using RFFE bit 0                                   // gpio_resetb *** reset-gpios
+    /* Bit of the FPGA RFFE control register, driven through the accessor
+     * table in platform_bladerf2. The device handle goes into .extra at
+     * init time, where it is known. */
+    .gpio_resetb = { .number = RFFE_CONTROL_RESET_N,
+                     .platform_ops = &bladerf2_gpio_ops },	// Reset using RFFE bit 0                                   // gpio_resetb *** reset-gpios
 
     /* MCS Sync */
-    -1,             // Future use (MCS Sync)                                            // gpio_sync *** sync-gpios
-    -1,             // Future use (MCS Sync)                                            // gpio_cal_sw1 *** cal-sw1-gpios
-    -1,             // Future use (MCS Sync)                                            // gpio_cal_sw2 *** cal-sw2-gpios
+    .gpio_sync = { .number = -1 },	// Future use (MCS Sync)                                            // gpio_sync *** sync-gpios
+    .gpio_cal_sw1 = { .number = -1 },	// Future use (MCS Sync)                                            // gpio_cal_sw1 *** cal-sw1-gpios
+    .gpio_cal_sw2 = { .number = -1 },	// Future use (MCS Sync)                                            // gpio_cal_sw2 *** cal-sw2-gpios
 
     /* External LO clocks */
-    NULL,           // Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
-    NULL,           // Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()
-    NULL            // Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_set_rate)()
+    /* SPI reaches the device through the accessor table in
+     * platform_bladerf2; the handle goes into .extra at init time. */
+    .spi_param = { .platform_ops = &bladerf2_spi_ops },
+
+    .ad9361_rfpll_ext_recalc_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
+    .ad9361_rfpll_ext_round_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()
+    .ad9361_rfpll_ext_set_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_set_rate)()
 };
 // clang-format on
 
@@ -307,287 +313,293 @@ AD9361_InitParam bladerf2_rfic_init_params = {
 // clang-format off
 AD9361_InitParam bladerf2_rfic_init_params_fastagc_burst = {
     /* Device selection */
-    ID_AD9361,      // AD9361 RF Agile Transceiver                                      // dev_sel
+    .dev_sel = ID_AD9361,	// AD9361 RF Agile Transceiver                                      // dev_sel
 
     /* Identification number */
-    0,              // Chip ID 0                                                        // id_no
 
     /* Reference Clock */
-    38400000UL,     // RefClk = 38.4 MHz                                                // reference_clk_rate
+    .reference_clk_rate = 38400000UL,	// RefClk = 38.4 MHz                                                // reference_clk_rate
 
     /* Base Configuration */
-    1,              // use 2Rx2Tx mode                                                  // two_rx_two_tx_mode_enable *** adi,2rx-2tx-mode-enable
-    1,              // N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_rx_num *** adi,1rx-1tx-mode-use-rx-num
-    1,              // N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_tx_num *** adi,1rx-1tx-mode-use-tx-num
-    1,              // use FDD mode                                                     // frequency_division_duplex_mode_enable *** adi,frequency-division-duplex-mode-enable
-    1,              // use independent FDD mode                                         // frequency_division_duplex_independent_mode_enable *** adi,frequency-division-duplex-independent-mode-enable
-    0,              // N/A when frequency_division_duplex_mode_enable = 1               // tdd_use_dual_synth_mode_enable *** adi,tdd-use-dual-synth-mode-enable
-    0,              // N/A when frequency_division_duplex_mode_enable = 1               // tdd_skip_vco_cal_enable *** adi,tdd-skip-vco-cal-enable
-    0,              // TX fastlock delay = 0 ns                                         // tx_fastlock_delay_ns *** adi,tx-fastlock-delay-ns
-    0,              // RX fastlock delay = 0 ns                                         // rx_fastlock_delay_ns *** adi,rx-fastlock-delay-ns
-    0,              // RX fastlock pin control disabled                                 // rx_fastlock_pincontrol_enable *** adi,rx-fastlock-pincontrol-enable
-    0,              // TX fastlock pin control disabled                                 // tx_fastlock_pincontrol_enable *** adi,tx-fastlock-pincontrol-enable
-    0,              // use internal RX LO                                               // external_rx_lo_enable *** adi,external-rx-lo-enable
-    0,              // use internal TX LO                                               // external_tx_lo_enable *** adi,external-tx-lo-enable
-    5,              // apply new tracking word: on gain change, after exiting RX state  // dc_offset_tracking_update_event_mask *** adi,dc-offset-tracking-update-event-mask
-    6,              // atten value for DC tracking, RX LO > 4 GHz                       // dc_offset_attenuation_high_range *** adi,dc-offset-attenuation-high-range
-    5,              // atten value for DC tracking, RX LO < 4 GHz                       // dc_offset_attenuation_low_range *** adi,dc-offset-attenuation-low-range
-    0x28,           // loop gain for DC tracking, RX LO > 4 GHz                         // dc_offset_count_high_range *** adi,dc-offset-count-high-range
-    0x32,           // loop gain for DC tracking, RX LO < 4 GHz                         // dc_offset_count_low_range *** adi,dc-offset-count-low-range
-    0,              // use full gain table                                              // split_gain_table_mode_enable *** adi,split-gain-table-mode-enable
-    MAX_SYNTH_FREF, // f_ref window 80 MHz                                              // trx_synthesizer_target_fref_overwrite_hz *** adi,trx-synthesizer-target-fref-overwrite-hz
-    0,              // don't use improved RX QEC tracking                               // qec_tracking_slow_mode_enable *** adi,qec-tracking-slow-mode-enable
+    .two_rx_two_tx_mode_enable = 1,	// use 2Rx2Tx mode                                                  // two_rx_two_tx_mode_enable *** adi,2rx-2tx-mode-enable
+    .one_rx_one_tx_mode_use_rx_num = 1,	// N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_rx_num *** adi,1rx-1tx-mode-use-rx-num
+    .one_rx_one_tx_mode_use_tx_num = 1,	// N/A when two_rx_two_tx_mode_enable = 1                           // one_rx_one_tx_mode_use_tx_num *** adi,1rx-1tx-mode-use-tx-num
+    .frequency_division_duplex_mode_enable = 1,	// use FDD mode                                                     // frequency_division_duplex_mode_enable *** adi,frequency-division-duplex-mode-enable
+    .frequency_division_duplex_independent_mode_enable = 1,	// use independent FDD mode                                         // frequency_division_duplex_independent_mode_enable *** adi,frequency-division-duplex-independent-mode-enable
+    .tdd_use_dual_synth_mode_enable = 0,	// N/A when frequency_division_duplex_mode_enable = 1               // tdd_use_dual_synth_mode_enable *** adi,tdd-use-dual-synth-mode-enable
+    .tdd_skip_vco_cal_enable = 0,	// N/A when frequency_division_duplex_mode_enable = 1               // tdd_skip_vco_cal_enable *** adi,tdd-skip-vco-cal-enable
+    .tx_fastlock_delay_ns = 0,	// TX fastlock delay = 0 ns                                         // tx_fastlock_delay_ns *** adi,tx-fastlock-delay-ns
+    .rx_fastlock_delay_ns = 0,	// RX fastlock delay = 0 ns                                         // rx_fastlock_delay_ns *** adi,rx-fastlock-delay-ns
+    .rx_fastlock_pincontrol_enable = 0,	// RX fastlock pin control disabled                                 // rx_fastlock_pincontrol_enable *** adi,rx-fastlock-pincontrol-enable
+    .tx_fastlock_pincontrol_enable = 0,	// TX fastlock pin control disabled                                 // tx_fastlock_pincontrol_enable *** adi,tx-fastlock-pincontrol-enable
+    .external_rx_lo_enable = 0,	// use internal RX LO                                               // external_rx_lo_enable *** adi,external-rx-lo-enable
+    .external_tx_lo_enable = 0,	// use internal TX LO                                               // external_tx_lo_enable *** adi,external-tx-lo-enable
+    .dc_offset_tracking_update_event_mask = 5,	// apply new tracking word: on gain change, after exiting RX state  // dc_offset_tracking_update_event_mask *** adi,dc-offset-tracking-update-event-mask
+    .dc_offset_attenuation_high_range = 6,	// atten value for DC tracking, RX LO > 4 GHz                       // dc_offset_attenuation_high_range *** adi,dc-offset-attenuation-high-range
+    .dc_offset_attenuation_low_range = 5,	// atten value for DC tracking, RX LO < 4 GHz                       // dc_offset_attenuation_low_range *** adi,dc-offset-attenuation-low-range
+    .dc_offset_count_high_range = 0x28,	// loop gain for DC tracking, RX LO > 4 GHz                         // dc_offset_count_high_range *** adi,dc-offset-count-high-range
+    .dc_offset_count_low_range = 0x32,	// loop gain for DC tracking, RX LO < 4 GHz                         // dc_offset_count_low_range *** adi,dc-offset-count-low-range
+    .split_gain_table_mode_enable = 0,	// use full gain table                                              // split_gain_table_mode_enable *** adi,split-gain-table-mode-enable
+    .trx_synthesizer_target_fref_overwrite_hz = MAX_SYNTH_FREF,	// f_ref window 80 MHz                                              // trx_synthesizer_target_fref_overwrite_hz *** adi,trx-synthesizer-target-fref-overwrite-hz
+    .qec_tracking_slow_mode_enable = 0,	// don't use improved RX QEC tracking                               // qec_tracking_slow_mode_enable *** adi,qec-tracking-slow-mode-enable
 
     /* ENSM Control */
-    0,              // use level mode on ENABLE and TXNRX pins                          // ensm_enable_pin_pulse_mode_enable *** adi,ensm-enable-pin-pulse-mode-enable
-    0,              // use SPI writes for ENSM state, not ENABLE/TXNRX pins             // ensm_enable_txnrx_control_enable *** adi,ensm-enable-txnrx-control-enable
+    .ensm_enable_pin_pulse_mode_enable = 0,	// use level mode on ENABLE and TXNRX pins                          // ensm_enable_pin_pulse_mode_enable *** adi,ensm-enable-pin-pulse-mode-enable
+    .ensm_enable_txnrx_control_enable = 0,	// use SPI writes for ENSM state, not ENABLE/TXNRX pins             // ensm_enable_txnrx_control_enable *** adi,ensm-enable-txnrx-control-enable
 
     /* LO Control */
-    2400000000UL,   // DEFAULT                                                          // rx_synthesizer_frequency_hz *** adi,rx-synthesizer-frequency-hz
-    2400000000UL,   // DEFAULT                                                          // tx_synthesizer_frequency_hz *** adi,tx-synthesizer-frequency-hz
+    .rx_synthesizer_frequency_hz = 2400000000UL,	// DEFAULT                                                          // rx_synthesizer_frequency_hz *** adi,rx-synthesizer-frequency-hz
+    .tx_synthesizer_frequency_hz = 2400000000UL,	// DEFAULT                                                          // tx_synthesizer_frequency_hz *** adi,tx-synthesizer-frequency-hz
 
     /* Rate & BW Control */
-    { 983040000, 245760000, 122880000, 61440000, 30720000, 30720000 },  // DEFAULT      // uint32_t rx_path_clock_frequencies[6] *** adi,rx-path-clock-frequencies
-    { 983040000, 122880000, 122880000, 61440000, 30720000, 30720000 },  // DEFAULT      // uint32_t tx_path_clock_frequencies[6] *** adi,tx-path-clock-frequencies
-    18000000,       // DEFAULT                                                          // rf_rx_bandwidth_hz *** adi,rf-rx-bandwidth-hz
-    18000000,       // DEFAULT                                                          // rf_tx_bandwidth_hz *** adi,rf-tx-bandwidth-hz
+    .rx_path_clock_frequencies = { 983040000, 245760000, 122880000, 61440000, 30720000, 30720000 },	// DEFAULT      // uint32_t rx_path_clock_frequencies[6] *** adi,rx-path-clock-frequencies
+    .tx_path_clock_frequencies = { 983040000, 122880000, 122880000, 61440000, 30720000, 30720000 },	// DEFAULT      // uint32_t tx_path_clock_frequencies[6] *** adi,tx-path-clock-frequencies
+    .rf_rx_bandwidth_hz = 18000000,	// DEFAULT                                                          // rf_rx_bandwidth_hz *** adi,rf-rx-bandwidth-hz
+    .rf_tx_bandwidth_hz = 18000000,	// DEFAULT                                                          // rf_tx_bandwidth_hz *** adi,rf-tx-bandwidth-hz
 
     /* RF Port Control */
-    0,              // DEFAULT                                                          // rx_rf_port_input_select *** adi,rx-rf-port-input-select
-    0,              // DEFAULT                                                          // tx_rf_port_input_select *** adi,tx-rf-port-input-select
+    .rx_rf_port_input_select = 0,	// DEFAULT                                                          // rx_rf_port_input_select *** adi,rx-rf-port-input-select
+    .tx_rf_port_input_select = 0,	// DEFAULT                                                          // tx_rf_port_input_select *** adi,tx-rf-port-input-select
 
     /* TX Attenuation Control */
-    10000,          // DEFAULT                                                          // tx_attenuation_mdB *** adi,tx-attenuation-mdB
-    0,              // N/A when frequency_division_duplex_mode_enable = 1               // update_tx_gain_in_alert_enable *** adi,update-tx-gain-in-alert-enable
+    .tx_attenuation_mdB = 10000,	// DEFAULT                                                          // tx_attenuation_mdB *** adi,tx-attenuation-mdB
+    .update_tx_gain_in_alert_enable = 0,	// N/A when frequency_division_duplex_mode_enable = 1               // update_tx_gain_in_alert_enable *** adi,update-tx-gain-in-alert-enable
 
     /* Reference Clock Control */
-    1,              // Expect external clock into XTALN                                 // xo_disable_use_ext_refclk_enable *** adi,xo-disable-use-ext-refclk-enable
-    {3, 5920},      // ~0 ppm DCXO trim (N/A if ext clk)                                // dcxo_coarse_and_fine_tune[2] *** adi,dcxo-coarse-and-fine-tune
-    CLKOUT_DISABLE, // disable clkout pin (see enum ad9361_clkout)                      // clk_output_mode_select *** adi,clk-output-mode-select
+    .xo_disable_use_ext_refclk_enable = 1,	// Expect external clock into XTALN                                 // xo_disable_use_ext_refclk_enable *** adi,xo-disable-use-ext-refclk-enable
+    .dcxo_coarse_and_fine_tune = {3, 5920},	// ~0 ppm DCXO trim (N/A if ext clk)                                // dcxo_coarse_and_fine_tune[2] *** adi,dcxo-coarse-and-fine-tune
+    .clk_output_mode_select = CLKOUT_DISABLE,	// disable clkout pin (see enum ad9361_clkout)                      // clk_output_mode_select *** adi,clk-output-mode-select
 
     /* Gain Control */
-    RF_GAIN_FASTATTACK_AGC, // RX1 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx1_mode *** adi,gc-rx1-mode
-    RF_GAIN_FASTATTACK_AGC, // RX2 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx2_mode *** adi,gc-rx2-mode
-    58,             // magic AGC setting, see AD9361 docs                               // gc_adc_large_overload_thresh *** adi,gc-adc-large-overload-thresh
-    4,              // magic AGC setting, see AD9361 docs                               // gc_adc_ovr_sample_size *** adi,gc-adc-ovr-sample-size
-    47,             // magic AGC setting, see AD9361 docs                               // gc_adc_small_overload_thresh *** adi,gc-adc-small-overload-thresh
-    2,           // magic AGC setting, see AD9361 docs                               // gc_dec_pow_measurement_duration *** adi,gc-dec-pow-measurement-duration
-    0,              // magic AGC setting, see AD9361 docs                               // gc_dig_gain_enable *** adi,gc-dig-gain-enable
-    480,            // magic AGC setting, see AD9361 docs                               // gc_lmt_overload_high_thresh *** adi,gc-lmt-overload-high-thresh
-    400,            //  magic AGC setting, see AD9361 docs                               // gc_lmt_overload_low_thresh *** adi,gc-lmt-overload-low-thresh
-    40,             // magic AGC setting, see AD9361 docs                               // gc_low_power_thresh *** adi,gc-low-power-thresh
-    15,             // magic AGC setting, see AD9361 docs                               // gc_max_dig_gain *** adi,gc-max-dig-gain
+    .gc_rx1_mode = RF_GAIN_FASTATTACK_AGC,	// RX1 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx1_mode *** adi,gc-rx1-mode
+    .gc_rx2_mode = RF_GAIN_FASTATTACK_AGC,	// RX2 BLADERF_GAIN_DEFAULT = slow attack AGC               // gc_rx2_mode *** adi,gc-rx2-mode
+    .gc_adc_large_overload_thresh = 58,	// magic AGC setting, see AD9361 docs                               // gc_adc_large_overload_thresh *** adi,gc-adc-large-overload-thresh
+    .gc_adc_ovr_sample_size = 4,	// magic AGC setting, see AD9361 docs                               // gc_adc_ovr_sample_size *** adi,gc-adc-ovr-sample-size
+    .gc_adc_small_overload_thresh = 47,	// magic AGC setting, see AD9361 docs                               // gc_adc_small_overload_thresh *** adi,gc-adc-small-overload-thresh
+    .gc_dec_pow_measurement_duration = 2,	// magic AGC setting, see AD9361 docs                               // gc_dec_pow_measurement_duration *** adi,gc-dec-pow-measurement-duration
+    .gc_dig_gain_enable = 0,	// magic AGC setting, see AD9361 docs                               // gc_dig_gain_enable *** adi,gc-dig-gain-enable
+    .gc_lmt_overload_high_thresh = 480,	// magic AGC setting, see AD9361 docs                               // gc_lmt_overload_high_thresh *** adi,gc-lmt-overload-high-thresh
+    .gc_lmt_overload_low_thresh = 400,	//  magic AGC setting, see AD9361 docs                               // gc_lmt_overload_low_thresh *** adi,gc-lmt-overload-low-thresh
+    .gc_low_power_thresh = 40,	// magic AGC setting, see AD9361 docs                               // gc_low_power_thresh *** adi,gc-low-power-thresh
+    .gc_max_dig_gain = 15,	// magic AGC setting, see AD9361 docs                               // gc_max_dig_gain *** adi,gc-max-dig-gain
 
     /* Gain MGC Control */
-    2,              // N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_dec_gain_step *** adi,mgc-dec-gain-step
-    2,              // N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_inc_gain_step *** adi,mgc-inc-gain-step
-    0,              // don't use CTRL_IN for RX1 MGC stepping                           // mgc_rx1_ctrl_inp_enable *** adi,mgc-rx1-ctrl-inp-enable
-    0,              // don't use CTRL_IN for RX2 MGC stepping                           // mgc_rx2_ctrl_inp_enable *** adi,mgc-rx2-ctrl-inp-enable
-    0,              // N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_split_table_ctrl_inp_gain_mode *** adi,mgc-split-table-ctrl-inp-gain-mode
+    .mgc_dec_gain_step = 2,	// N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_dec_gain_step *** adi,mgc-dec-gain-step
+    .mgc_inc_gain_step = 2,	// N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_inc_gain_step *** adi,mgc-inc-gain-step
+    .mgc_rx1_ctrl_inp_enable = 0,	// don't use CTRL_IN for RX1 MGC stepping                           // mgc_rx1_ctrl_inp_enable *** adi,mgc-rx1-ctrl-inp-enable
+    .mgc_rx2_ctrl_inp_enable = 0,	// don't use CTRL_IN for RX2 MGC stepping                           // mgc_rx2_ctrl_inp_enable *** adi,mgc-rx2-ctrl-inp-enable
+    .mgc_split_table_ctrl_inp_gain_mode = 0,	// N/A when mgc_rx(1,2)_ctrl_inp_enable = 0                         // mgc_split_table_ctrl_inp_gain_mode *** adi,mgc-split-table-ctrl-inp-gain-mode
 
     /* Gain AGC Control */
-    10,             // magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_exceed_counter *** adi,agc-adc-large-overload-exceed-counter
-    2,              // magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_inc_steps *** adi,agc-adc-large-overload-inc-steps
-    0,              // magic AGC setting, see AD9361 docs                               // agc_adc_lmt_small_overload_prevent_gain_inc_enable *** adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable
-    10,             // magic AGC setting, see AD9361 docs                               // agc_adc_small_overload_exceed_counter *** adi,agc-adc-small-overload-exceed-counter
-    4,              // magic AGC setting, see AD9361 docs                               // agc_dig_gain_step_size *** adi,agc-dig-gain-step-size
-    3,              // magic AGC setting, see AD9361 docs                               // agc_dig_saturation_exceed_counter *** adi,agc-dig-saturation-exceed-counter
-    1,           // magic AGC setting, see AD9361 docs                               // agc_gain_update_interval_us *** adi,agc-gain-update-interval-us
-    0,              // magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_adc_overload_enable *** adi,agc-immed-gain-change-if-large-adc-overload-enable
-    0,              // magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_lmt_overload_enable *** adi,agc-immed-gain-change-if-large-lmt-overload-enable
-    10,             // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high *** adi,agc-inner-thresh-high
-    1,              // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high_dec_steps *** adi,agc-inner-thresh-high-dec-steps
-    12,             // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low *** adi,agc-inner-thresh-low
-    1,              // magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low_inc_steps *** adi,agc-inner-thresh-low-inc-steps
-    10,             // magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_exceed_counter *** adi,agc-lmt-overload-large-exceed-counter
-    2,              // magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_inc_steps *** adi,agc-lmt-overload-large-inc-steps
-    10,             // magic AGC setting, see AD9361 docs                               // agc_lmt_overload_small_exceed_counter *** adi,agc-lmt-overload-small-exceed-counter
-    5,              // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high *** adi,agc-outer-thresh-high
-    2,              // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high_dec_steps *** adi,agc-outer-thresh-high-dec-steps
-    18,             // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low *** adi,agc-outer-thresh-low
-    2,              // magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low_inc_steps *** adi,agc-outer-thresh-low-inc-steps
-    1,              // magic AGC setting, see AD9361 docs                               // agc_attack_delay_extra_margin_us; *** adi,agc-attack-delay-extra-margin-us
-    0,              // magic AGC setting, see AD9361 docs                               // agc_sync_for_gain_counter_enable *** adi,agc-sync-for-gain-counter-enable
+    .agc_adc_large_overload_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_exceed_counter *** adi,agc-adc-large-overload-exceed-counter
+    .agc_adc_large_overload_inc_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_adc_large_overload_inc_steps *** adi,agc-adc-large-overload-inc-steps
+    .agc_adc_lmt_small_overload_prevent_gain_inc_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_adc_lmt_small_overload_prevent_gain_inc_enable *** adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable
+    .agc_adc_small_overload_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_adc_small_overload_exceed_counter *** adi,agc-adc-small-overload-exceed-counter
+    .agc_dig_gain_step_size = 4,	// magic AGC setting, see AD9361 docs                               // agc_dig_gain_step_size *** adi,agc-dig-gain-step-size
+    .agc_dig_saturation_exceed_counter = 3,	// magic AGC setting, see AD9361 docs                               // agc_dig_saturation_exceed_counter *** adi,agc-dig-saturation-exceed-counter
+    .agc_gain_update_interval_us = 1,	// magic AGC setting, see AD9361 docs                               // agc_gain_update_interval_us *** adi,agc-gain-update-interval-us
+    .agc_immed_gain_change_if_large_adc_overload_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_adc_overload_enable *** adi,agc-immed-gain-change-if-large-adc-overload-enable
+    .agc_immed_gain_change_if_large_lmt_overload_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_immed_gain_change_if_large_lmt_overload_enable *** adi,agc-immed-gain-change-if-large-lmt-overload-enable
+    .agc_inner_thresh_high = 10,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high *** adi,agc-inner-thresh-high
+    .agc_inner_thresh_high_dec_steps = 1,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_high_dec_steps *** adi,agc-inner-thresh-high-dec-steps
+    .agc_inner_thresh_low = 12,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low *** adi,agc-inner-thresh-low
+    .agc_inner_thresh_low_inc_steps = 1,	// magic AGC setting, see AD9361 docs                               // agc_inner_thresh_low_inc_steps *** adi,agc-inner-thresh-low-inc-steps
+    .agc_lmt_overload_large_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_exceed_counter *** adi,agc-lmt-overload-large-exceed-counter
+    .agc_lmt_overload_large_inc_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_lmt_overload_large_inc_steps *** adi,agc-lmt-overload-large-inc-steps
+    .agc_lmt_overload_small_exceed_counter = 10,	// magic AGC setting, see AD9361 docs                               // agc_lmt_overload_small_exceed_counter *** adi,agc-lmt-overload-small-exceed-counter
+    .agc_outer_thresh_high = 5,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high *** adi,agc-outer-thresh-high
+    .agc_outer_thresh_high_dec_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_high_dec_steps *** adi,agc-outer-thresh-high-dec-steps
+    .agc_outer_thresh_low = 18,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low *** adi,agc-outer-thresh-low
+    .agc_outer_thresh_low_inc_steps = 2,	// magic AGC setting, see AD9361 docs                               // agc_outer_thresh_low_inc_steps *** adi,agc-outer-thresh-low-inc-steps
+    .agc_attack_delay_extra_margin_us = 1,	// magic AGC setting, see AD9361 docs                               // agc_attack_delay_extra_margin_us; *** adi,agc-attack-delay-extra-margin-us
+    .agc_sync_for_gain_counter_enable = 0,	// magic AGC setting, see AD9361 docs                               // agc_sync_for_gain_counter_enable *** adi,agc-sync-for-gain-counter-enable
 
     /* Fast AGC */
-    16,             // magic AGC setting, see AD9361 docs                               // fagc_dec_pow_measuremnt_duration ***  adi,fagc-dec-pow-measurement-duration
-    260,            // magic AGC setting, see AD9361 docs                               // fagc_state_wait_time_ns ***  adi,fagc-state-wait-time-ns
+    .fagc_dec_pow_measuremnt_duration = 16,	// magic AGC setting, see AD9361 docs                               // fagc_dec_pow_measuremnt_duration ***  adi,fagc-dec-pow-measurement-duration
+    .fagc_state_wait_time_ns = 260,	// magic AGC setting, see AD9361 docs                               // fagc_state_wait_time_ns ***  adi,fagc-state-wait-time-ns
 
     /* Fast AGC - Low Power */
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_allow_agc_gain_increase ***  adi,fagc-allow-agc-gain-increase-enable
-    5,              // magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_time ***  adi,fagc-lp-thresh-increment-time
-    7,              // magic AGC setting, see AD9361 docs                               // fagc.lp_thresh_increment_steps ***  adi,fagc-lp-thresh-increment-steps
+    .fagc_allow_agc_gain_increase = 0,	// magic AGC setting, see AD9361 docs                               // fagc_allow_agc_gain_increase ***  adi,fagc-allow-agc-gain-increase-enable
+    .fagc_lp_thresh_increment_time = 5,	// magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_time ***  adi,fagc-lp-thresh-increment-time
+    .fagc_lp_thresh_increment_steps = 7,	// magic AGC setting, see AD9361 docs                               // fagc_lp_thresh_increment_steps ***  adi,fagc-lp-thresh-increment-steps
 
     /* Fast AGC - Lock Level */
-    10,             // magic AGC setting, see AD9361 docs                               // fagc_lock_level ***  adi,fagc-lock-level
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lock_level_lmt_gain_increase_en ***  adi,fagc-lock-level-lmt-gain-increase-enable
-    63,              // magic AGC setting, see AD9361 docs                               // fagc_lock_level_gain_increase_upper_limit ***  adi,fagc-lock-level-gain-increase-upper-limit
+    .fagc_lock_level_lmt_gain_increase_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lock_level_lmt_gain_increase_en ***  adi,fagc-lock-level-lmt-gain-increase-enable
+    .fagc_lock_level_gain_increase_upper_limit = 63,	// magic AGC setting, see AD9361 docs                               // fagc_lock_level_gain_increase_upper_limit ***  adi,fagc-lock-level-gain-increase-upper-limit
 
     /* Fast AGC - Peak Detectors and Final Settling */
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lpf_final_settling_steps ***  adi,fagc-lpf-final-settling-steps
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_lmt_final_settling_steps ***  adi,fagc-lmt-final-settling-steps
-    3,              // magic AGC setting, see AD9361 docs                               // fagc_final_overrange_count ***  adi,fagc-final-overrange-count
+    .fagc_lpf_final_settling_steps = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lpf_final_settling_steps ***  adi,fagc-lpf-final-settling-steps
+    .fagc_lmt_final_settling_steps = 1,	// magic AGC setting, see AD9361 docs                               // fagc_lmt_final_settling_steps ***  adi,fagc-lmt-final-settling-steps
+    .fagc_final_overrange_count = 3,	// magic AGC setting, see AD9361 docs                               // fagc_final_overrange_count ***  adi,fagc-final-overrange-count
 
     /* Fast AGC - Final Power Test */
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_gain_increase_after_gain_lock_en ***  adi,fagc-gain-increase-after-gain-lock-enable
+    .fagc_gain_increase_after_gain_lock_en = 0,	// magic AGC setting, see AD9361 docs                               // fagc_gain_increase_after_gain_lock_en ***  adi,fagc-gain-increase-after-gain-lock-enable
 
     /* Fast AGC - Unlocking the Gain */
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_gain_index_type_after_exit_rx_mode ***  adi,fagc-gain-index-type-after-exit-rx-mode
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_use_last_lock_level_for_set_gain_en ***  adi,fagc-use-last-lock-level-for-set-gain-enable
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-stronger-sig-thresh-exceeded-enable
-    5,              // magic AGC setting, see AD9361 docs                               // fagc_optimized_gain_offset ***  adi,fagc-optimized-gain-offset
-    10,             // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_above_ll ***  adi,fagc-rst-gla-stronger-sig-thresh-above-ll
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-exceeded-enable
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_goto_optim_gain_en ***  adi,fagc-rst-gla-engergy-lost-goto-optim-gain-enable
-    10,             // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_below_ll ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-below-ll
-    3,              // magic AGC setting, see AD9361 docs                               // fagc_energy_lost_stronger_sig_gain_lock_exit_cnt ***  adi,fagc-energy-lost-stronger-sig-gain-lock-exit-cnt
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_adc_overload_en ***  adi,fagc-rst-gla-large-adc-overload-enable
-    1,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_lmt_overload_en ***  adi,fagc-rst-gla-large-lmt-overload-enable
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_en_agc_pulled_high_en ***  adi,fagc-rst-gla-en-agc-pulled-high-enable
-    0,              // magic AGC setting, see AD9361 docs                               // fagc_rst_gla_if_en_agc_pulled_high_mode ***  adi,fagc-rst-gla-if-en-agc-pulled-high-mode
-    64,             // magic AGC setting, see AD9361 docs                               // fagc_power_measurement_duration_in_state5 ***  adi,fagc-power-measurement-duration-in-state5
+    .fagc_gain_index_type_after_exit_rx_mode = 0,	// magic AGC setting, see AD9361 docs                               // fagc_gain_index_type_after_exit_rx_mode ***  adi,fagc-gain-index-type-after-exit-rx-mode
+    .fagc_use_last_lock_level_for_set_gain_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_use_last_lock_level_for_set_gain_en ***  adi,fagc-use-last-lock-level-for-set-gain-enable
+    .fagc_rst_gla_stronger_sig_thresh_exceeded_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-stronger-sig-thresh-exceeded-enable
+    .fagc_optimized_gain_offset = 5,	// magic AGC setting, see AD9361 docs                               // fagc_optimized_gain_offset ***  adi,fagc-optimized-gain-offset
+    .fagc_rst_gla_stronger_sig_thresh_above_ll = 10,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_stronger_sig_thresh_above_ll ***  adi,fagc-rst-gla-stronger-sig-thresh-above-ll
+    .fagc_rst_gla_engergy_lost_sig_thresh_exceeded_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_exceeded_en ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-exceeded-enable
+    .fagc_rst_gla_engergy_lost_goto_optim_gain_en = 0,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_goto_optim_gain_en ***  adi,fagc-rst-gla-engergy-lost-goto-optim-gain-enable
+    .fagc_rst_gla_engergy_lost_sig_thresh_below_ll = 10,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_engergy_lost_sig_thresh_below_ll ***  adi,fagc-rst-gla-engergy-lost-sig-thresh-below-ll
+    .fagc_energy_lost_stronger_sig_gain_lock_exit_cnt = 3,	// magic AGC setting, see AD9361 docs                               // fagc_energy_lost_stronger_sig_gain_lock_exit_cnt ***  adi,fagc-energy-lost-stronger-sig-gain-lock-exit-cnt
+    .fagc_rst_gla_large_adc_overload_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_adc_overload_en ***  adi,fagc-rst-gla-large-adc-overload-enable
+    .fagc_rst_gla_large_lmt_overload_en = 1,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_large_lmt_overload_en ***  adi,fagc-rst-gla-large-lmt-overload-enable
+    .fagc_rst_gla_en_agc_pulled_high_en = 0,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_en_agc_pulled_high_en ***  adi,fagc-rst-gla-en-agc-pulled-high-enable
+    .fagc_rst_gla_if_en_agc_pulled_high_mode = 0,	// magic AGC setting, see AD9361 docs                               // fagc_rst_gla_if_en_agc_pulled_high_mode ***  adi,fagc-rst-gla-if-en-agc-pulled-high-mode
+    .fagc_power_measurement_duration_in_state5 = 64,	// magic AGC setting, see AD9361 docs                               // fagc_power_measurement_duration_in_state5 ***  adi,fagc-power-measurement-duration-in-state5
 
     /* RSSI Control */
-    1,              // settling delay on RSSI algo restart = 1 μs                       // rssi_delay *** adi,rssi-delay
-    1000,           // total RSSI measurement duration = 1000 μs                        // rssi_duration *** adi,rssi-duration
-    GAIN_CHANGE_OCCURS, // reset RSSI accumulator on gain change event                  // rssi_restart_mode *** adi,rssi-restart-mode
-    0,              // RSSI control values are in microseconds                          // rssi_unit_is_rx_samples_enable *** adi,rssi-unit-is-rx-samples-enable
-    1,              // wait 1 μs between RSSI measurements                              // rssi_wait *** adi,rssi-wait
+    .rssi_delay = 1,	// settling delay on RSSI algo restart = 1 μs                       // rssi_delay *** adi,rssi-delay
+    .rssi_duration = 1000,	// total RSSI measurement duration = 1000 μs                        // rssi_duration *** adi,rssi-duration
+    .rssi_restart_mode = GAIN_CHANGE_OCCURS,	// reset RSSI accumulator on gain change event                  // rssi_restart_mode *** adi,rssi-restart-mode
+    .rssi_unit_is_rx_samples_enable = 0,	// RSSI control values are in microseconds                          // rssi_unit_is_rx_samples_enable *** adi,rssi-unit-is-rx-samples-enable
+    .rssi_wait = 1,	// wait 1 μs between RSSI measurements                              // rssi_wait *** adi,rssi-wait
 
     /* Aux ADC Control */
     /* bladeRF Micro: N/A, pin tied to GND */
-    256,            // AuxADC decimate by 256                                           // aux_adc_decimation *** adi,aux-adc-decimation
-    40000000UL,     // AuxADC sample rate 40 MHz                                        // aux_adc_rate *** adi,aux-adc-rate
+    .aux_adc_decimation = 256,	// AuxADC decimate by 256                                           // aux_adc_decimation *** adi,aux-adc-decimation
+    .aux_adc_rate = 40000000UL,	// AuxADC sample rate 40 MHz                                        // aux_adc_rate *** adi,aux-adc-rate
 
     /* AuxDAC Control */
     /* bladeRF Micro: AuxDAC1 is TP7 and AUXDAC_TRIM, AuxDAC2 is TP8 */
-    1,              // AuxDAC does not slave the ENSM                                   // aux_dac_manual_mode_enable ***  adi,aux-dac-manual-mode-enable
-    0,              // AuxDAC1 default value = 0 mV                                     // aux_dac1_default_value_mV ***  adi,aux-dac1-default-value-mV
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_rx_enable ***  adi,aux-dac1-active-in-rx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_tx_enable ***  adi,aux-dac1-active-in-tx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_alert_enable ***  adi,aux-dac1-active-in-alert-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_rx_delay_us ***  adi,aux-dac1-rx-delay-us
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_tx_delay_us ***  adi,aux-dac1-tx-delay-us
-    0,              // AuxDAC2 default value = 0 mV                                     // aux_dac2_default_value_mV ***  adi,aux-dac2-default-value-mV
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_rx_enable ***  adi,aux-dac2-active-in-rx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_tx_enable ***  adi,aux-dac2-active-in-tx-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_alert_enable ***  adi,aux-dac2-active-in-alert-enable
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_rx_delay_us ***  adi,aux-dac2-rx-delay-us
-    0,              // N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_tx_delay_us ***  adi,aux-dac2-tx-delay-us
+    .aux_dac_manual_mode_enable = 1,	// AuxDAC does not slave the ENSM                                   // aux_dac_manual_mode_enable ***  adi,aux-dac-manual-mode-enable
+    .aux_dac1_default_value_mV = 0,	// AuxDAC1 default value = 0 mV                                     // aux_dac1_default_value_mV ***  adi,aux-dac1-default-value-mV
+    .aux_dac1_active_in_rx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_rx_enable ***  adi,aux-dac1-active-in-rx-enable
+    .aux_dac1_active_in_tx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_tx_enable ***  adi,aux-dac1-active-in-tx-enable
+    .aux_dac1_active_in_alert_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_active_in_alert_enable ***  adi,aux-dac1-active-in-alert-enable
+    .aux_dac1_rx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_rx_delay_us ***  adi,aux-dac1-rx-delay-us
+    .aux_dac1_tx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac1_tx_delay_us ***  adi,aux-dac1-tx-delay-us
+    .aux_dac2_default_value_mV = 0,	// AuxDAC2 default value = 0 mV                                     // aux_dac2_default_value_mV ***  adi,aux-dac2-default-value-mV
+    .aux_dac2_active_in_rx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_rx_enable ***  adi,aux-dac2-active-in-rx-enable
+    .aux_dac2_active_in_tx_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_tx_enable ***  adi,aux-dac2-active-in-tx-enable
+    .aux_dac2_active_in_alert_enable = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_active_in_alert_enable ***  adi,aux-dac2-active-in-alert-enable
+    .aux_dac2_rx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_rx_delay_us ***  adi,aux-dac2-rx-delay-us
+    .aux_dac2_tx_delay_us = 0,	// N/A when aux_dac_manual_mode_enable = 1                          // aux_dac2_tx_delay_us ***  adi,aux-dac2-tx-delay-us
 
     /* Temperature Sensor Control */
-    256,            // Temperature sensor decimate by 256                               // temp_sense_decimation *** adi,temp-sense-decimation
-    1000,           // Measure temperature every 1000 ms                                // temp_sense_measurement_interval_ms *** adi,temp-sense-measurement-interval-ms
-    206,            // Offset = +206 degrees C                                          // temp_sense_offset_signed *** adi,temp-sense-offset-signed
-    1,              // Periodic temperature measurements enabled                        // temp_sense_periodic_measurement_enable *** adi,temp-sense-periodic-measurement-enable
+    .temp_sense_decimation = 256,	// Temperature sensor decimate by 256                               // temp_sense_decimation *** adi,temp-sense-decimation
+    .temp_sense_measurement_interval_ms = 1000,	// Measure temperature every 1000 ms                                // temp_sense_measurement_interval_ms *** adi,temp-sense-measurement-interval-ms
+    .temp_sense_offset_signed = 206,	// Offset = +206 degrees C                                          // temp_sense_offset_signed *** adi,temp-sense-offset-signed
+    .temp_sense_periodic_measurement_enable = 1,	// Periodic temperature measurements enabled                        // temp_sense_periodic_measurement_enable *** adi,temp-sense-periodic-measurement-enable
 
     /* Control Out Setup */
     /* See https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361-customization#control_output_setup */
-    0xFF,           // Enable all CTRL_OUT bits                                         // ctrl_outs_enable_mask *** adi,ctrl-outs-enable-mask
-    7,              // CTRL_OUT index is 0                                              // ctrl_outs_index *** adi,ctrl-outs-index
+    .ctrl_outs_enable_mask = 0xFF,	// Enable all CTRL_OUT bits                                         // ctrl_outs_enable_mask *** adi,ctrl-outs-enable-mask
+    .ctrl_outs_index = 7,	// CTRL_OUT index is 0                                              // ctrl_outs_index *** adi,ctrl-outs-index
 
     /* External LNA Control */
     /* bladeRF Micro: GPO_0 is TP3, GPO_1 is TP4 */
-    0,              // N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_settling_delay_ns *** adi,elna-settling-delay-ns
-    0,              // MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_gain_mdB *** adi,elna-gain-mdB
-    0,              // MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_bypass_loss_mdB *** adi,elna-bypass-loss-mdB
-    0,              // Ext LNA Ctrl bit in Rx1 gain table does NOT set GPO0 state       // elna_rx1_gpo0_control_enable *** adi,elna-rx1-gpo0-control-enable
-    0,              // Ext LNA Ctrl bit in Rx2 gain table does NOT set GPO1 state       // elna_rx2_gpo1_control_enable *** adi,elna-rx2-gpo1-control-enable
-    0,              // N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_gaintable_all_index_enable *** adi,elna-gaintable-all-index-enable
+    .elna_settling_delay_ns = 0,	// N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_settling_delay_ns *** adi,elna-settling-delay-ns
+    .elna_gain_mdB = 0,	// MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_gain_mdB *** adi,elna-gain-mdB
+    .elna_bypass_loss_mdB = 0,	// MUST be 0 when elna_rx(1,2)_gpo(0,1)_control_enable = 0          // elna_bypass_loss_mdB *** adi,elna-bypass-loss-mdB
+    .elna_rx1_gpo0_control_enable = 0,	// Ext LNA Ctrl bit in Rx1 gain table does NOT set GPO0 state       // elna_rx1_gpo0_control_enable *** adi,elna-rx1-gpo0-control-enable
+    .elna_rx2_gpo1_control_enable = 0,	// Ext LNA Ctrl bit in Rx2 gain table does NOT set GPO1 state       // elna_rx2_gpo1_control_enable *** adi,elna-rx2-gpo1-control-enable
+    .elna_gaintable_all_index_enable = 0,	// N/A when elna_rx(1,2)_gpo(0,1)_control_enable = 0                // elna_gaintable_all_index_enable *** adi,elna-gaintable-all-index-enable
 
     /* Digital Interface Control */
 #ifdef ENABLE_AD9361_DIGITAL_INTERFACE_TIMING_VERIFICATION
     /* Calibrate the digital interface delay (hardware validation) */
-    0,              // Don't skip digital interface tuning                              // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
+    .digital_interface_tune_skip_mode = 0,	// Don't skip digital interface tuning                              // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
 #else
     /* Use hardcoded digital interface delay values (production) */
-    2,              // Skip RX and TX tuning; use hardcoded values below                // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
+    .digital_interface_tune_skip_mode = 2,	// Skip RX and TX tuning; use hardcoded values below                // digital_interface_tune_skip_mode *** adi,digital-interface-tune-skip-mode
 #endif // ENABLE_AD9361_DIGITAL_INTERFACE_TIMING_VERIFICATION
-    0,              // ?? UNDOCUMENTED ??                                               // digital_interface_tune_fir_disable *** adi,digital-interface-tune-fir-disable
-    1,              // Swap I and Q (spectral inversion)                                // pp_tx_swap_enable *** adi,pp-tx-swap-enable
-    1,              // Swap I and Q (spectral inversion)                                // pp_rx_swap_enable *** adi,pp-rx-swap-enable
-    0,              // Don't swap TX1 and TX2                                           // tx_channel_swap_enable *** adi,tx-channel-swap-enable
-    0,              // Don't swap RX1 and RX2                                           // rx_channel_swap_enable *** adi,rx-channel-swap-enable
-    1,              // Toggle RX_FRAME with 50% duty cycle                              // rx_frame_pulse_mode_enable *** adi,rx-frame-pulse-mode-enable
-    0,              // Data port timing reflects # of enabled signal paths              // two_t_two_r_timing_enable *** adi,2t2r-timing-enable
-    0,              // Don't invert data bus                                            // invert_data_bus_enable *** adi,invert-data-bus-enable
-    0,              // Don't invert data clock                                          // invert_data_clk_enable *** adi,invert-data-clk-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // fdd_alt_word_order_enable *** adi,fdd-alt-word-order-enable
-    0,              // Don't invert RX_FRAME                                            // invert_rx_frame_enable *** adi,invert-rx-frame-enable
-    0,              // Don't make RX sample rate 2x the TX sample rate                  // fdd_rx_rate_2tx_enable *** adi,fdd-rx-rate-2tx-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // swap_ports_enable *** adi,swap-ports-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // single_data_rate_enable *** adi,single-data-rate-enable
-    1,              // Use LVDS mode on data port                                       // lvds_mode_enable *** adi,lvds-mode-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // half_duplex_mode_enable *** adi,half-duplex-mode-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // single_port_mode_enable *** adi,single-port-mode-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // full_port_enable *** adi,full-port-enable
-    0,              // MUST be 0 when lvds_mode_enable = 1                              // full_duplex_swap_bits_enable *** adi,full-duplex-swap-bits-enable
-    0,              // RX_DATA delay rel to RX_FRAME = 0 DATA_CLK/2 cycles              // delay_rx_data *** adi,delay-rx-data
+    .digital_interface_tune_fir_disable = 0,	// ?? UNDOCUMENTED ??                                               // digital_interface_tune_fir_disable *** adi,digital-interface-tune-fir-disable
+    .pp_tx_swap_enable = 1,	// Swap I and Q (spectral inversion)                                // pp_tx_swap_enable *** adi,pp-tx-swap-enable
+    .pp_rx_swap_enable = 1,	// Swap I and Q (spectral inversion)                                // pp_rx_swap_enable *** adi,pp-rx-swap-enable
+    .tx_channel_swap_enable = 0,	// Don't swap TX1 and TX2                                           // tx_channel_swap_enable *** adi,tx-channel-swap-enable
+    .rx_channel_swap_enable = 0,	// Don't swap RX1 and RX2                                           // rx_channel_swap_enable *** adi,rx-channel-swap-enable
+    .rx_frame_pulse_mode_enable = 1,	// Toggle RX_FRAME with 50% duty cycle                              // rx_frame_pulse_mode_enable *** adi,rx-frame-pulse-mode-enable
+    .two_t_two_r_timing_enable = 0,	// Data port timing reflects # of enabled signal paths              // two_t_two_r_timing_enable *** adi,2t2r-timing-enable
+    .invert_data_bus_enable = 0,	// Don't invert data bus                                            // invert_data_bus_enable *** adi,invert-data-bus-enable
+    .invert_data_clk_enable = 0,	// Don't invert data clock                                          // invert_data_clk_enable *** adi,invert-data-clk-enable
+    .fdd_alt_word_order_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // fdd_alt_word_order_enable *** adi,fdd-alt-word-order-enable
+    .invert_rx_frame_enable = 0,	// Don't invert RX_FRAME                                            // invert_rx_frame_enable *** adi,invert-rx-frame-enable
+    .fdd_rx_rate_2tx_enable = 0,	// Don't make RX sample rate 2x the TX sample rate                  // fdd_rx_rate_2tx_enable *** adi,fdd-rx-rate-2tx-enable
+    .swap_ports_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // swap_ports_enable *** adi,swap-ports-enable
+    .single_data_rate_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // single_data_rate_enable *** adi,single-data-rate-enable
+    .lvds_mode_enable = 1,	// Use LVDS mode on data port                                       // lvds_mode_enable *** adi,lvds-mode-enable
+    .half_duplex_mode_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // half_duplex_mode_enable *** adi,half-duplex-mode-enable
+    .single_port_mode_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // single_port_mode_enable *** adi,single-port-mode-enable
+    .full_port_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // full_port_enable *** adi,full-port-enable
+    .full_duplex_swap_bits_enable = 0,	// MUST be 0 when lvds_mode_enable = 1                              // full_duplex_swap_bits_enable *** adi,full-duplex-swap-bits-enable
+    .delay_rx_data = 0,	// RX_DATA delay rel to RX_FRAME = 0 DATA_CLK/2 cycles              // delay_rx_data *** adi,delay-rx-data
     // Approx 0.3 ns/LSB on next 4 values
-    5,              // DATA_CLK delay = 1.5 ns                                          // rx_data_clock_delay *** adi,rx-data-clock-delay
-    0,              // RX_DATA/RX_FRAME delay = 0 ns                                    // rx_data_delay *** adi,rx-data-delay
-    0,              // FB_CLK delay = 0 ns                                              // tx_fb_clock_delay *** adi,tx-fb-clock-delay
-    5,              // TX_DATA/TX_FRAME delay = 1.5 ns                                  // tx_data_delay *** adi,tx-data-delay
-    300,            // LVDS driver bias 300 mV                                          // lvds_bias_mV *** adi,lvds-bias-mV
-    1,              // Enable LVDS on-chip termination                                  // lvds_rx_onchip_termination_enable *** adi,lvds-rx-onchip-termination-enable
-    1,              // RX1 and RX2 are not phase-aligned                                // rx1rx2_phase_inversion_en *** adi,rx1-rx2-phase-inversion-enable
-    0xFF,           // Default signal inversion mappings                                // lvds_invert1_control *** adi,lvds-invert1-control
-    0x0F,           // Default signal inversion mappings                                // lvds_invert2_control *** adi,lvds-invert2-control
-    1,              // CLK_OUT drive increased by ~20%                                  // clk_out_drive
-    1,              // DATA_CLK drive increased by ~20%                                 // dataclk_drive
-    1,              // Data port drive increased by ~20%                                // data_port_drive
-    0,              // CLK_OUT minimum slew (fastest rise/fall)                         // clk_out_slew
-    0,              // DATA_CLK minimum slew (fastest rise/fall)                        // dataclk_slew
-    0,              // Data port minimum slew (fastest rise/fall)                       // data_port_slew
+    .rx_data_clock_delay = 5,	// DATA_CLK delay = 1.5 ns                                          // rx_data_clock_delay *** adi,rx-data-clock-delay
+    .rx_data_delay = 0,	// RX_DATA/RX_FRAME delay = 0 ns                                    // rx_data_delay *** adi,rx-data-delay
+    .tx_fb_clock_delay = 0,	// FB_CLK delay = 0 ns                                              // tx_fb_clock_delay *** adi,tx-fb-clock-delay
+    .tx_data_delay = 5,	// TX_DATA/TX_FRAME delay = 1.5 ns                                  // tx_data_delay *** adi,tx-data-delay
+    .lvds_bias_mV = 300,	// LVDS driver bias 300 mV                                          // lvds_bias_mV *** adi,lvds-bias-mV
+    .lvds_rx_onchip_termination_enable = 1,	// Enable LVDS on-chip termination                                  // lvds_rx_onchip_termination_enable *** adi,lvds-rx-onchip-termination-enable
+    .rx1rx2_phase_inversion_en = 1,	// RX1 and RX2 are not phase-aligned                                // rx1rx2_phase_inversion_en *** adi,rx1-rx2-phase-inversion-enable
+    .lvds_invert1_control = 0xFF,	// Default signal inversion mappings                                // lvds_invert1_control *** adi,lvds-invert1-control
+    .lvds_invert2_control = 0x0F,	// Default signal inversion mappings                                // lvds_invert2_control *** adi,lvds-invert2-control
+    .clk_out_drive = 1,	// CLK_OUT drive increased by ~20%                                  // clk_out_drive
+    .dataclk_drive = 1,	// DATA_CLK drive increased by ~20%                                 // dataclk_drive
+    .data_port_drive = 1,	// Data port drive increased by ~20%                                // data_port_drive
+    .clk_out_slew = 0,	// CLK_OUT minimum slew (fastest rise/fall)                         // clk_out_slew
+    .dataclk_slew = 0,	// DATA_CLK minimum slew (fastest rise/fall)                        // dataclk_slew
+    .data_port_slew = 0,	// Data port minimum slew (fastest rise/fall)                       // data_port_slew
 
     /* GPO Control */
-    0,              // GPO0 is LOW in Sleep/Wait/Alert states                           // gpo0_inactive_state_high_enable *** adi,gpo0-inactive-state-high-enable
-    0,              // GPO1 is LOW in Sleep/Wait/Alert states                           // gpo1_inactive_state_high_enable *** adi,gpo1-inactive-state-high-enable
-    0,              // GPO2 is LOW in Sleep/Wait/Alert states                           // gpo2_inactive_state_high_enable *** adi,gpo2-inactive-state-high-enable
-    0,              // GPO3 is LOW in Sleep/Wait/Alert states                           // gpo3_inactive_state_high_enable *** adi,gpo3-inactive-state-high-enable
-    0,              // GPO0 does not change state when entering RX state                // gpo0_slave_rx_enable *** adi,gpo0-slave-rx-enable
-    0,              // GPO0 does not change state when entering TX state                // gpo0_slave_tx_enable *** adi,gpo0-slave-tx-enable
-    0,              // GPO1 does not change state when entering RX state                // gpo1_slave_rx_enable *** adi,gpo1-slave-rx-enable
-    0,              // GPO1 does not change state when entering TX state                // gpo1_slave_tx_enable *** adi,gpo1-slave-tx-enable
-    0,              // GPO2 does not change state when entering RX state                // gpo2_slave_rx_enable *** adi,gpo2-slave-rx-enable
-    0,              // GPO2 does not change state when entering TX state                // gpo2_slave_tx_enable *** adi,gpo2-slave-tx-enable
-    0,              // GPO3 does not change state when entering RX state                // gpo3_slave_rx_enable *** adi,gpo3-slave-rx-enable
-    0,              // GPO3 does not change state when entering TX state                // gpo3_slave_tx_enable *** adi,gpo3-slave-tx-enable
-    0,              // N/A when gpo0_slave_rx_enable = 0                                // gpo0_rx_delay_us *** adi,gpo0-rx-delay-us
-    0,              // N/A when gpo0_slave_tx_enable = 0                                // gpo0_tx_delay_us *** adi,gpo0-tx-delay-us
-    0,              // N/A when gpo1_slave_rx_enable = 0                                // gpo1_rx_delay_us *** adi,gpo1-rx-delay-us
-    0,              // N/A when gpo1_slave_tx_enable = 0                                // gpo1_tx_delay_us *** adi,gpo1-tx-delay-us
-    0,              // N/A when gpo2_slave_rx_enable = 0                                // gpo2_rx_delay_us *** adi,gpo2-rx-delay-us
-    0,              // N/A when gpo2_slave_tx_enable = 0                                // gpo2_tx_delay_us *** adi,gpo2-tx-delay-us
-    0,              // N/A when gpo3_slave_rx_enable = 0                                // gpo3_rx_delay_us *** adi,gpo3-rx-delay-us
-    0,              // N/A when gpo3_slave_tx_enable = 0                                // gpo3_tx_delay_us *** adi,gpo3-tx-delay-us
+    .gpo0_inactive_state_high_enable = 0,	// GPO0 is LOW in Sleep/Wait/Alert states                           // gpo0_inactive_state_high_enable *** adi,gpo0-inactive-state-high-enable
+    .gpo1_inactive_state_high_enable = 0,	// GPO1 is LOW in Sleep/Wait/Alert states                           // gpo1_inactive_state_high_enable *** adi,gpo1-inactive-state-high-enable
+    .gpo2_inactive_state_high_enable = 0,	// GPO2 is LOW in Sleep/Wait/Alert states                           // gpo2_inactive_state_high_enable *** adi,gpo2-inactive-state-high-enable
+    .gpo3_inactive_state_high_enable = 0,	// GPO3 is LOW in Sleep/Wait/Alert states                           // gpo3_inactive_state_high_enable *** adi,gpo3-inactive-state-high-enable
+    .gpo0_slave_rx_enable = 0,	// GPO0 does not change state when entering RX state                // gpo0_slave_rx_enable *** adi,gpo0-slave-rx-enable
+    .gpo0_slave_tx_enable = 0,	// GPO0 does not change state when entering TX state                // gpo0_slave_tx_enable *** adi,gpo0-slave-tx-enable
+    .gpo1_slave_rx_enable = 0,	// GPO1 does not change state when entering RX state                // gpo1_slave_rx_enable *** adi,gpo1-slave-rx-enable
+    .gpo1_slave_tx_enable = 0,	// GPO1 does not change state when entering TX state                // gpo1_slave_tx_enable *** adi,gpo1-slave-tx-enable
+    .gpo2_slave_rx_enable = 0,	// GPO2 does not change state when entering RX state                // gpo2_slave_rx_enable *** adi,gpo2-slave-rx-enable
+    .gpo2_slave_tx_enable = 0,	// GPO2 does not change state when entering TX state                // gpo2_slave_tx_enable *** adi,gpo2-slave-tx-enable
+    .gpo3_slave_rx_enable = 0,	// GPO3 does not change state when entering RX state                // gpo3_slave_rx_enable *** adi,gpo3-slave-rx-enable
+    .gpo3_slave_tx_enable = 0,	// GPO3 does not change state when entering TX state                // gpo3_slave_tx_enable *** adi,gpo3-slave-tx-enable
+    .gpo0_rx_delay_us = 0,	// N/A when gpo0_slave_rx_enable = 0                                // gpo0_rx_delay_us *** adi,gpo0-rx-delay-us
+    .gpo0_tx_delay_us = 0,	// N/A when gpo0_slave_tx_enable = 0                                // gpo0_tx_delay_us *** adi,gpo0-tx-delay-us
+    .gpo1_rx_delay_us = 0,	// N/A when gpo1_slave_rx_enable = 0                                // gpo1_rx_delay_us *** adi,gpo1-rx-delay-us
+    .gpo1_tx_delay_us = 0,	// N/A when gpo1_slave_tx_enable = 0                                // gpo1_tx_delay_us *** adi,gpo1-tx-delay-us
+    .gpo2_rx_delay_us = 0,	// N/A when gpo2_slave_rx_enable = 0                                // gpo2_rx_delay_us *** adi,gpo2-rx-delay-us
+    .gpo2_tx_delay_us = 0,	// N/A when gpo2_slave_tx_enable = 0                                // gpo2_tx_delay_us *** adi,gpo2-tx-delay-us
+    .gpo3_rx_delay_us = 0,	// N/A when gpo3_slave_rx_enable = 0                                // gpo3_rx_delay_us *** adi,gpo3-rx-delay-us
+    .gpo3_tx_delay_us = 0,	// N/A when gpo3_slave_tx_enable = 0                                // gpo3_tx_delay_us *** adi,gpo3-tx-delay-us
 
     /* Tx Monitor Control */
     /* bladeRF Micro: N/A, TX_MON1 and TX_MON2 tied to GND */
-    37000,          // N/A                                                              // low_high_gain_threshold_mdB *** adi,txmon-low-high-thresh
-    0,              // N/A                                                              // low_gain_dB *** adi,txmon-low-gain
-    24,             // N/A                                                              // high_gain_dB *** adi,txmon-high-gain
-    0,              // N/A                                                              // tx_mon_track_en *** adi,txmon-dc-tracking-enable
-    0,              // N/A                                                              // one_shot_mode_en *** adi,txmon-one-shot-mode-enable
-    511,            // N/A                                                              // tx_mon_delay *** adi,txmon-delay
-    8192,           // N/A                                                              // tx_mon_duration *** adi,txmon-duration
-    2,              // N/A                                                              // tx1_mon_front_end_gain *** adi,txmon-1-front-end-gain
-    2,              // N/A                                                              // tx2_mon_front_end_gain *** adi,txmon-2-front-end-gain
-    48,             // N/A                                                              // tx1_mon_lo_cm *** adi,txmon-1-lo-cm
-    48,             // N/A                                                              // tx2_mon_lo_cm *** adi,txmon-2-lo-cm
+    .low_high_gain_threshold_mdB = 37000,	// N/A                                                              // low_high_gain_threshold_mdB *** adi,txmon-low-high-thresh
+    .low_gain_dB = 0,	// N/A                                                              // low_gain_dB *** adi,txmon-low-gain
+    .high_gain_dB = 24,	// N/A                                                              // high_gain_dB *** adi,txmon-high-gain
+    .tx_mon_track_en = 0,	// N/A                                                              // tx_mon_track_en *** adi,txmon-dc-tracking-enable
+    .one_shot_mode_en = 0,	// N/A                                                              // one_shot_mode_en *** adi,txmon-one-shot-mode-enable
+    .tx_mon_delay = 511,	// N/A                                                              // tx_mon_delay *** adi,txmon-delay
+    .tx_mon_duration = 8192,	// N/A                                                              // tx_mon_duration *** adi,txmon-duration
+    .tx1_mon_front_end_gain = 2,	// N/A                                                              // tx1_mon_front_end_gain *** adi,txmon-1-front-end-gain
+    .tx2_mon_front_end_gain = 2,	// N/A                                                              // tx2_mon_front_end_gain *** adi,txmon-2-front-end-gain
+    .tx1_mon_lo_cm = 48,	// N/A                                                              // tx1_mon_lo_cm *** adi,txmon-1-lo-cm
+    .tx2_mon_lo_cm = 48,	// N/A                                                              // tx2_mon_lo_cm *** adi,txmon-2-lo-cm
 
     /* GPIO definitions */
-    RFFE_CONTROL_RESET_N,   // Reset using RFFE bit 0                                   // gpio_resetb *** reset-gpios
+    /* Bit of the FPGA RFFE control register, driven through the accessor
+     * table in platform_bladerf2. The device handle goes into .extra at
+     * init time, where it is known. */
+    .gpio_resetb = { .number = RFFE_CONTROL_RESET_N,
+                     .platform_ops = &bladerf2_gpio_ops },	// Reset using RFFE bit 0                                   // gpio_resetb *** reset-gpios
 
     /* MCS Sync */
-    -1,             // Future use (MCS Sync)                                            // gpio_sync *** sync-gpios
-    -1,             // Future use (MCS Sync)                                            // gpio_cal_sw1 *** cal-sw1-gpios
-    -1,             // Future use (MCS Sync)                                            // gpio_cal_sw2 *** cal-sw2-gpios
+    .gpio_sync = { .number = -1 },	// Future use (MCS Sync)                                            // gpio_sync *** sync-gpios
+    .gpio_cal_sw1 = { .number = -1 },	// Future use (MCS Sync)                                            // gpio_cal_sw1 *** cal-sw1-gpios
+    .gpio_cal_sw2 = { .number = -1 },	// Future use (MCS Sync)                                            // gpio_cal_sw2 *** cal-sw2-gpios
 
     /* External LO clocks */
-    NULL,           // Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
-    NULL,           // Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()
-    NULL            // Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_set_rate)()
+    /* SPI reaches the device through the accessor table in
+     * platform_bladerf2; the handle goes into .extra at init time. */
+    .spi_param = { .platform_ops = &bladerf2_spi_ops },
+
+    .ad9361_rfpll_ext_recalc_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_recalc_rate)()
+    .ad9361_rfpll_ext_round_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_round_rate)()
+    .ad9361_rfpll_ext_set_rate = NULL,	// Future use (RX_EXT_LO, TX_EXT_LO control)                        // (*ad9361_rfpll_ext_set_rate)()
 };
 // clang-format on
 

--- a/hdl/fpga/ip/nuand/simulation/fifo_reader_tb.vhd
+++ b/hdl/fpga/ip/nuand/simulation/fifo_reader_tb.vhd
@@ -1,0 +1,212 @@
+-- Copyright (c) 2026 Nuand LLC
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+
+-- Does the TX feed gate hold a burst until its timestamp arrives?
+--
+-- Two cases, both required:
+--   scheduled  a burst timestamped in the future must produce NO sample
+--              reads before that timestamp, and all of them after
+--   now        a burst with timestamp 0 (the host's TX_NOW encoding, which
+--              the reader turns into all ones by subtracting 1) must start
+--              immediately
+--
+-- The scheduled case regressed when meta_p_time was derived from the
+-- registered copy of meta_fifo_data: that copy is all zeros out of reset,
+-- and 0 - 1 wraps to all ones, i.e. the META_NOW sentinel, so the gate
+-- opened at once for a future burst.
+--
+-- Run with GHDL:
+--   ghdl -a --std=08 fx3_gpif_p.vhd fifo_readwrite_p.vhd \
+--                    fifo_reader.vhd fifo_reader_tb.vhd
+--   ghdl -e --std=08 fifo_reader_tb
+--   ghdl -r --std=08 fifo_reader_tb --stop-time=70us
+
+library ieee;
+    use ieee.std_logic_1164.all;
+    use ieee.numeric_std.all;
+library work;
+    use work.fifo_readwrite_p.all;
+    use work.fx3_gpif_p.all;
+
+entity fifo_reader_tb is
+    generic (
+        -- Sample timestamp for the burst. 0 means "transmit now".
+        TGT : natural := 4000
+    );
+end entity;
+
+architecture sim of fifo_reader_tb is
+
+    constant NSTREAMS : natural := 1;
+
+    signal clock      : std_logic := '0';
+    signal reset      : std_logic := '1';
+    signal enable     : std_logic := '0';
+    signal usb_speed  : std_logic := '0';   -- '0' = SuperSpeed
+    signal meta_en    : std_logic := '1';
+    signal packet_en  : std_logic := '0';
+    signal eight_bit  : std_logic := '0';
+    signal packed_en  : std_logic := '0';
+    signal timestamp  : unsigned(63 downto 0) := (others => '0');
+
+    signal fifo_usedw : std_logic_vector(11 downto 0) := (others => '1');
+    signal fifo_read  : std_logic;
+    signal fifo_empty : std_logic := '0';
+    signal fifo_data  : std_logic_vector(63 downto 0) := x"0BAD0BAD0BAD0BAD";
+    signal fifo_hold  : std_logic := '0';
+
+    signal pkt_ctrl   : packet_control_t;
+    signal pkt_empty  : std_logic;
+    signal pkt_ready  : std_logic := '0';
+
+    signal m_usedw    : std_logic_vector(2 downto 0) := "001";
+    signal m_read     : std_logic;
+    signal m_empty    : std_logic := '0';
+    signal m_data     : std_logic_vector(127 downto 0);
+
+    signal in_ctrl    : sample_controls_t(0 to NSTREAMS-1) := (others => SAMPLE_CONTROL_ENABLE);
+    signal out_smp    : sample_streams_t(0 to NSTREAMS-1);
+
+    signal uf_led     : std_logic;
+    signal uf_count   : unsigned(63 downto 0);
+    signal uf_dur     : unsigned(15 downto 0) := x"ffff";
+
+    signal reads_before : natural := 0;
+    signal reads_after  : natural := 0;
+    signal done         : boolean := false;
+
+    -- Bits 95 downto 32 of the meta header carry the timestamp.
+    function hdr(ts : unsigned(63 downto 0)) return std_logic_vector is
+        variable v : std_logic_vector(127 downto 0) := (others => '0');
+    begin
+        v(95 downto 32) := std_logic_vector(ts);
+        return v;
+    end function;
+
+begin
+
+    clock <= not clock after 5 ns when not done else '0';
+
+    m_data <= hdr(to_unsigned(TGT, 64));
+
+    -- One header only: once it has been read the meta FIFO is empty.
+    -- Without this META_LOAD re-arms forever and the later reads would be
+    -- legitimate, hiding the defect.
+    meta_drain : process(clock)
+    begin
+        if rising_edge(clock) then
+            if reset = '1' then
+                m_empty <= '0';
+            elsif m_read = '1' then
+                m_empty <= '1';
+            end if;
+        end if;
+    end process;
+
+    -- The sample clock runs regardless, as it does in hardware.
+    tick : process(clock)
+    begin
+        if rising_edge(clock) and reset = '0' then
+            timestamp <= timestamp + 1;
+        end if;
+    end process;
+
+    counters : process(clock)
+    begin
+        if rising_edge(clock) and reset = '0' and fifo_read = '1' then
+            if timestamp < to_unsigned(TGT, 64) then
+                reads_before <= reads_before + 1;
+            else
+                reads_after <= reads_after + 1;
+            end if;
+        end if;
+    end process;
+
+    U_fifo_reader : entity work.fifo_reader
+        generic map (
+            NUM_STREAMS           => NSTREAMS,
+            FIFO_READ_THROTTLE    => 0,
+            FIFO_USEDW_WIDTH      => 12,
+            FIFO_DATA_WIDTH       => 64,
+            META_FIFO_USEDW_WIDTH => 3,
+            META_FIFO_DATA_WIDTH  => 128
+        )
+        port map (
+            clock                 => clock,
+            reset                 => reset,
+            enable                => enable,
+            usb_speed             => usb_speed,
+            meta_en               => meta_en,
+            packet_en             => packet_en,
+            eight_bit_mode_en     => eight_bit,
+            highly_packed_mode_en => packed_en,
+            timestamp             => timestamp,
+            fifo_usedw            => fifo_usedw,
+            fifo_read             => fifo_read,
+            fifo_empty            => fifo_empty,
+            fifo_data             => fifo_data,
+            fifo_holdoff          => fifo_hold,
+            packet_control        => pkt_ctrl,
+            packet_empty          => pkt_empty,
+            packet_ready          => pkt_ready,
+            meta_fifo_usedw       => m_usedw,
+            meta_fifo_read        => m_read,
+            meta_fifo_empty       => m_empty,
+            meta_fifo_data        => m_data,
+            in_sample_controls    => in_ctrl,
+            out_samples           => out_smp,
+            underflow_led         => uf_led,
+            underflow_count       => uf_count,
+            underflow_duration    => uf_dur
+        );
+
+    stim : process
+    begin
+        wait for 50 ns;
+        reset  <= '0';
+        wait for 20 ns;
+        enable <= '1';
+
+        wait for 60 us;
+
+        report "TGT = " & integer'image(TGT) &
+               "  reads before = " & integer'image(reads_before) &
+               "  reads after = " & integer'image(reads_after);
+
+        if TGT = 0 then
+            assert reads_after > 0
+                report "TX_NOW burst never started"
+                severity failure;
+            report "TX_NOW: feed started";
+        else
+            assert reads_before = 0
+                report "gate leaked: feed ran before its timestamp"
+                severity failure;
+            assert reads_after > 0
+                report "gate never opened at its timestamp"
+                severity failure;
+            report "scheduled: gate held until the timestamp";
+        end if;
+
+        done <= true;
+        wait;
+    end process;
+
+end architecture;

--- a/hdl/fpga/ip/nuand/synthesis/fifo_reader.vhd
+++ b/hdl/fpga/ip/nuand/synthesis/fifo_reader.vhd
@@ -224,7 +224,14 @@ begin
         meta_future.meta_pkt_eop <= '0';
         meta_future.meta_fifo_empty <= meta_fifo_empty;
         meta_future.meta_fifo_data  <= meta_fifo_data;
-        meta_time := unsigned(meta_current.meta_fifo_data(95 downto 32)) - 1;
+        -- Use the header the meta FIFO is presenting now, not the copy
+        -- registered on the previous cycle. That copy is all zeros out of
+        -- reset, and "0 - 1" wraps to all ones -- which is exactly the
+        -- META_NOW sentinel. META_WAIT then sees meta_p_time =
+        -- MAX_TIMESTAMP and opens the gate immediately, so a burst
+        -- scheduled in the future is emitted at once and nothing is left
+        -- to send when its timestamp actually arrives.
+        meta_time := unsigned(meta_fifo_data(95 downto 32)) - 1;
         meta_future.meta_p_time_r <= meta_time;
 
         case meta_current.state is

--- a/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic_cmds.c
+++ b/hdl/fpga/platforms/common/bladerf/software/bladeRF_nios/src/devices_rfic_cmds.c
@@ -821,6 +821,13 @@ bool _rfic_cmd_rd_rssi(struct rfic_state *state,
     if (BLADERF_CHANNEL_IS_TX(channel)) {
         uint32_t rssi = 0;
 
+        /* The TX power monitor gates the measurement block behind
+         * REG_TX_RSSI. Without it those registers stay at zero and this
+         * reports 0 dBm at every gain setting, which reads as "no
+         * output" rather than "not measured". */
+        CHECK_BOOL(
+            ad9361_txmon_enable(state->phy, (0 == rfic_ch) ? TX_1 : TX_2));
+
         CHECK_BOOL(ad9361_get_tx_rssi(state->phy, rfic_ch, &rssi));
 
         mul = -1000;

--- a/hdl/fpga/platforms/common/bladerf/vhdl/tb/fx3_gpif_wedge_tb.vhd
+++ b/hdl/fpga/platforms/common/bladerf/vhdl/tb/fx3_gpif_wedge_tb.vhd
@@ -59,6 +59,12 @@ architecture arch of fx3_gpif_wedge_tb is
     signal freeze        : std_logic := '0';
     signal tx_dis        : std_logic := '0';
     signal tx_req_gone   : std_logic := '0';
+    signal rx_req_gone   : std_logic := '0';
+    signal rx_full       : std_logic := '0';
+
+    -- 2048 words is enough for a GPIF burst but below rx_fifo_critical;
+    -- rx_full pushes it over that line to flip the arbiter's priority.
+    signal rx_usedw      : std_logic_vector(USEDW-1 downto 0);
 
     -- FX3 handshake, active low on the wire
     alias dma0_rx_ack   is ctl_out(0);
@@ -112,9 +118,7 @@ begin
             rx_fifo_read        => rx_fifo_read,
             rx_fifo_full        => '0',
             rx_fifo_empty       => '0',
-            -- enough for a GPIF burst but below rx_fifo_critical, so the
-            -- arbiter's TX-first priority actually gets exercised
-            rx_fifo_usedw       => std_logic_vector(to_unsigned(2048, USEDW)),
+            rx_fifo_usedw       => rx_usedw,
             rx_fifo_data        => x"deadbeef",
 
             rx_meta_fifo_read   => rx_meta_read,
@@ -130,7 +134,10 @@ begin
     ctl_in(5)  <= not tx_dis;               -- tx enabled
     ctl_in(6)  <= '0' when (freeze = '1' or dma0_rx_ack = '1' or
                            dma3_tx_ack = '1') else '1';
-    ctl_in(8)  <= '0';                      -- rx0 requesting (active low)
+    rx_usedw   <= std_logic_vector(to_unsigned(7000, USEDW)) when rx_full = '1'
+                  else std_logic_vector(to_unsigned(2048, USEDW));
+
+    ctl_in(8)  <= rx_req_gone;              -- rx0 requesting (active low)
     ctl_in(10) <= '1';                      -- tx2 never used by the firmware
     ctl_in(11) <= tx_req_gone;              -- tx3 requesting (active low)
     ctl_in(12) <= '1';                      -- rx1 never used
@@ -149,6 +156,7 @@ begin
 
     stim : process
         variable tx_acks    : natural := 0;
+        variable waited     : natural := 0;
         variable idle_seen  : natural := 0;
         variable stuck      : natural := 0;
         constant WATCHDOG   : natural := 4000;
@@ -208,6 +216,50 @@ begin
                 wait until rising_edge(pclk);
             end loop;
             tx_req_gone <= '0';
+        elsif SCENARIO = 7 then
+            -- RX crosses the TX transaction: the host reading RX makes the
+            -- FX3 raise and drop its RX request while a TX burst is being
+            -- acked. This is the condition the wedge needs on hardware - TX
+            -- alone never wedges, TX with RX being read does.
+            -- bounded: a disturbance loop that waits on an ack forever would
+            -- hang the bench instead of reporting the wedge it is looking for
+            for k in 1 to 12 loop
+                waited := 0;
+                while dma3_tx_ack = '0' and waited < 4000 loop
+                    wait until rising_edge(pclk);
+                    waited := waited + 1;
+                end loop;
+                exit when waited >= 4000;
+                rx_req_gone <= '1';
+                for i in 1 to 3 loop
+                    wait until rising_edge(pclk);
+                end loop;
+                rx_req_gone <= '0';
+                waited := 0;
+                while dma0_rx_ack = '0' and waited < 4000 loop
+                    wait until rising_edge(pclk);
+                    waited := waited + 1;
+                end loop;
+                exit when waited >= 4000;
+                rx_req_gone <= '1';
+                wait until rising_edge(pclk);
+                rx_req_gone <= '0';
+            end loop;
+            report "scenario 7: disturbance loop ran " &
+                   integer'image(waited) & " idle cycles at exit"
+                   severity note;
+        elsif SCENARIO = 8 then
+            -- RX FIFO crosses the critical line mid-TX, which flips the
+            -- arbiter's priority away from TX in the same cycle it is
+            -- servicing one.
+            for k in 1 to 12 loop
+                wait until rising_edge(pclk) and dma3_tx_ack = '1';
+                rx_full <= '1';
+                for i in 1 to 5 loop
+                    wait until rising_edge(pclk);
+                end loop;
+                rx_full <= '0';
+            end loop;
         elsif SCENARIO = 5 then
             -- same, but the drop lands during the metadata phase
             wait until rising_edge(pclk) and dma3_tx_ack = '1';

--- a/hdl/fpga/platforms/common/bladerf/vhdl/tb/fx3_gpif_wedge_tb.vhd
+++ b/hdl/fpga/platforms/common/bladerf/vhdl/tb/fx3_gpif_wedge_tb.vhd
@@ -1,0 +1,248 @@
+-- Does the GPIF state machine always return to IDLE when the host tears the
+-- TX stream down mid-transaction while RX keeps running?
+--
+-- The machine has no timeout in any state. Every exit from META_WRITE,
+-- SAMPLE_WRITE and SAMPLE_WRITE_IGNORE is a single equality test against a
+-- downcount that saturates at -1, so a downcount that skips its exit value
+-- parks the machine forever and the FX3 TX DMA channel never drains.
+--
+-- Runs standalone under GHDL: only nuand.fx3_gpif_p and set_clear_ff are
+-- needed, no vendor PLL. The FX3 side is modelled by hand.
+--
+-- Generic SCENARIO:
+--   0  steady TX+RX traffic, no host interference   (control, must pass)
+--   1  meta_enable drops while a TX transaction is in flight
+--   2  meta_enable rises while a TX transaction is in flight
+--
+-- Pass criterion: the machine reaches IDLE again within WATCHDOG cycles of
+-- the disturbance. Failure is reported as a stuck state, which is the wedge.
+
+library ieee;
+    use ieee.std_logic_1164.all;
+    use ieee.numeric_std.all;
+
+entity fx3_gpif_wedge_tb is
+    generic (
+        SCENARIO : natural := 0
+    );
+end entity;
+
+architecture arch of fx3_gpif_wedge_tb is
+
+    constant HALF   : time    := 4 ns;      -- 125 MHz pclk
+    constant USEDW  : natural := 14;
+
+    signal pclk     : std_logic := '0';
+    signal reset    : std_logic := '1';
+    signal done     : boolean   := false;
+
+    signal gpif_in  : std_logic_vector(31 downto 0) := (others => '0');
+    signal gpif_out : std_logic_vector(31 downto 0);
+    signal gpif_oe  : std_logic;
+    signal ctl_in   : std_logic_vector(12 downto 0) := (others => '1');
+    signal ctl_out  : std_logic_vector(12 downto 0);
+    signal ctl_oe   : std_logic_vector(12 downto 0);
+
+    signal tx_enable_o  : std_logic;
+    signal rx_enable_o  : std_logic;
+    signal meta_enable  : std_logic := '1';
+    signal packet_enable: std_logic := '0';
+
+    signal tx_fifo_write : std_logic;
+    signal tx_fifo_data  : std_logic_vector(31 downto 0);
+    signal tx_meta_write : std_logic;
+    signal tx_meta_data  : std_logic_vector(31 downto 0);
+    signal rx_fifo_read  : std_logic;
+    signal rx_meta_read  : std_logic;
+
+    signal tx_timestamp  : unsigned(63 downto 0) := (others => '0');
+    signal freeze        : std_logic := '0';
+    signal tx_dis        : std_logic := '0';
+    signal tx_req_gone   : std_logic := '0';
+
+    -- FX3 handshake, active low on the wire
+    alias dma0_rx_ack   is ctl_out(0);
+    alias dma3_tx_ack   is ctl_out(3);
+
+    -- ctl_in bits driven by the FX3
+    --   4 dma_rx_enable, 5 dma_tx_enable, 6 dma_idle,
+    --   8 rx0 reqx, 10 tx2 reqx, 11 tx3 reqx, 12 rx1 reqx
+begin
+
+    clk : process
+    begin
+        while not done loop
+            pclk <= '0'; wait for HALF;
+            pclk <= '1'; wait for HALF;
+        end loop;
+        wait;
+    end process;
+
+    U_dut : entity work.fx3_gpif
+        port map (
+            pclk                => pclk,
+            reset               => reset,
+            usb_speed           => '0',            -- SuperSpeed
+
+            gpif_in             => gpif_in,
+            gpif_out            => gpif_out,
+            gpif_oe             => gpif_oe,
+            ctl_in              => ctl_in,
+            ctl_out             => ctl_out,
+            ctl_oe              => ctl_oe,
+
+            tx_enable           => tx_enable_o,
+            rx_enable           => rx_enable_o,
+            meta_enable         => meta_enable,
+            packet_enable       => packet_enable,
+
+            tx_fifo_write       => tx_fifo_write,
+            tx_fifo_full        => '0',
+            tx_fifo_empty       => '1',
+            tx_fifo_usedw       => std_logic_vector(to_unsigned(0, USEDW)),
+            tx_fifo_data        => tx_fifo_data,
+
+            tx_timestamp        => tx_timestamp,
+            tx_meta_fifo_write  => tx_meta_write,
+            tx_meta_fifo_full   => '0',
+            tx_meta_fifo_empty  => '1',
+            tx_meta_fifo_usedw  => std_logic_vector(to_unsigned(0, USEDW)),
+            tx_meta_fifo_data   => tx_meta_data,
+
+            rx_fifo_read        => rx_fifo_read,
+            rx_fifo_full        => '0',
+            rx_fifo_empty       => '0',
+            -- enough for a GPIF burst but below rx_fifo_critical, so the
+            -- arbiter's TX-first priority actually gets exercised
+            rx_fifo_usedw       => std_logic_vector(to_unsigned(2048, USEDW)),
+            rx_fifo_data        => x"deadbeef",
+
+            rx_meta_fifo_read   => rx_meta_read,
+            rx_meta_fifo_full   => '0',
+            rx_meta_fifo_empty  => '0',
+            rx_meta_fifo_usedr  => std_logic_vector(to_unsigned(2**USEDW - 1, USEDW)),
+            rx_meta_fifo_data   => x"00000010"
+        );
+
+    -- The FX3 always has a TX buffer ready and always wants RX data. dma_idle
+    -- follows the ack lines: the FX3 drops idle while a transaction is acked.
+    ctl_in(4)  <= '1';                      -- rx enabled
+    ctl_in(5)  <= not tx_dis;               -- tx enabled
+    ctl_in(6)  <= '0' when (freeze = '1' or dma0_rx_ack = '1' or
+                           dma3_tx_ack = '1') else '1';
+    ctl_in(8)  <= '0';                      -- rx0 requesting (active low)
+    ctl_in(10) <= '1';                      -- tx2 never used by the firmware
+    ctl_in(11) <= tx_req_gone;              -- tx3 requesting (active low)
+    ctl_in(12) <= '1';                      -- rx1 never used
+    ctl_in(9)  <= '0';
+    ctl_in(7)  <= '0';
+    ctl_in(3 downto 0) <= (others => '0');
+
+    -- A valid TX meta header: timestamp 0 means "now", which the machine
+    -- accepts and routes to SAMPLE_WRITE.
+    gpif_in <= (others => '0');
+
+    -- Negative control: scenario 3 freezes the FX3 idle line, which is a real
+    -- stop. If the watchdog below cannot see that, it cannot see the wedge
+    -- either and every "alive" verdict is worthless.
+    freeze <= '1' when SCENARIO = 3 else '0';
+
+    stim : process
+        variable tx_acks    : natural := 0;
+        variable idle_seen  : natural := 0;
+        variable stuck      : natural := 0;
+        constant WATCHDOG   : natural := 4000;
+    begin
+        reset <= '1';
+        wait for 20 * HALF;
+        reset <= '0';
+
+        -- Let transactions run, and count TX acks: without them the run only
+        -- exercises RX and proves nothing about the TX path.
+        for i in 1 to 600 loop
+            wait until rising_edge(pclk);
+            if dma3_tx_ack = '1' then
+                tx_acks := tx_acks + 1;
+            end if;
+        end loop;
+        assert tx_acks > 0 or SCENARIO = 3
+            report "testbench broken: no TX transaction ever happened"
+            severity failure;
+
+        -- disturbance: the host reconfigures the TX stream, which flips
+        -- meta_enable while the machine is inside a TX transaction
+        if SCENARIO = 1 then
+            wait until rising_edge(pclk) and dma3_tx_ack = '1';
+            wait until rising_edge(pclk);
+            wait until rising_edge(pclk);
+            meta_enable <= '0';
+        elsif SCENARIO = 2 then
+            meta_enable <= '0';
+            for i in 1 to 400 loop
+                wait until rising_edge(pclk);
+            end loop;
+            wait until rising_edge(pclk) and dma3_tx_ack = '1';
+            wait until rising_edge(pclk);
+            wait until rising_edge(pclk);
+            meta_enable <= '1';
+        elsif SCENARIO = 4 then
+            -- dma_tx_enable drops mid-transaction. This is what the host does
+            -- through enable_module when it tears the TX stream down.
+            wait until rising_edge(pclk) and dma3_tx_ack = '1';
+            wait until rising_edge(pclk);
+            wait until rising_edge(pclk);
+            tx_dis <= '1';
+            for i in 1 to 200 loop
+                wait until rising_edge(pclk);
+            end loop;
+            tx_dis <= '0';
+        elsif SCENARIO = 6 then
+            -- The FX3 withdraws the TX buffer request mid-transaction. This is
+            -- what a DmaChannelReset on the UtoP channel looks like from the
+            -- FPGA side: the request line simply goes away while the FPGA is
+            -- still counting down a burst it was acked for.
+            wait until rising_edge(pclk) and dma3_tx_ack = '1';
+            wait until rising_edge(pclk);
+            tx_req_gone <= '1';
+            for i in 1 to 200 loop
+                wait until rising_edge(pclk);
+            end loop;
+            tx_req_gone <= '0';
+        elsif SCENARIO = 5 then
+            -- same, but the drop lands during the metadata phase
+            wait until rising_edge(pclk) and dma3_tx_ack = '1';
+            tx_dis <= '1';
+            for i in 1 to 200 loop
+                wait until rising_edge(pclk);
+            end loop;
+            tx_dis <= '0';
+        end if;
+
+        -- after the disturbance the machine must keep servicing the FX3.
+        -- Progress is observable as continued acks; a wedged machine acks
+        -- nothing ever again.
+        idle_seen := 0;
+        stuck     := 0;
+        while idle_seen < 4 and stuck < WATCHDOG loop
+            wait until rising_edge(pclk);
+            stuck := stuck + 1;
+            if dma3_tx_ack = '1' or dma0_rx_ack = '1' then
+                idle_seen := idle_seen + 1;
+                stuck     := 0;
+            end if;
+        end loop;
+
+        if stuck >= WATCHDOG then
+            report "WEDGED: no DMA ack for " & integer'image(WATCHDOG) &
+                   " cycles after disturbance, scenario " &
+                   integer'image(SCENARIO) severity failure;
+        else
+            report "alive: machine kept acking after scenario " &
+                   integer'image(SCENARIO) severity note;
+        end if;
+
+        done <= true;
+        wait;
+    end process;
+
+end architecture;

--- a/host/common/include/thread.h
+++ b/host/common/include/thread.h
@@ -116,7 +116,7 @@ static inline int posix_cond_timedwait(pthread_cond_t *c,
         ts.tv_sec++;
         ts.tv_nsec -= 1000000000;
     }
-    return pthread_cond_timedwait(c, m, &ts) == ETIMEDOUT ? -1 : 0;
+    return pthread_cond_timedwait(c, m, &ts);
 }
 #define COND_TIMED_WAIT(c, m, t) posix_cond_timedwait(c, m, t)
 

--- a/host/common/thirdparty/ad936x/CMakeLists.txt
+++ b/host/common/thirdparty/ad936x/CMakeLists.txt
@@ -56,8 +56,11 @@ add_library(ad936x STATIC
     ${LIBAD936X_PLATFORM_DIR}/platform.c
     ${LIBAD936X_PLATFORM_DIR}/bladerf2_spi.c
     ${LIBAD936X_PLATFORM_DIR}/bladerf2_gpio.c
-    # adc_core.c and dac_core.c drove the AXI ADC/DAC cores, which this board
-    # does not have; config.h defines AXI_ADC_NOT_PRESENT.
+    # FPGA AXI ad9361 core: the board DOES have it (NIOS ADI_AXI target).
+    # axi_adc_init/ad9361_post_setup deassert its reset — without them the RX
+    # sample path is dead after every cold power-up.
+    ${LIBAD936X_PLATFORM_DIR}/bladerf2_axi_io.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/axi_adc_core.c
     ${LIBAD936X_FPGACOMMON_DIR}/src/ad936x_params.c
 )
 
@@ -216,11 +219,13 @@ foreach(cpfile IN ITEMS ${LIBAD936X_UPSTREAM_UTIL_FILES})
     )
 endforeach(cpfile)
 
-# The driver includes the AXI core headers unconditionally, but every call into
-# them is guarded by AXI_ADC_NOT_PRESENT, which config.h defines for this
-# board. Headers only; the cores are not built.
+# AXI adc core is built (it initializes the FPGA-side ad9361 interface core);
+# the dac core is header-only here (included but not called by the driver).
 configure_file(
     "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_adc_core/axi_adc_core.h"
+    "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
+configure_file(
+    "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_adc_core/axi_adc_core.c"
     "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
 configure_file(
     "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_dac_core/axi_dac_core.h"

--- a/host/common/thirdparty/ad936x/CMakeLists.txt
+++ b/host/common/thirdparty/ad936x/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(ad936x STATIC
     # sample path is dead after every cold power-up.
     ${LIBAD936X_PLATFORM_DIR}/bladerf2_axi_io.c
     ${LIBAD936X_UPSTREAM_BUILD_DIR}/axi_adc_core.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/axi_dac_core.c
     ${LIBAD936X_FPGACOMMON_DIR}/src/ad936x_params.c
 )
 
@@ -219,8 +220,9 @@ foreach(cpfile IN ITEMS ${LIBAD936X_UPSTREAM_UTIL_FILES})
     )
 endforeach(cpfile)
 
-# AXI adc core is built (it initializes the FPGA-side ad9361 interface core);
-# the dac core is header-only here (included but not called by the driver).
+# Both halves of the FPGA-side ad9361 interface core are built: axi_adc_init
+# brings the RX side out of reset, axi_dac_init does the same for TX and -
+# critically - points the DAC at the DMA stream instead of its internal DDS.
 configure_file(
     "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_adc_core/axi_adc_core.h"
     "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
@@ -229,6 +231,9 @@ configure_file(
     "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
 configure_file(
     "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_dac_core/axi_dac_core.h"
+    "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
+configure_file(
+    "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_dac_core/axi_dac_core.c"
     "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
 
 # No patches are applied any more.

--- a/host/common/thirdparty/ad936x/CMakeLists.txt
+++ b/host/common/thirdparty/ad936x/CMakeLists.txt
@@ -20,7 +20,16 @@ set(LIBAD936X_PATCH_DIR "${LIBAD936X_LOCAL_DIR}/patches")
 set(LIBAD936X_PLATFORM_DIR "${LIBAD936X_LOCAL_DIR}/platform_bladerf2")
 
 # Upstream source (clean)
-set(LIBAD936X_UPSTREAM_DIR "${LIBAD936X_LOCAL_DIR}/../no-OS/ad9361/sw")
+#
+# The driver moved out of ad9361/sw/ into drivers/rf-transceiver/ad9361/ and
+# util.c was renamed ad9361_util.c. The shared headers and helpers it now pulls
+# in live in include/ and util/.
+set(LIBAD936X_UPSTREAM_ROOT "${LIBAD936X_LOCAL_DIR}/../no-OS")
+set(LIBAD936X_UPSTREAM_DIR "${LIBAD936X_UPSTREAM_ROOT}/drivers/rf-transceiver/ad9361")
+set(LIBAD936X_UPSTREAM_INCLUDE_DIR "${LIBAD936X_UPSTREAM_ROOT}/include")
+set(LIBAD936X_UPSTREAM_UTIL_DIR "${LIBAD936X_UPSTREAM_ROOT}/util")
+set(LIBAD936X_UPSTREAM_API_DIR "${LIBAD936X_UPSTREAM_ROOT}/drivers/api")
+set(LIBAD936X_UPSTREAM_AXI_DIR "${LIBAD936X_UPSTREAM_ROOT}/drivers/axi_core")
 # Upstream source (patched)
 set(LIBAD936X_UPSTREAM_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -33,10 +42,22 @@ add_library(ad936x STATIC
     ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361.c
     ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361_api.c
     ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361_conv.c
-    ${LIBAD936X_UPSTREAM_BUILD_DIR}/util.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361_util.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/ad9361_ext_band_ctrl.c
+    # Shared helpers the driver now calls through the no-OS headers.
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/no_os_alloc.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/no_os_clk.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/no_os_util.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/no_os_mutex.c
+    # Generic API layer: dispatches to the platform ops tables in
+    # platform_bladerf2.
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/no_os_gpio.c
+    ${LIBAD936X_UPSTREAM_BUILD_DIR}/no_os_spi.c
     ${LIBAD936X_PLATFORM_DIR}/platform.c
-    ${LIBAD936X_PLATFORM_DIR}/adc_core.c
-    ${LIBAD936X_PLATFORM_DIR}/dac_core.c
+    ${LIBAD936X_PLATFORM_DIR}/bladerf2_spi.c
+    ${LIBAD936X_PLATFORM_DIR}/bladerf2_gpio.c
+    # adc_core.c and dac_core.c drove the AXI ADC/DAC cores, which this board
+    # does not have; config.h defines AXI_ADC_NOT_PRESENT.
     ${LIBAD936X_FPGACOMMON_DIR}/src/ad936x_params.c
 )
 
@@ -148,8 +169,10 @@ set(LIBAD936X_UPSTREAM_FILES
     ad9361_api.h
     ad9361_conv.c
     common.h
-    util.c
-    util.h
+    ad9361_util.c
+    ad9361_util.h
+    ad9361_ext_band_ctrl.h
+    ad9361_ext_band_ctrl.c
 )
 
 foreach(cpfile IN ITEMS ${LIBAD936X_UPSTREAM_FILES})
@@ -160,32 +183,73 @@ foreach(cpfile IN ITEMS ${LIBAD936X_UPSTREAM_FILES})
     )
 endforeach(cpfile)
 
-# Patch the upstream files
-set(LIBAD936X_PATCHES
-    0001-0bba46e-nuand-modifications.patch
-    0002-0bba46e-pr-561.patch
-    0003-0bba46e-pr-573.patch
-    0004-0bba46e-pr-598.patch
-    0005-0bba46e-rm-ad9361_parse_fir.patch
-    0006-0bba46e-compilefix.patch
+# Shared no-OS headers the driver includes, and the few helpers it links
+# against. Copied alongside the driver so the build directory stays the single
+# include root, as it was when the driver lived in one directory.
+file(GLOB LIBAD936X_UPSTREAM_NOOS_HEADERS
+     "${LIBAD936X_UPSTREAM_INCLUDE_DIR}/no_os_*.h")
+
+foreach(cpfile IN LISTS LIBAD936X_UPSTREAM_NOOS_HEADERS)
+    configure_file("${cpfile}" "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
+endforeach(cpfile)
+
+set(LIBAD936X_UPSTREAM_UTIL_FILES
+    no_os_alloc.c
+    no_os_clk.c
+    no_os_util.c
+    no_os_mutex.c
 )
 
-find_package(Patcher REQUIRED)
-
-foreach(patchfile IN ITEMS ${LIBAD936X_PATCHES})
-    message(STATUS "libad936x: Applying patch: ${patchfile}")
-    execute_process(
-        COMMAND ${Patcher_EXECUTABLE} -p3
-        INPUT_FILE ${LIBAD936X_PATCH_DIR}/${patchfile}
-        WORKING_DIRECTORY "${LIBAD936X_UPSTREAM_BUILD_DIR}"
-        OUTPUT_QUIET
-        RESULT_VARIABLE resultcode
-        ERROR_VARIABLE errvar
+foreach(cpfile IN ITEMS no_os_gpio.c no_os_spi.c)
+    configure_file(
+        "${LIBAD936X_UPSTREAM_API_DIR}/${cpfile}"
+        "${LIBAD936X_UPSTREAM_BUILD_DIR}/"
+        COPYONLY
     )
+endforeach(cpfile)
 
-    if(resultcode)
-        message(FATAL_ERROR "Failed to apply ${patchfile}: ${errvar}")
-    endif(resultcode)
-endforeach(patchfile)
+foreach(cpfile IN ITEMS ${LIBAD936X_UPSTREAM_UTIL_FILES})
+    configure_file(
+        "${LIBAD936X_UPSTREAM_UTIL_DIR}/${cpfile}"
+        "${LIBAD936X_UPSTREAM_BUILD_DIR}/"
+        COPYONLY
+    )
+endforeach(cpfile)
+
+# The driver includes the AXI core headers unconditionally, but every call into
+# them is guarded by AXI_ADC_NOT_PRESENT, which config.h defines for this
+# board. Headers only; the cores are not built.
+configure_file(
+    "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_adc_core/axi_adc_core.h"
+    "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
+configure_file(
+    "${LIBAD936X_UPSTREAM_AXI_DIR}/axi_dac_core/axi_dac_core.h"
+    "${LIBAD936X_UPSTREAM_BUILD_DIR}/" COPYONLY)
+
+# No patches are applied any more.
+#
+# The six patches this tree used to carry were written against 0bba46e (2018)
+# and every one of them is now unnecessary:
+#
+#   0001 nuand-modifications  substituted the SPI accessors inside the driver
+#                             body behind #ifdef NUAND_MODIFICATIONS. The
+#                             driver now takes the transfer through
+#                             struct no_os_spi_platform_ops, so the
+#                             substitution lives in platform_bladerf2 instead
+#                             (bladerf2_spi.c) and the driver source is used
+#                             unmodified.
+#   0002 pr-561               FreeBSD build guard; superseded upstream.
+#   0003 pr-573               uintptr_t cast in a return; the affected code is
+#                             gone.
+#   0004 pr-598               lowered MIN_CARRIER_FREQ_HZ to 47 MHz. Upstream
+#                             now splits the limit per direction:
+#                             MIN_RX_CARRIER_FREQ_HZ 70 MHz and
+#                             MIN_TX_CARRIER_FREQ_HZ 46875001 Hz, which is what
+#                             this board reports for RX and TX respectively.
+#   0005 rm-ad9361_parse_fir  removed a parser that is no longer built here.
+#   0006 compilefix           follow-up to 0002.
+#
+# What replaces them: platform_bladerf2/bladerf2_spi.c, app_config.h, and
+# AXI_ADC_NOT_PRESENT in config.h.
 
 message(STATUS "libad936x: Build configured")

--- a/host/libraries/libbladeRF/CMakeLists.txt
+++ b/host/libraries/libbladeRF/CMakeLists.txt
@@ -82,9 +82,15 @@ option(ENABLE_LOCK_CHECKS
        OFF
 )
 
+# Off by default: the port reset costs more than the crash recovery it buys.
+# A bladeRF 2.0 micro advertises bU1DevExitLat=0 and bU2DevExitLat=0, so the
+# kernel answers every SuperSpeed renegotiation with "LPM exit latency is
+# zeroed, disabling LPM". One open is one reset, measured, and after enough of
+# them the link stops coming up as SuperSpeed at all and the device settles on
+# Hi-Speed. Turn it back on if you actually hit issue #95.
 option(ENABLE_USB_DEV_RESET_ON_OPEN
        "Perform a USB port reset when opening a device. This works around an issue on some Linux USB 3.0 setups that prevents a device from being opened after an application crash or unclean exit."
-       ${BLADERF_OS_LINUX}
+       OFF
 )
 
 option(ENABLE_RFIC_TIMING_CALIBRATION

--- a/host/libraries/libbladeRF/include/bladeRF2.h
+++ b/host/libraries/libbladeRF/include/bladeRF2.h
@@ -117,6 +117,28 @@ int CALL_CONV bladerf_set_rfic_register(struct bladerf *dev,
                                         uint8_t val);
 
 /**
+ * Read the RFFE control register
+ *
+ * This register lives in the FPGA, not in the RFIC, and carries the RF
+ * front-end state that no RFIC register reflects: the SPDT switch
+ * positions, the per-channel enables, and the direction ENABLE/TXNRX
+ * bits. Without it, a caller debugging a dead or attenuated RF path has
+ * no way to tell a switch left in its shutdown position from an RFIC
+ * problem -- every RFIC register can read back correct while the signal
+ * is routed nowhere.
+ *
+ * The bit positions are the RFFE_CONTROL_* constants in
+ * fpga_common/include/bladerf2_common.h.
+ *
+ * @param       dev         Device handle
+ * @param[out]  value       RFFE control register value
+ *
+ * @return 0 on success, value from \ref RETCODES list on failure
+ */
+API_EXPORT
+int CALL_CONV bladerf_get_rffe_control(struct bladerf *dev, uint32_t *value);
+
+/**
  * Read the temperature from the RFIC
  *
  * @param       dev         Device handle

--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -2764,6 +2764,14 @@ int CALL_CONV bladerf_get_timestamp(struct bladerf *dev,
  * @param[in]   num_transfers   The number of active USB transfers that may be
  *                              in-flight at any given time. If unsure of what
  *                              to use here, try values of 4, 8, or 16.
+ *
+ *                              Each in-flight transfer is pinned by the
+ *                              kernel, so `num_transfers * buffer_size` must
+ *                              fit within the usbfs memory limit (16 MiB by
+ *                              default on Linux, see
+ *                              /sys/module/usbcore/parameters/usbfs_memory_mb).
+ *                              Configurations that exceed it are rejected
+ *                              with ::BLADERF_ERR_INVAL.
  * @param[in]   stream_timeout  Timeout (milliseconds) for transfers in the
  *                              underlying data stream.
  *

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1006,10 +1006,17 @@ static inline void cancel_all_transfers(struct bladerf_stream *stream)
     for (i = 0; i < stream_data->num_transfers; i++) {
         if (stream_data->transfer_status[i] == TRANSFER_IN_FLIGHT) {
             status = libusb_cancel_transfer(stream_data->transfers[i]);
-            if (status < 0 && status != LIBUSB_ERROR_NOT_FOUND) {
+            if (status < 0 && status != LIBUSB_ERROR_NOT_FOUND &&
+                status != LIBUSB_ERROR_NO_DEVICE) {
                 log_error("Error canceling transfer (%d): %s\n",
                         status, libusb_error_name(status));
             } else {
+                /* LIBUSB_ERROR_NO_DEVICE is expected when the device has
+                 * been unplugged or reset: the transfer cannot be cancelled
+                 * because the device is gone. libusb still delivers the
+                 * completion callback, so mark it pending like any other
+                 * cancellation instead of logging an error per transfer.
+                 */
                 stream_data->transfer_status[i] = TRANSFER_CANCEL_PENDING;
             }
         }

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -80,7 +80,29 @@ struct lusb_stream_data {
 
     /* Report a stalled feed once per stream, not once per transfer. */
     bool timeout_reported;
+
+    /* Completion flag for libusb_handle_events_timeout_completed(). libusb
+     * re-checks it under its own event lock, which is what makes the wait
+     * safe when RX and TX both handle events on one context. Set wherever
+     * the stream reaches STREAM_DONE. */
+    int done_flag;
 };
+
+/* Finish a stream and wake anyone waiting on libusb events for it.
+ *
+ * The state and the completion flag have to move together: a waiter inside
+ * libusb only re-checks the flag, so setting the state alone leaves it
+ * sleeping until its timeout expires.
+ */
+static inline void mark_stream_done(struct bladerf_stream *stream)
+{
+    struct lusb_stream_data *stream_data = stream->backend_data;
+
+    stream->state = STREAM_DONE;
+    if (stream_data != NULL) {
+        stream_data->done_flag = 1;
+    }
+}
 
 static inline struct bladerf_lusb * lusb_backend(struct bladerf *dev)
 {
@@ -1187,7 +1209,7 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
         /* We know we're done when all of our transfers have returned to their
          * "available" states */
         if (stream_data->num_avail == stream_data->num_transfers) {
-            stream->state = STREAM_DONE;
+            mark_stream_done(stream);
         } else {
             cancel_all_transfers(stream);
         }
@@ -1315,6 +1337,7 @@ static int lusb_init_stream(void *driver, struct bladerf_stream *stream,
     stream_data->out_of_order_event = false;
     stream_data->num_complete = 0;
     stream_data->timeout_reported = false;
+    stream_data->done_flag = 0;
 
     stream_data->transfers =
         malloc(num_transfers * sizeof(struct libusb_transfer *));
@@ -1407,7 +1430,7 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
                 } else {
                     /* No transfers have been shipped out yet so we can
                      * simply enter our "done" state */
-                    stream->state = STREAM_DONE;
+                    mark_stream_done(stream);
                 }
 
                 /* In either of the above we don't want to attempt to
@@ -1437,9 +1460,22 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
     }
     MUTEX_UNLOCK(&stream->lock);
 
-    /* This loop is required so libusb can do callbacks and whatnot */
+    /* This loop is required so libusb can do callbacks and whatnot.
+     *
+     * RX and TX each run this loop on the same libusb context, so two threads
+     * compete for event handling. libusb allows that, but only one thread
+     * actually handles events while the others wait, and a waiter that
+     * decided to wait before the state it is waiting on changed will keep
+     * waiting - the classic lost wakeup that libusb_handle_events_completed()
+     * exists to close. Checking stream->state outside the event lock, as a
+     * plain handle_events_timeout() call requires, is exactly that pattern.
+     *
+     * Pass the completion flag instead: libusb re-checks it under its own
+     * event lock and returns immediately if it is already set.
+     */
     while (stream->state != STREAM_DONE) {
-        status = libusb_handle_events_timeout(lusb->context, &tv);
+        status = libusb_handle_events_timeout_completed(
+            lusb->context, &tv, &stream_data->done_flag);
 
         if (status < 0 && status != LIBUSB_ERROR_INTERRUPTED &&
             status != LIBUSB_ERROR_TIMEOUT) {
@@ -1460,7 +1496,7 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
         MUTEX_LOCK(&stream->lock);
         if (stream->state == STREAM_SHUTTING_DOWN) {
             if (stream_data->num_avail == stream_data->num_transfers) {
-                stream->state = STREAM_DONE;
+                mark_stream_done(stream);
             } else {
                 cancel_all_transfers(stream);
             }
@@ -1481,7 +1517,7 @@ int lusb_submit_stream_buffer(void *driver, struct bladerf_stream *stream,
 
     if (buffer == BLADERF_STREAM_SHUTDOWN) {
         if (stream_data->num_avail == stream_data->num_transfers) {
-            stream->state = STREAM_DONE;
+            mark_stream_done(stream);
         } else {
             stream->state = STREAM_SHUTTING_DOWN;
         }

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -46,6 +46,16 @@
 #   define LIBUSB_HANDLE_EVENTS_TIMEOUT_NSEC    (15 * 1000)
 #endif
 
+/* No short polling timeout on TX transfers, deliberately.
+ *
+ * Retiring an in-flight TX transfer cuts it wherever it happens to be, and a
+ * cut that is not a multiple of the FX3's 8192-byte buffer leaves the DMA
+ * channel holding an unfinished buffer that nothing can complete - the wedge
+ * documented and fixed in "libusb: do not cut a TX transfer in the middle of
+ * a buffer". A transfer waiting on a scheduled timestamp must be left alone
+ * until it finishes; capacity control belongs at submission, not in the
+ * transfer timeout. */
+
 struct bladerf_lusb {
     libusb_device           *dev;
     libusb_device_handle    *handle;
@@ -85,6 +95,7 @@ struct lusb_stream_data {
 
     /* Report a stalled feed once per stream, not once per transfer. */
     bool timeout_reported;
+
 
     /* Completion flag for libusb_handle_events_timeout_completed(). libusb
      * re-checks it under its own event lock, which is what makes the wait
@@ -1129,6 +1140,8 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
     } else {
         stream_data->transfer_status[transfer_i] = TRANSFER_AVAIL;
         stream_data->num_avail++;
+
+
         COND_SIGNAL(&stream->can_submit_buffer);
     }
 
@@ -1158,6 +1171,60 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
                     (int)transfer->status, transfer->actual_length,
                     (int)transfer->length,
                     (unsigned)stream_data->num_complete);
+    }
+
+    /* A TX transfer that timed out without moving a byte is backpressure,
+     * not a fault.
+     *
+     * With SC16_Q11_META the FPGA pulls a block out of the FX3 only once its
+     * timestamp comes due (fifo_reader.vhd: timestamp >= meta_p_time). A
+     * burst scheduled into the future is therefore not consumed at all until
+     * its start time: the FX3 buffers fill, the endpoint stops accepting, and
+     * the kernel retires the queued URBs with -ENOENT after their timeout.
+     *
+     * Confirmed with usbmon on a bladeRF 2.0 micro: 18 submissions, 18
+     * completions, one with status 0 carrying the full buffer, the rest one
+     * second later with status -2 and zero bytes - while the other endpoint
+     * kept completing normally throughout. Nothing was lost and the link was
+     * healthy; the device simply had nowhere to put the data yet.
+     *
+     * Tearing the stream down here turns that wait into a hard failure: the
+     * worker exits, no thread services completions, and the remainder of the
+     * burst is stranded. Instead, hand the transfer back to the pool and
+     * leave the stream running. The buffer stays IN_FLIGHT and unsent, so
+     * sync_tx() re-submits it through the reclaim path once the device is
+     * ready - no samples are dropped and none are duplicated.
+     *
+     * Only a transfer that moved nothing is retried. Resuming a partially
+     * accepted buffer from where it stopped was tried and does not help: the
+     * device is full either way, so the remainder stalls exactly like the
+     * whole did (measured: one resume of 8192 bytes, then 95 consecutive
+     * zero-byte stalls). Retrying it also cannot be done by resending from
+     * the start, which would put the accepted samples on the air twice. RX
+     * is left alone - there a timeout does mean the feed stopped. */
+    if (transfer->status == LIBUSB_TRANSFER_TIMED_OUT &&
+        transfer->actual_length == 0 &&
+        (stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX &&
+        stream->state == STREAM_RUNNING) {
+        int resubmit;
+
+        log_verbose("TX transfer %p timed out with nothing sent; device not "
+                    "ready for scheduled samples yet. Requeueing.\n",
+                    transfer->buffer);
+
+        /* submit_transfer() takes a fresh transfer from the pool - this one
+         * was returned to it a few lines above - so nothing is reused from
+         * under libusb. Nothing of the buffer reached the device, so this
+         * neither drops nor duplicates samples; it simply waits again. */
+        resubmit = submit_transfer(stream, transfer->buffer,
+                                   async_stream_buf_bytes(stream));
+        if (resubmit == 0) {
+            MUTEX_UNLOCK(&stream->lock);
+            return;
+        }
+
+        log_debug("Could not requeue stalled TX transfer: %s\n",
+                  bladerf_strerror(resubmit));
     }
 
     /* Check to see if the transfer has been cancelled or errored */
@@ -1557,6 +1624,8 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
     return status;
 }
 
+
+
 /* The top-level code will have aquired the stream->lock for us */
 int lusb_submit_stream_buffer(void *driver, struct bladerf_stream *stream,
                               void *buffer, size_t *length,
@@ -1575,6 +1644,20 @@ int lusb_submit_stream_buffer(void *driver, struct bladerf_stream *stream,
         return 0;
     }
 
+    /* Room means both a free transfer and space the device can actually take.
+     *
+     * Counting only transfers queues past what the hardware holds: with a
+     * scheduled burst nothing is consumed until its start time, so the extra
+     * submissions sit on a full endpoint and time out. Waiting here instead
+     * keeps the feed matched to the device and lets a burst of any length go
+     * out, a piece at a time, as room frees up. */
+    /* A byte-level admission gate was tried here and measured worse: the only
+     * cheap feedback is URB completion, which for a scheduled burst arrives
+     * only after consumption begins, so the gate starved the feed during
+     * playback and stalled configurations that work without it. Capacity
+     * pressure is instead absorbed by requeueing zero-byte TX timeouts in
+     * lusb_stream_cb, which keeps the stream alive while the device waits
+     * for its timestamp. */
     if (stream_data->num_avail == 0) {
         if (nonblock) {
             log_debug("Non-blocking buffer submission requested, but no "

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -69,11 +69,6 @@ struct lusb_stream_data {
     struct libusb_transfer **transfers; /* Array of transfer metadata */
     transfer_status *transfer_status;   /* Status of each transfer */
 
-    /* # of transfers that completed with a full buffer on this stream.
-     * Reported when a transfer fails: zero means the device never produced
-     * anything, nonzero means it stopped after having worked. */
-    size_t num_complete;
-
    /* Warn the first time we get a transfer callback out of order.
     * This shouldn't happen normally, but we've seen it intermittently on
     * libusb 1.0.19 for Windows. Further investigation required...

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1406,6 +1406,25 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
                         "%d: %s\n", status, libusb_error_name(status));
             status = error_conv(status);
         }
+
+        /* Finish a shutdown that has nothing left to complete.
+         *
+         * The SHUTTING_DOWN -> DONE transition normally happens in
+         * lusb_stream_cb(), so it needs a transfer to come back. When a
+         * shutdown is requested while nothing is in flight - a stopped TX
+         * feed, for instance - no callback ever runs and this loop would spin
+         * until the worker is cancelled. Cancel here and settle it once every
+         * transfer is accounted for.
+         */
+        MUTEX_LOCK(&stream->lock);
+        if (stream->state == STREAM_SHUTTING_DOWN) {
+            if (stream_data->num_avail == stream_data->num_transfers) {
+                stream->state = STREAM_DONE;
+            } else {
+                cancel_all_transfers(stream);
+            }
+        }
+        MUTEX_UNLOCK(&stream->lock);
     }
 
     return status;

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1064,6 +1064,19 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
         COND_SIGNAL(&stream->can_submit_buffer);
     }
 
+    /* A short or failed transfer says a lot about a stalled feed, and the
+     * status alone is easy to guess wrong about: a stalled TX feed shows up as
+     * TIMED_OUT, never as a zero-length COMPLETED. Log what actually came
+     * back so the next person does not have to instrument this again. */
+    if (transfer->status != LIBUSB_TRANSFER_COMPLETED ||
+        transfer->actual_length != (int)transfer->length) {
+        log_verbose("%s: %s transfer status %d, %d of %d bytes\n", __FUNCTION__,
+                    (stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX
+                        ? "TX" : "RX",
+                    (int)transfer->status, transfer->actual_length,
+                    (int)transfer->length);
+    }
+
     /* Check to see if the transfer has been cancelled or errored */
     if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
         /* Errored out for some reason .. */
@@ -1487,6 +1500,14 @@ static int lusb_deinit_stream(void *driver, struct bladerf_stream *stream)
     struct lusb_stream_data *stream_data = stream->backend_data;
 
     for (i = 0; i < stream_data->num_transfers; i++) {
+        if (stream_data->transfer_status[i] != TRANSFER_AVAIL &&
+            stream_data->transfer_status[i] != TRANSFER_UNINITIALIZED) {
+            log_warning("deinit_stream: transfer %u still %d, num_avail %u of "
+                        "%u\n", (unsigned)i,
+                        (int)stream_data->transfer_status[i],
+                        (unsigned)stream_data->num_avail,
+                        (unsigned)stream_data->num_transfers);
+        }
         libusb_free_transfer(stream_data->transfers[i]);
         stream_data->transfers[i] = NULL;
         stream_data->transfer_status[i] = TRANSFER_UNINITIALIZED;

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -68,6 +68,11 @@ struct lusb_stream_data {
     struct libusb_transfer **transfers; /* Array of transfer metadata */
     transfer_status *transfer_status;   /* Status of each transfer */
 
+    /* # of transfers that completed with a full buffer on this stream.
+     * Reported when a transfer fails: zero means the device never produced
+     * anything, nonzero means it stopped after having worked. */
+    size_t num_complete;
+
    /* Warn the first time we get a transfer callback out of order.
     * This shouldn't happen normally, but we've seen it intermittently on
     * libusb 1.0.19 for Windows. Further investigation required...
@@ -1057,6 +1062,11 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
         COND_SIGNAL(&stream->can_submit_buffer);
     }
 
+    if (transfer->status == LIBUSB_TRANSFER_COMPLETED &&
+        transfer->actual_length == (int)transfer->length) {
+        stream_data->num_complete++;
+    }
+
     /* Check to see if the transfer has been cancelled or errored */
     if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
         /* Errored out for some reason .. */
@@ -1086,9 +1096,19 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
                 break;
 
             case LIBUSB_TRANSFER_TIMED_OUT:
-                log_error("Transfer timed out for %s buffer %p\n\r",
+                /* How much of the buffer arrived, and whether anything ever
+                 * arrived on this stream, separates two very different
+                 * faults that both surface as BLADERF_ERR_TIMEOUT: a device
+                 * that never started producing, and one that stopped
+                 * mid-stream. Without these numbers the caller only sees
+                 * "timed out" and has to instrument the library to tell them
+                 * apart. */
+                log_error("Transfer timed out for %s buffer %p: %d of %d "
+                          "bytes, %u transfer(s) completed on this stream\n\r",
                           (stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX ? "TX" : "RX",
-                          transfer->buffer);
+                          transfer->buffer, transfer->actual_length,
+                          (int)transfer->length,
+                          (unsigned)stream_data->num_complete);
                 stream->error_code = BLADERF_ERR_TIMEOUT;
                 break;
 
@@ -1267,6 +1287,7 @@ static int lusb_init_stream(void *driver, struct bladerf_stream *stream,
     stream_data->num_avail = 0;
     stream_data->i = 0;
     stream_data->out_of_order_event = false;
+    stream_data->num_complete = 0;
 
     stream_data->transfers =
         malloc(num_transfers * sizeof(struct libusb_transfer *));

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -36,6 +36,7 @@
 #include "backend/usb/usb.h"
 #include "streaming/async.h"
 #include "helpers/timeout.h"
+#include "helpers/wallclock.h"
 
 #include "bladeRF.h"
 
@@ -77,6 +78,10 @@ struct lusb_stream_data {
     /* Full transfers completed on this stream, so a stall can report how far
      * the feed got before it stopped. */
     size_t num_complete;
+
+    /* When an in-flight TX transfer may no longer be given time to finish
+     * on its own. Zero until a shutdown starts. */
+    uint64_t cancel_deadline_ns;
 
     /* Report a stalled feed once per stream, not once per transfer. */
     bool timeout_reported;
@@ -1032,6 +1037,40 @@ static inline void cancel_all_transfers(struct bladerf_stream *stream)
     int status;
     struct lusb_stream_data *stream_data = stream->backend_data;
 
+    /* Cancelling a TX transfer that is already moving cuts the stream in the
+     * middle of a buffer, and the device cannot use a partial one.
+     *
+     * Measured on the wire: cancelled OUT transfers come back with 1024,
+     * 3072, 5120, 6144, 8192, 13312 and 27648 bytes done - all multiples of
+     * the 1024-byte SuperSpeed packet, none a multiple of the 32768-byte
+     * buffer. The FX3 TX channel is CY_U3P_DMA_TYPE_AUTO over 8192-byte
+     * buffers, so it assembles whole buffers; a cut leaves it holding an
+     * unfinished one, and later submissions have nowhere to complete. What
+     * follows is eight submissions sitting for a full stream timeout while
+     * the RX endpoint keeps completing normally.
+     *
+     * So let an in-flight TX transfer finish on its own. The event loop calls
+     * this on every iteration while shutting down, so returning here means
+     * trying again in 15 ms; each transfer already carries its own timeout,
+     * which bounds the wait. Cancel only once that deadline has passed, since
+     * by then the transfer is not going to complete anyway.
+     *
+     * Transfers that never started are unaffected: they complete immediately
+     * either way.
+     */
+    if ((stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX &&
+        stream->transfer_timeout != 0) {
+        const uint64_t now = wallclock_get_current_nsec();
+
+        if (stream_data->cancel_deadline_ns == 0) {
+            stream_data->cancel_deadline_ns =
+                now + (uint64_t)stream->transfer_timeout * 1000000u;
+        }
+        if (now < stream_data->cancel_deadline_ns) {
+            return;
+        }
+    }
+
     for (i = 0; i < stream_data->num_transfers; i++) {
         if (stream_data->transfer_status[i] == TRANSFER_IN_FLIGHT) {
             status = libusb_cancel_transfer(stream_data->transfers[i]);
@@ -1337,6 +1376,7 @@ static int lusb_init_stream(void *driver, struct bladerf_stream *stream,
     stream_data->out_of_order_event = false;
     stream_data->num_complete = 0;
     stream_data->timeout_reported = false;
+    stream_data->cancel_deadline_ns = 0;
     stream_data->done_flag = 0;
 
     stream_data->transfers =

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -73,6 +73,13 @@ struct lusb_stream_data {
     * libusb 1.0.19 for Windows. Further investigation required...
     */
     bool out_of_order_event;
+
+    /* Full transfers completed on this stream, so a stall can report how far
+     * the feed got before it stopped. */
+    size_t num_complete;
+
+    /* Report a stalled feed once per stream, not once per transfer. */
+    bool timeout_reported;
 };
 
 static inline struct bladerf_lusb * lusb_backend(struct bladerf *dev)
@@ -1068,13 +1075,28 @@ static void LIBUSB_CALL lusb_stream_cb(struct libusb_transfer *transfer)
      * status alone is easy to guess wrong about: a stalled TX feed shows up as
      * TIMED_OUT, never as a zero-length COMPLETED. Log what actually came
      * back so the next person does not have to instrument this again. */
-    if (transfer->status != LIBUSB_TRANSFER_COMPLETED ||
-        transfer->actual_length != (int)transfer->length) {
-        log_verbose("%s: %s transfer status %d, %d of %d bytes\n", __FUNCTION__,
+    if (transfer->status == LIBUSB_TRANSFER_COMPLETED &&
+        transfer->actual_length == (int)transfer->length) {
+        stream_data->num_complete++;
+    } else if (transfer->status == LIBUSB_TRANSFER_TIMED_OUT &&
+               !stream_data->timeout_reported) {
+        /* Once per stream, at a level people actually run with: a feed that
+         * stops does it after a fixed number of transfers, and that count is
+         * the first thing worth knowing about it. */
+        stream_data->timeout_reported = true;
+        log_warning("%s: %s transfer timed out after %u full transfers\n",
+                    __FUNCTION__,
+                    (stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX
+                        ? "TX" : "RX",
+                    (unsigned)stream_data->num_complete);
+    } else {
+        log_verbose("%s: %s transfer status %d, %d of %d bytes, after %u full "
+                    "transfers\n", __FUNCTION__,
                     (stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX
                         ? "TX" : "RX",
                     (int)transfer->status, transfer->actual_length,
-                    (int)transfer->length);
+                    (int)transfer->length,
+                    (unsigned)stream_data->num_complete);
     }
 
     /* Check to see if the transfer has been cancelled or errored */
@@ -1291,6 +1313,8 @@ static int lusb_init_stream(void *driver, struct bladerf_stream *stream,
     stream_data->num_avail = 0;
     stream_data->i = 0;
     stream_data->out_of_order_event = false;
+    stream_data->num_complete = 0;
+    stream_data->timeout_reported = false;
 
     stream_data->transfers =
         malloc(num_transfers * sizeof(struct libusb_transfer *));

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1186,8 +1186,12 @@ get_next_available_transfer(struct lusb_stream_data *stream_data)
             if (stream_data->i != i &&
                 stream_data->out_of_order_event == false) {
 
-                log_warning("Transfer callback occurred out of order. "
-                            "(Warning only this time.)\n");
+                log_warning("Transfer callback occurred out of order: "
+                            "wanted %u, found %u, num_avail %u of %u. "
+                            "(Warning only this time.)\n",
+                            (unsigned)stream_data->i, (unsigned)i,
+                            (unsigned)stream_data->num_avail,
+                            (unsigned)stream_data->num_transfers);
                 stream_data->out_of_order_event = true;
             }
 
@@ -1256,11 +1260,11 @@ static int submit_transfer(struct bladerf_stream *stream, void *buffer, size_t l
         assert(stream_data->transfer_status[prev_idx] == TRANSFER_IN_FLIGHT);
         stream_data->transfer_status[prev_idx] = TRANSFER_AVAIL;
         stream_data->num_avail++;
-        if (stream_data->i == 0) {
-            stream_data->i = stream_data->num_transfers - 1;
-        } else {
-            stream_data->i--;
-        }
+
+        /* Undo the index step. prev_idx is the slot we took, and
+         * get_next_available_transfer() had already pointed stream_data->i at
+         * it, so this restores exactly what we found. */
+        stream_data->i = prev_idx;
     }
 
     return error_conv(status);

--- a/host/libraries/libbladeRF/src/backend/usb/libusb.c
+++ b/host/libraries/libbladeRF/src/backend/usb/libusb.c
@@ -1393,7 +1393,8 @@ static int lusb_stream(void *driver, struct bladerf_stream *stream,
     while (stream->state != STREAM_DONE) {
         status = libusb_handle_events_timeout(lusb->context, &tv);
 
-        if (status < 0 && status != LIBUSB_ERROR_INTERRUPTED) {
+        if (status < 0 && status != LIBUSB_ERROR_INTERRUPTED &&
+            status != LIBUSB_ERROR_TIMEOUT) {
             log_warning("unexpected value from events processing: "
                         "%d: %s\n", status, libusb_error_name(status));
             status = error_conv(status);

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -2236,6 +2236,12 @@ int bladerf_load_gain_calibration(struct bladerf *dev, bladerf_channel ch, const
     }
 
     if (cal_file_loc != NULL) {
+        if (strlen(cal_file_loc) >= filename_len) {
+            log_error("Gain calibration path is too long (%zu >= %zu)\n",
+                      strlen(cal_file_loc), filename_len);
+            status = BLADERF_ERR_INVAL;
+            goto error;
+        }
         strcpy(filename, cal_file_loc);
     } else {
         log_debug("No calibration file specified, using serial number\n");
@@ -2258,6 +2264,10 @@ int bladerf_load_gain_calibration(struct bladerf *dev, bladerf_channel ch, const
 
     /** Convert to binary format if CSV */
     full_path_bin = (char*)malloc(strlen(full_path) + 1);
+    if (full_path_bin == NULL) {
+        status = BLADERF_ERR_MEM;
+        goto error;
+    }
     strcpy(full_path_bin, full_path);
     ext = strstr(full_path_bin, ".csv");
     if (ext) {

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -552,12 +552,18 @@ int bladerf_enable_module(struct bladerf *dev, bladerf_channel ch, bool enable)
 int bladerf_set_gain(struct bladerf *dev, bladerf_channel ch, int gain)
 {
     int status;
-    bladerf_gain_mode gain_mode;
+    bladerf_gain_mode gain_mode  = BLADERF_GAIN_MGC;
+    bladerf_gain_mode restore_to = BLADERF_GAIN_MGC;
+    bool restore_gain_mode       = false;
     bladerf_frequency freq;
     bladerf_gain assigned_gain = gain;
     MUTEX_LOCK(&dev->lock);
 
-    /* Change gain mode to manual if ch = RX */
+    /* The RFIC only accepts a manual gain value while it is in MGC: the
+     * AD936x driver rejects the write outright otherwise. Borrow MGC for the
+     * duration of the write and hand the channel back in the mode the caller
+     * chose, rather than silently leaving AGC switched off behind them.
+     */
     if (BLADERF_CHANNEL_IS_TX(ch) == false) {
         status = dev->board->get_gain_mode(dev, ch, &gain_mode);
         if (status != 0) {
@@ -566,12 +572,14 @@ int bladerf_set_gain(struct bladerf *dev, bladerf_channel ch, int gain)
         }
 
         if (gain_mode != BLADERF_GAIN_MGC) {
-            log_warning("Setting gain mode to manual\n");
             status = dev->board->set_gain_mode(dev, ch, BLADERF_GAIN_MGC);
             if (status != 0) {
                 log_error("Failed to set gain mode\n");
                 goto error;
             }
+
+            restore_to         = gain_mode;
+            restore_gain_mode  = true;
         }
     }
 
@@ -585,7 +593,16 @@ int bladerf_set_gain(struct bladerf *dev, bladerf_channel ch, int gain)
     status = dev->board->set_gain(dev, ch, assigned_gain);
     if (status != 0) {
         log_error("Failed to set gain\n");
-        goto error;
+    }
+
+    if (restore_gain_mode) {
+        int restore_status = dev->board->set_gain_mode(dev, ch, restore_to);
+        if (restore_status != 0) {
+            log_error("Failed to restore gain mode\n");
+            if (status == 0) {
+                status = restore_status;
+            }
+        }
     }
 
 error:

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -1117,6 +1117,7 @@ int bladerf_init_stream(struct bladerf_stream **stream,
     if (format == BLADERF_FORMAT_SC8_Q7 || format == BLADERF_FORMAT_SC8_Q7_META) {
         if (strcmp(bladerf_get_board_name(dev), "bladerf2") != 0) {
             log_error("bladeRF 2.0 required for 8bit format\n");
+            MUTEX_UNLOCK(&dev->lock);
             return BLADERF_ERR_UNSUPPORTED;
         }
     }
@@ -1216,6 +1217,7 @@ int bladerf_sync_config(struct bladerf *dev,
     if (format == BLADERF_FORMAT_SC8_Q7 || format == BLADERF_FORMAT_SC8_Q7_META) {
         if (strcmp(bladerf_get_board_name(dev), "bladerf2") != 0) {
             log_error("bladeRF 2.0 required for 8bit format\n");
+            MUTEX_UNLOCK(&dev->lock);
             return BLADERF_ERR_UNSUPPORTED;
         }
     }

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1439,19 +1439,34 @@ static int bladerf2_get_quick_tune(struct bladerf *dev,
     pm = _get_band_port_map_by_freq(ch, freq);
 
     if (BLADERF_CHANNEL_IS_TX(ch)) {
-        if (board_data->quick_tune_tx_profile < NUM_BBP_FASTLOCK_PROFILES) {
-            /* Assign Nios and RFFE profile numbers */
-            quick_tune->nios_profile = board_data->quick_tune_tx_profile++;
-            log_verbose("Quick tune assigned Nios TX fast lock index: %u\n",
-                        quick_tune->nios_profile);
-            quick_tune->rffe_profile =
-                quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
-            log_verbose("Quick tune assigned RFFE TX fast lock index: %u\n",
-                        quick_tune->rffe_profile);
-        } else {
-            log_error("Reached maximum number of TX quick tune profiles.");
-            return BLADERF_ERR_UNEXPECTED;
-        }
+        /* Profile indices wrap instead of running out.
+         *
+         * The counter only ever incremented, and was reset in exactly one
+         * place: board initialisation. An application that keeps asking for
+         * quick tunes therefore had a hard budget of 256 for the lifetime of
+         * the device handle, after which every further call failed with
+         * BLADERF_ERR_UNEXPECTED and no way to recover short of reopening.
+         *
+         * That budget is not a hardware limit on how many retune targets may
+         * exist over time. The RFIC holds NUM_RFFE_FASTLOCK_PROFILES slots
+         * and the Nios holds NUM_BBP_FASTLOCK_PROFILES; both are caches that
+         * the code already overwrites - the RFFE index is assigned modulo the
+         * slot count, so profile 8 has always overwritten profile 0. Letting
+         * the Nios index wrap in the same way makes the two consistent and
+         * keeps a long-running sweep working.
+         *
+         * Measured on a bladeRF 2.0 micro xA4 sweeping 70 MHz - 6 GHz with
+         * 4700 stops: the counter reached 256 after roughly 165-229 s and
+         * every subsequent retune to a new frequency failed.
+         */
+        quick_tune->nios_profile =
+            board_data->quick_tune_tx_profile++ % NUM_BBP_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned Nios TX fast lock index: %u\n",
+                    quick_tune->nios_profile);
+        quick_tune->rffe_profile =
+            quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned RFFE TX fast lock index: %u\n",
+                    quick_tune->rffe_profile);
 
         /* Create a fast lock profile in the RFIC */
         CHECK_STATUS(
@@ -1468,19 +1483,15 @@ static int bladerf2_get_quick_tune(struct bladerf *dev,
         quick_tune->spdt = (pm->spdt << 6) | (pm->spdt << 4);
 
     } else {
-        if (board_data->quick_tune_rx_profile < NUM_BBP_FASTLOCK_PROFILES) {
-            /* Assign Nios and RFFE profile numbers */
-            quick_tune->nios_profile = board_data->quick_tune_rx_profile++;
-            log_verbose("Quick tune assigned Nios RX fast lock index: %u\n",
-                        quick_tune->nios_profile);
-            quick_tune->rffe_profile =
-                quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
-            log_verbose("Quick tune assigned RFFE RX fast lock index: %u\n",
-                        quick_tune->rffe_profile);
-        } else {
-            log_error("Reached maximum number of RX quick tune profiles.");
-            return BLADERF_ERR_UNEXPECTED;
-        }
+        /* Profile indices wrap instead of running out; see the TX branch. */
+        quick_tune->nios_profile =
+            board_data->quick_tune_rx_profile++ % NUM_BBP_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned Nios RX fast lock index: %u\n",
+                    quick_tune->nios_profile);
+        quick_tune->rffe_profile =
+            quick_tune->nios_profile % NUM_RFFE_FASTLOCK_PROFILES;
+        log_verbose("Quick tune assigned RFFE RX fast lock index: %u\n",
+                    quick_tune->rffe_profile);
 
         /* Create a fast lock profile in the RFIC */
         CHECK_STATUS(

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -533,6 +533,29 @@ static void bladerf2_close(struct bladerf *dev)
                 {
                     sync_deinit(&board_data->sync[ch]);
 
+                    /* Tell the FX3 the direction is going away.
+                     *
+                     * sync_deinit() only tears down host-side structures, and
+                     * putting the RFIC in standby further down is a
+                     * control-plane operation: neither reaches the FX3 sample
+                     * endpoint or its DMA channel. The firmware clears those
+                     * from its RF_RX/RF_TX handler, and only on the disable
+                     * transition, so a close that never disables leaves the
+                     * data plane in whatever state the last stream left it.
+                     * A later open then inherits it, and every RX transfer
+                     * comes back timed out with zero bytes.
+                     */
+                    if (board_data->state >= STATE_INITIALIZED &&
+                        dev->backend->is_fpga_configured(dev)) {
+                        int status = dev->backend->enable_module(dev, dir, false);
+                        if (status != 0) {
+                            log_debug("%s: could not disable %s on close: %s\n",
+                                      __FUNCTION__,
+                                      (dir == BLADERF_RX) ? "RX" : "TX",
+                                      bladerf_strerror(status));
+                        }
+                    }
+
                     /* Cancel scheduled retunes here to avoid the device
                      * retuning underneath the user should they open it again in
                      * the future.

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -3117,6 +3117,19 @@ int bladerf_get_rfic_register(struct bladerf *dev,
     return 0;
 }
 
+int bladerf_get_rffe_control(struct bladerf *dev, uint32_t *value)
+{
+    CHECK_BOARD_IS_BLADERF2(dev);
+    CHECK_BOARD_STATE(STATE_FPGA_LOADED);
+    NULL_CHECK(value);
+
+    WITH_MUTEX(&dev->lock, {
+        CHECK_STATUS_LOCKED(dev->backend->rffe_control_read(dev, value));
+    });
+
+    return 0;
+}
+
 int bladerf_set_rfic_register(struct bladerf *dev,
                               uint16_t address,
                               uint8_t val)

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1175,16 +1175,42 @@ static int bladerf2_set_sample_rate(struct bladerf *dev,
         rate /= 2;
     }
 
-    /* Set the sample rate */
-    CHECK_STATUS(rfic->set_sample_rate(dev, ch, rate));
-
-    /* If the previous sample rate was below the native range, but the new one
-     * isn't, switch back to the default filters. */
+    /* Leaving the sub-native range: restore the default filters BEFORE
+     * applying the new rate, mirroring the low-rate path above.
+     *
+     * With the 4x interpolation filter still active, the AD9361 computes the
+     * TX clock chain as (new rate * 4). Restoring 61.44 MSPS therefore asks
+     * for 245.76 MHz, above MAX_TX_HB1 (160 MHz), and the transition fails:
+     *
+     *   ad9361_validate_trx_clock_chain: Failed TX max rate check
+     *       (245760000 > 160000000)
+     *   ad9361_calculate_rf_clock_chain: Failed to find suitable dividers:
+     *       ADC clock below limit
+     *
+     * Both chains are validated together, so RX-only applications hit this
+     * too. Resetting the filters after set_sample_rate() (as before) made
+     * that reset unreachable, since CHECK_STATUS() had already returned.
+     *
+     * The intermediate-rate step is the same trick the low-rate path above
+     * already uses. That guard even spells out this direction:
+     *
+     *   (rate > 40e6 && current < 2083334)
+     *
+     * but it lives inside "if (new_low)", where the new rate is low by
+     * definition, so that half of the condition can never run. The step is
+     * applied here instead, where the transition actually happens.
+     *
+     * 30 MSPS works for both sides of the switch: it is inside the native
+     * range (no FIR needed) and 30 * 4 = 120 MHz stays under MAX_TX_HB1, so
+     * it is valid with the 4x filters still active and after they are
+     * cleared. */
     if (old_low && !new_low) {
         if (rxfir != BLADERF_RFIC_RXFIR_DEFAULT ||
             txfir != BLADERF_RFIC_TXFIR_DEFAULT) {
             log_debug("%s: disabling 4x decimation/interpolation filters\n",
                       __FUNCTION__);
+
+            CHECK_STATUS(rfic->set_sample_rate(dev, ch, 30e6));
 
             CHECK_STATUS(rfic->set_filter(dev, BLADERF_CHANNEL_RX(0),
                                           BLADERF_RFIC_RXFIR_DEFAULT, 0));
@@ -1192,6 +1218,9 @@ static int bladerf2_set_sample_rate(struct bladerf *dev,
                                           BLADERF_RFIC_TXFIR_DEFAULT));
         }
     }
+
+    /* Set the sample rate */
+    CHECK_STATUS(rfic->set_sample_rate(dev, ch, rate));
 
     /* If requested, fetch the new sample rate and return it. */
     if (actual != NULL) {

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -1544,9 +1544,39 @@ static int bladerf2_schedule_retune(struct bladerf *dev,
         return BLADERF_ERR_UNSUPPORTED;
     }
 
-    return dev->backend->retune2(dev, ch, timestamp, quick_tune->nios_profile,
-                                 quick_tune->rffe_profile, quick_tune->port,
-                                 quick_tune->spdt);
+    CHECK_STATUS(dev->backend->retune2(dev, ch, timestamp,
+                                       quick_tune->nios_profile,
+                                       quick_tune->rffe_profile,
+                                       quick_tune->port, quick_tune->spdt));
+
+    /* The Nios recalls the profile by writing the RFIC directly, which
+     * leaves the part in fastlock mode with FORCE_ALC_ENABLE asserted.
+     * ad9361_fastlock_prepare() cannot undo that on its own: it is gated
+     * on this driver's own bookkeeping, and a recall performed by the
+     * FPGA never touches it. Ownership of the RFPLL therefore returns to
+     * host tuning with forced controls still active.
+     *
+     * Measured on a bladeRF 2.0 micro xA4, interleaving a recall with
+     * ordinary tuning every fifth stop of a 242-point sweep:
+     *
+     *   without this exit   49 lock failures in 643 tunes, first at 280
+     *   with it              1 lock failure  in 702 tunes, first at 495
+     *
+     * Without the exit the failures form a series that never recovers,
+     * and 0x247 reads 0x40 throughout: the charge pump has saturated
+     * low. Three runs with it in place gave zero consecutive failures,
+     * and confirmed the leak occurs on every recall without exception.
+     *
+     * Immediate scheduling is the only case handled here. A retune
+     * scheduled for a future timestamp completes inside the FPGA long
+     * after this call returns, so the exit has to happen there instead.
+     */
+    if (BLADERF_RETUNE_NOW == timestamp) {
+        CHECK_AD936X(ad9361_fastlock_exit_foreign(
+            board_data->phy, BLADERF_CHANNEL_IS_TX(ch)));
+    }
+
+    return 0;
 }
 
 static int bladerf2_cancel_scheduled_retunes(struct bladerf *dev,

--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -448,6 +448,17 @@ static int _rfic_host_set_frequency(struct bladerf *dev,
         return BLADERF_ERR_RANGE;
     }
 
+    /* A quick tune scheduled for a future timestamp is recalled by the
+     * FPGA's Nios core, which writes REG_(RX|TX)_FAST_LOCK_SETUP directly
+     * and leaves the part in fastlock mode behind the driver's back. The
+     * exit in bladerf2_schedule_retune() only covers BLADERF_RETUNE_NOW,
+     * because a deferred recall completes long after that call returns.
+     * Tuning ordinarily while the leaked state is in place pins the RF PLL
+     * charge pump (0x247 reads 0x80 during the failed tune, 0x40 after),
+     * so leave fastlock here before touching the synthesizer. The call
+     * reads first and writes nothing when not in fastlock mode. */
+    CHECK_AD936X(ad9361_fastlock_exit_foreign(phy, BLADERF_CHANNEL_IS_TX(ch)));
+
     /* Set up band selection */
     CHECK_STATUS(rfic->select_band(dev, ch, frequency));
 

--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -245,7 +245,11 @@ static int _rfic_host_enable_module(struct bladerf *dev,
     CHECK_STATUS(dev->backend->rffe_control_read(dev, &reg));
     reg_old    = reg;
     ch_pending = _rffe_ch_enabled(reg, ch) != enable;
-    layout = board_data->sync->stream_config.layout;
+    /* board_data->sync is indexed by direction. Plain sync-> is sync[0],
+     * which is always the RX stream, so enabling or disabling a TX
+     * channel read the RX layout here and decided the MIMO question from
+     * the wrong stream. */
+    layout = board_data->sync[dir].stream_config.layout;
     mimo_enabled = layout == BLADERF_RX_X2 || layout == BLADERF_TX_X2;
 
     if (layout == BLADERF_TX_X2) {

--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -121,6 +121,14 @@ static int _rfic_host_initialize(struct bladerf *dev)
     {
         AD9361_InitParam *p = (AD9361_InitParam *)board_data->rfic_init_params;
 
+        /* The no_os_axi_io accessors (FPGA AXI ad9361 core over NIOS) have no
+         * context argument, so the handle travels through a file-static in
+         * platform_bladerf2 instead. */
+        {
+            extern void bladerf2_axi_io_set_dev(struct bladerf *dev);
+            bladerf2_axi_io_set_dev(dev);
+        }
+
         p->spi_param.extra = dev;
         p->gpio_resetb.extra = dev;
         p->gpio_sync.extra = dev;

--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -886,6 +886,15 @@ static int _rfic_host_get_rssi(struct bladerf *dev,
     if (BLADERF_CHANNEL_IS_TX(ch)) {
         uint32_t rssi = 0;
 
+        /* The TX power monitor gates the measurement block behind
+         * REG_TX_RSSI. Without it those registers stay at zero and this
+         * call reports 0 dBm at every gain setting, which reads as "no
+         * output" rather than "not measured". Measured on a bladeRF 2.0
+         * micro xA4: 0 dBm at TX gains 0/20/40/60 dB with the monitor
+         * off, -68/-68/-44/-44 dBm with it on. */
+        CHECK_AD936X(
+            ad9361_txmon_enable(phy, (0 == rfic_ch) ? TX_1 : TX_2));
+
         CHECK_AD936X(ad9361_get_tx_rssi(phy, rfic_ch, &rssi));
 
         pre = __round_int(rssi / 1000.0);

--- a/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/rfic_host.c
@@ -111,8 +111,24 @@ static int _rfic_host_initialize(struct bladerf *dev)
                 (void *)&bladerf2_rfic_init_params_fastagc_burst :
                 (void *)&bladerf2_rfic_init_params;
 
-    /* Initialize AD9361 */
-    CHECK_AD936X(ad9361_init(&phy, (AD9361_InitParam *)board_data->rfic_init_params, dev));
+    /* Initialize AD9361
+     *
+     * ad9361_init() used to take the device handle as a third argument and
+     * stash it for the SPI and GPIO accessors. It now builds its descriptors
+     * from the init parameters, so the handle travels in the .extra field of
+     * those parameters instead. The parameter block is shared, so this has to
+     * be filled in on every init rather than once at compile time. */
+    {
+        AD9361_InitParam *p = (AD9361_InitParam *)board_data->rfic_init_params;
+
+        p->spi_param.extra = dev;
+        p->gpio_resetb.extra = dev;
+        p->gpio_sync.extra = dev;
+        p->gpio_cal_sw1.extra = dev;
+        p->gpio_cal_sw2.extra = dev;
+
+        CHECK_AD936X(ad9361_init(&phy, p));
+    }
 
     if (NULL == phy || NULL == phy->pdata) {
         RETURN_ERROR_STATUS("ad9361_init struct initialization",
@@ -170,7 +186,12 @@ static int _rfic_host_deinitialize(struct bladerf *dev)
     CHECK_STATUS(_rfic_host_clear_rffe_control(dev));
 
     if (NULL != board_data->phy) {
-        CHECK_STATUS(ad9361_deinit(board_data->phy));
+        /* ad9361_deinit() was a local addition; upstream provides
+         * ad9361_remove(), which frees more: the clocks, the SPI and all four
+         * GPIO descriptors on top of the data. It does not drive the part into
+         * reset, but _rfic_host_clear_rffe_control() above already cleared the
+         * reset bit. */
+        CHECK_STATUS(ad9361_remove(board_data->phy));
         board_data->phy = NULL;
     }
 
@@ -484,10 +505,12 @@ static int _rfic_host_select_band(struct bladerf *dev,
     struct ad9361_rf_phy *phy              = board_data->phy;
     bladerf_channel port_ch                = ch;
     uint32_t reg;
+    uint32_t reg_orig;
     size_t i;
 
     /* Read RFFE control register */
     CHECK_STATUS(dev->backend->rffe_control_read(dev, &reg));
+    reg_orig = reg;
 
     /* Modify the SPDT bits. */
     /* We have to do this for all the channels sharing the same LO. */
@@ -502,8 +525,37 @@ static int _rfic_host_select_band(struct bladerf *dev,
         }
     }
 
-    /* Write RFFE control register */
-    CHECK_STATUS(dev->backend->rffe_control_write(dev, reg));
+    /* Write RFFE control register only when the SPDT bits actually changed.
+     *
+     * Retuning to the frequency that is already programmed used to rewrite
+     * this register unconditionally. Measured on a TX1 -> 40 dB pad -> RX1
+     * loopback at 30.72 MSPS, 2440 MHz, manual gain, cyclic tone: a
+     * same-frequency set_frequency() left the receive path in one of two
+     * stable level states about 2.9 dB apart, and the state persisted until
+     * the next call. Strict A/B in one process, interleaved, 5 reps each,
+     * reference tone measured by direct FFT over 6 fresh captures:
+     *
+     *   nothing                        range 0.23 dB, sigma 0.093
+     *   stream stop/start              range 0.29 dB, sigma 0.131
+     *   stream cycle + set_frequency   range 3.33 dB, sigma 1.323
+     *   stream cycle + LO no-op        range 0.21 dB, sigma 0.085
+     *
+     * Ruled out by measurement: settling time (0 vs 300 ms after the call:
+     * sigma 1.788 vs 1.672), RX module enable cycle alone (sigma 0.182),
+     * the RX gain table (a repeated set_gain does not clear it, and
+     * ad9361_load_gt() returns early for an unchanged band), the SPI bus
+     * itself (a frequency read matches control at sigma 0.248), one side
+     * only (RX sigma 1.883 vs TX 2.025 - both), spectral leakage (11 bins
+     * instead of 3: range 3.68 vs 3.65) and image aliasing (the mirror sits
+     * 20-30 dB below the tone and does not track it). RFIC registers
+     * 0x200-0x2FF are identical in both states.
+     *
+     * Skipping the write when nothing changed is safe: the register is
+     * read-modify-write, so an unchanged value carries no information, and
+     * the AD9361 port is still selected below. */
+    if (reg != reg_orig) {
+        CHECK_STATUS(dev->backend->rffe_control_write(dev, reg));
+    }
 
     /* Set AD9361 port */
     CHECK_STATUS(

--- a/host/libraries/libbladeRF/src/device_calibration.c
+++ b/host/libraries/libbladeRF/src/device_calibration.c
@@ -115,9 +115,13 @@ int gain_cal_csv_to_bin(struct bladerf *dev, const char *csv_path, const char *b
     if (!csvFile || !binaryFile) {
         status = BLADERF_ERR_NO_FILE;
         if (getcwd(current_dir, sizeof(current_dir)) != NULL) {
-            log_error("Error opening calibration file: %s\n", strcat(current_dir, csv_path));
+            /* strcat() here appends a caller-supplied path of arbitrary
+             * length to a buffer already holding the working directory,
+             * overflowing it for long paths. Print the two parts instead. */
+            log_error("Error opening calibration file: %s/%s\n",
+                      current_dir, csv_path);
         } else {
-            log_error("Error opening calibration file\n");
+            log_error("Error opening calibration file: %s\n", csv_path);
         }
         goto error;
     }

--- a/host/libraries/libbladeRF/src/streaming/async.c
+++ b/host/libraries/libbladeRF/src/streaming/async.c
@@ -32,6 +32,56 @@
 #include "helpers/timeout.h"
 #include "helpers/have_cap.h"
 
+/* Kernel default for /sys/module/usbcore/parameters/usbfs_memory_mb.
+ * Used when the sysfs entry cannot be read (non-Linux, restricted /sys). */
+#define USBFS_MEMORY_MB_DEFAULT 16
+
+/* Reserve part of the budget for other users of the bus: the limit is
+ * per-host, not per-device, and a bladeRF is rarely alone on it. */
+#define USBFS_BUDGET_FRACTION 0.9
+
+/**
+ * Verify that a stream configuration fits in the kernel's usbfs memory
+ * budget. Each in-flight transfer is pinned for its lifetime, so a stream
+ * needs num_transfers * buffer_size_bytes of it simultaneously.
+ *
+ * @return 0 if the configuration fits, BLADERF_ERR_INVAL otherwise.
+ */
+static int usbfs_budget_check(size_t num_transfers, size_t buffer_size_bytes)
+{
+    size_t limit_mb = USBFS_MEMORY_MB_DEFAULT;
+    size_t needed, budget;
+
+#if BLADERF_OS_LINUX
+    FILE *f = fopen("/sys/module/usbcore/parameters/usbfs_memory_mb", "r");
+    if (f != NULL) {
+        unsigned int v = 0;
+        if (fscanf(f, "%u", &v) == 1 && v > 0) {
+            limit_mb = v;
+        }
+        fclose(f);
+    }
+#endif
+
+    needed = num_transfers * buffer_size_bytes;
+    budget = (size_t)(limit_mb * 1024 * 1024 * USBFS_BUDGET_FRACTION);
+
+    if (needed > budget) {
+        size_t max_transfers = budget / buffer_size_bytes;
+
+        log_error("Stream needs %zu MiB of in-flight USB buffers "
+                  "(%zu transfers x %zu bytes), but usbfs_memory_mb is %zu. "
+                  "Use at most %zu transfers, or raise the limit with "
+                  "'echo <MiB> > /sys/module/usbcore/parameters/"
+                  "usbfs_memory_mb'.\n",
+                  needed / (1024 * 1024), num_transfers, buffer_size_bytes,
+                  limit_mb, max_transfers);
+        return BLADERF_ERR_INVAL;
+    }
+
+    return 0;
+}
+
 int async_init_stream(struct bladerf_stream **stream,
                       struct bladerf *dev,
                       bladerf_stream_cb callback,
@@ -75,6 +125,20 @@ int async_init_stream(struct bladerf_stream **stream,
         log_error("Samples_per_buffer must be multiples of %u\n",
                   bytes_to_samples(format, gpif_buffer_size));
         return BLADERF_ERR_INVAL;
+    }
+
+    /* Reject configurations that cannot fit in the kernel's usbfs memory
+     * budget. Every in-flight transfer is pinned by the kernel, so the
+     * stream needs num_transfers * buffer_size_bytes available at once.
+     *
+     * Without this check the failure is reported far from its cause:
+     * bladerf_sync_config() succeeds, submit_transfer() then fails
+     * asynchronously with LIBUSB_ERROR_NO_MEM, and the caller only sees
+     * BLADERF_ERR_MEM from the first bladerf_sync_rx().
+     */
+    status = usbfs_budget_check(num_transfers, buffer_size_bytes);
+    if (status != 0) {
+        return status;
     }
 
     /* Create a stream and populate it with the appropriate information */

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -594,8 +594,22 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
             case SYNC_STATE_RESET_BUF_MGMT:
                 MUTEX_LOCK(&b->lock);
                 /* When the RX stream starts up, it will submit the first T
-                 * transfers, so the consumer index must be reset to 0 */
-                b->cons_i = 0;
+                 * transfers, so the consumer index must be reset to 0.
+                 *
+                 * For TX the consumer index means the opposite thing: it names
+                 * the buffer the callback should ship out next, and
+                 * BUFFER_MGMT_INVALID_INDEX is how sync_init() says "nothing
+                 * is deferred yet". Resetting it to 0 here makes a restarted
+                 * TX worker believe buffer 0 is a deferred, full buffer, so
+                 * tx_callback submits a buffer the producer has not filled and
+                 * the ring accounting drifts from that point on.
+                 */
+                if ((s->stream_config.layout & BLADERF_DIRECTION_MASK) ==
+                    BLADERF_TX) {
+                    b->cons_i = BUFFER_MGMT_INVALID_INDEX;
+                } else {
+                    b->cons_i = 0;
+                }
                 MUTEX_UNLOCK(&b->lock);
                 /* The restarted stream begins a fresh timestamp sequence, so
                  * its first header must not be reported as a discontinuity. */

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1182,6 +1182,82 @@ static int advance_tx_buffer(struct bladerf_sync *s, struct buffer_mgmt *b)
         } else {
            len = async_stream_buf_bytes(s->worker->stream);
         }
+
+        /* Hold this buffer back until the samples just ahead of it have gone
+         * to air, so the device never sits on data whose timestamp has not
+         * come due.
+         *
+         * Measured on a bladeRF 2.0 micro (usbmon + loopback): samples
+         * delivered AHEAD of their timestamp are never played. The path
+         * absorbs 122880 bytes - 11 FX3 DMA buffers of 8192 plus an
+         * 8192-sample FPGA FIFO - and then the endpoint stops accepting;
+         * playback does not begin even after the scheduled time passes, every
+         * queued URB dies in the kernel at its timeout, and only the first
+         * 30720 samples ever reach the air, however long the burst. Delivered
+         * AT or PAST the timestamp, the same data plays immediately and a
+         * burst of any length streams through (40-buffer series: 164 of 164
+         * transfers completed, four series in one stream).
+         *
+         * So the release point for a buffer ending at tick E is the moment
+         * the device clock reaches E - hold: everything the buffer trails is
+         * on the air, and the buffer itself arrives as its own window opens.
+         * The wait is computed from the tick deficit and the sample rate -
+         * one sleep, one confirming read - not polled.
+         *
+         * TX_NOW is exempt: the device consumes immediately and ordinary
+         * flow control suffices. If the clock or rate cannot be read, submit
+         * as before rather than guessing. */
+        if (s->stream_config.format == BLADERF_FORMAT_SC16_Q11_META &&
+            s->meta.in_burst && !s->meta.now) {
+            /* One FX3 DMA buffer (8192 B) of slack: enough for the transport
+             * to land the buffer before its first sample is due, small
+             * enough that the device is never asked to hold future data. */
+            const uint64_t hold_samples = 2048;
+            const uint64_t end          = s->meta.curr_timestamp;
+            uint64_t waited_us          = 0;
+            const uint64_t budget_us =
+                s->stream_config.timeout_ms == 0
+                    ? UINT64_MAX
+                    : (uint64_t)s->stream_config.timeout_ms * 1000;
+            bladerf_sample_rate rate = 0;
+
+            if (end > s->meta.burst_start + hold_samples &&
+                s->dev->board->get_sample_rate(
+                    s->dev, BLADERF_CHANNEL_TX(0), &rate) == 0 &&
+                rate != 0) {
+                const uint64_t release_tick = end - hold_samples;
+
+                for (;;) {
+                    uint64_t now_ts = 0;
+                    uint64_t deficit;
+                    uint64_t wait_us;
+
+                    if (s->dev->backend->get_timestamp(s->dev, BLADERF_TX,
+                                                       &now_ts) != 0 ||
+                        now_ts >= release_tick) {
+                        break;
+                    }
+
+                    deficit = release_tick - now_ts;
+                    wait_us = deficit * 1000000 / rate;
+                    if (wait_us == 0) {
+                        wait_us = 1;
+                    }
+
+                    if (waited_us + wait_us > budget_us) {
+                        log_debug("%s: %" PRIu64 " samples still ahead of "
+                                  "the device clock at the %u ms timeout\n",
+                                  __FUNCTION__, deficit,
+                                  s->stream_config.timeout_ms);
+                        break;
+                    }
+
+                    usleep((useconds_t)wait_us);
+                    waited_us += wait_us;
+                }
+            }
+        }
+
         status = async_submit_stream_buffer(s->worker->stream,
                                             b->buffers[idx],
                                             &len,
@@ -1309,6 +1385,7 @@ static inline int handle_tx_parameters(struct bladerf_metadata *user_meta,
                 log_verbose("%s: Starting burst \"now\"\n", __FUNCTION__);
             } else {
                 s->meta.curr_timestamp = user_meta->timestamp;
+                s->meta.burst_start    = user_meta->timestamp;
                 log_verbose("%s: Starting burst @ %llu\n", __FUNCTION__,
                             (unsigned long long)s->meta.curr_timestamp);
             }
@@ -1787,6 +1864,31 @@ unsigned int sync_buf2idx(struct buffer_mgmt *b, void *addr)
     for (i = 0; i < b->num_buffers; i++) {
         if (b->buffers[i] == addr) {
             return i;
+        }
+    }
+
+    /* Not the start of a buffer, so look for the buffer it falls inside.
+     *
+     * A TX transfer that stalls part-way is resumed from where the device
+     * stopped rather than from the start, so its address is the buffer base
+     * plus what already went out. Matching only exact bases turns that into
+     * "Buffer not found" and takes the process down with it. */
+    {
+        const uint8_t *want  = (const uint8_t *)addr;
+        unsigned int best    = b->num_buffers;
+        const uint8_t *bestp = NULL;
+
+        for (i = 0; i < b->num_buffers; i++) {
+            const uint8_t *base = (const uint8_t *)b->buffers[i];
+
+            if (base < want && (bestp == NULL || base > bestp)) {
+                bestp = base;
+                best  = i;
+            }
+        }
+
+        if (best < b->num_buffers) {
+            return best;
         }
     }
 

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -671,6 +671,31 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                             log_verbose("%s: buffer %u is ready to consume\n",
                                         __FUNCTION__, b->cons_i);
                         }
+                    } else {
+                        /* Go re-examine the worker instead of waiting on the
+                         * same buffer again.
+                         *
+                         * Leaving the state at WAIT_FOR_BUFFER makes the
+                         * timeout permanent whenever the worker is no longer
+                         * there to free anything: every later call re-enters
+                         * this branch, waits out the full timeout, and
+                         * returns the same error. The worker's START path
+                         * already knows how to recover -- it clears buffers
+                         * that were left IN_FLIGHT by a cancelled stream --
+                         * but it is only reachable through CHECK_WORKER, so
+                         * that recovery never runs.
+                         *
+                         * This is what turns one hiccup into a dead stream.
+                         * Measured on a bladeRF 2.0 micro xA4 at 15.36 MSps:
+                         * after enable_module(TX, false)/(true) the worker
+                         * failed to stop ("Timed out while stopping worker.
+                         * Canceling thread."), and from then on the feeding
+                         * thread submitted 0 buffers/s instead of 1917, with
+                         * a 1000 ms timeout on every sync_tx(). Downstream
+                         * the RFIC repeats its last sample, so it reads as a
+                         * dead transmitter rather than a stalled queue.
+                         */
+                        s->state = SYNC_STATE_CHECK_WORKER;
                     }
                 }
 

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -444,10 +444,20 @@ int sync_prime_stream(struct bladerf_sync *sync, unsigned int timeout_ms)
     return status;
 }
 
-/* Returns # of timestamps (or time steps) left in a message */
+/* Returns # of timestamps (or time steps) left in a message.
+ *
+ * curr_msg_off counts SAMPLES (it is advanced by samples_to_copy and
+ * compared against samples_per_msg), so it has to be subtracted before
+ * converting to time steps. Subtracting it from samples_per_msg /
+ * samples_per_ts mixed the units: correct for single-channel layouts
+ * where samples_per_ts == 1, but in X2 mode the unsigned subtraction
+ * underflowed once the offset passed half a message, and the huge
+ * result sent the seek logic down the wrong branch. */
 static inline unsigned int ts_remaining(struct bladerf_sync *s)
 {
-    size_t ret = s->meta.samples_per_msg / s->meta.samples_per_ts - s->meta.curr_msg_off;
+    size_t ret = (s->meta.samples_per_msg - s->meta.curr_msg_off) /
+                 s->meta.samples_per_ts;
+    assert(s->meta.curr_msg_off <= s->meta.samples_per_msg);
     assert(ret <= UINT_MAX);
 
     return (unsigned int) ret;

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1043,11 +1043,46 @@ out:
  * Assumes the buffer lock is held. Drops it around the submission, the same
  * way advance_tx_buffer() does, because submitting takes the stream lock.
  */
+/* Oldest buffer the callback still owes a submission for, or INVALID.
+ *
+ * cons_i alone is not enough. When transfers are cancelled - a teardown, an
+ * error, a timeout - libusb returns them through its own callback path, which
+ * never runs the sync callback, so cons_i keeps pointing at a buffer that has
+ * already been marked IN_FLIGHT and will never come back. The data waiting to
+ * go out is in the FULL buffers behind it.
+ */
+static unsigned int oldest_full_buffer(struct buffer_mgmt *b)
+{
+    unsigned int i, idx;
+
+    if (b->cons_i == BUFFER_MGMT_INVALID_INDEX) {
+        return BUFFER_MGMT_INVALID_INDEX;
+    }
+
+    for (i = 0; i < b->num_buffers; i++) {
+        idx = (b->cons_i + i) % b->num_buffers;
+        if (b->status[idx] == SYNC_BUFFER_FULL) {
+            return idx;
+        }
+    }
+
+    return BUFFER_MGMT_INVALID_INDEX;
+}
+
 static int reclaim_tx_submission(struct bladerf_sync *s, struct buffer_mgmt *b)
 {
-    const unsigned int idx = b->cons_i;
+    const unsigned int idx = oldest_full_buffer(b);
     size_t len;
     int status;
+
+    if (idx == BUFFER_MGMT_INVALID_INDEX) {
+        /* Nothing is waiting to go out, so the callback owes nothing and the
+         * duty is ours again. Reached when every buffer the callback was
+         * tracking came back through the cancellation path. */
+        b->submitter = SYNC_TX_SUBMITTER_FN;
+        b->cons_i    = BUFFER_MGMT_INVALID_INDEX;
+        return 0;
+    }
 
     if (s->stream_config.format == BLADERF_FORMAT_PACKET_META) {
         len = b->actual_lengths[idx];
@@ -1162,8 +1197,7 @@ static int advance_tx_buffer(struct bladerf_sync *s, struct buffer_mgmt *b)
          * busy, and when one is free the feed keeps moving.
          */
         if (b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
-            b->cons_i != BUFFER_MGMT_INVALID_INDEX &&
-            b->status[b->cons_i] == SYNC_BUFFER_FULL) {
+            b->cons_i != BUFFER_MGMT_INVALID_INDEX) {
             status = reclaim_tx_submission(s, b);
             if (status != 0) {
                 return status;
@@ -1380,8 +1414,7 @@ int sync_tx(struct bladerf_sync *s,
                      * wait had no reason to fail in the first place. */
                     if (status == BLADERF_ERR_TIMEOUT &&
                         b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
-                        b->cons_i != BUFFER_MGMT_INVALID_INDEX &&
-                        b->status[b->cons_i] == SYNC_BUFFER_FULL) {
+                        b->cons_i != BUFFER_MGMT_INVALID_INDEX) {
                         if (reclaim_tx_submission(s, b) == 0 &&
                             b->submitter == SYNC_TX_SUBMITTER_FN) {
                             status = 0;

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -650,8 +650,14 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                     s->state = SYNC_STATE_WAIT_FOR_BUFFER;
                     log_debug("%s: Worker is now running.\n", __FUNCTION__);
                 } else {
-                    log_debug("%s: Failed to start worker, (%d)\n",
-                              __FUNCTION__, status);
+                    /* At debug level this was invisible in practice: the
+                     * caller then waits out its timeout and reports a
+                     * timeout, which reads like a device that went quiet
+                     * rather than a worker that never started. */
+                    log_warning("%s: worker did not reach RUNNING in %u ms: "
+                                "%s\n", __FUNCTION__,
+                                SYNC_WORKER_START_TIMEOUT_MS,
+                                bladerf_strerror(status));
                 }
                 break;
 
@@ -1064,22 +1070,39 @@ out:
  * buffer marked IN_FLIGHT forever. Which is exactly why this asks whether
  * anything is waiting, not how many transfers are out.
  */
+static unsigned int oldest_full_buffer(struct buffer_mgmt *b);
+
 static bool tx_submission_parked(struct buffer_mgmt *b)
 {
-    return b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
-           b->cons_i != BUFFER_MGMT_INVALID_INDEX;
+    if (b->submitter == SYNC_TX_SUBMITTER_CALLBACK) {
+        return b->cons_i != BUFFER_MGMT_INVALID_INDEX;
+    }
+
+    /* Duty is ours, but buffers are still waiting to go out.
+     *
+     * Reached after the duty comes back from the callback: the callback path
+     * shipped what it could and handed submission back, and sync_tx() then
+     * only ever submits the buffer prod_i points at - so anything that piled
+     * up while the duty was parked stays FULL, with no transfer in flight to
+     * bring a callback that would move it. Measured on hardware: submitter
+     * FN, 0 in flight, 26 of 64 buffers FULL, and sync_tx timing out.
+     */
+    return b->submitter == SYNC_TX_SUBMITTER_FN &&
+           oldest_full_buffer(b) != BUFFER_MGMT_INVALID_INDEX;
 }
 
 static unsigned int oldest_full_buffer(struct buffer_mgmt *b)
 {
     unsigned int i, idx;
 
-    if (b->cons_i == BUFFER_MGMT_INVALID_INDEX) {
-        return BUFFER_MGMT_INVALID_INDEX;
-    }
+    /* Where to start looking. cons_i names the buffer the callback was told
+     * to ship; with the duty back with us it is INVALID, and then the oldest
+     * data is just ahead of the producer. */
+    const unsigned int from = (b->cons_i == BUFFER_MGMT_INVALID_INDEX)
+                                  ? b->prod_i : b->cons_i;
 
     for (i = 0; i < b->num_buffers; i++) {
-        idx = (b->cons_i + i) % b->num_buffers;
+        idx = (from + i) % b->num_buffers;
         if (b->status[idx] == SYNC_BUFFER_FULL) {
             return idx;
         }

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -622,8 +622,19 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                  * a consumer stall return history, and with a non-metadata
                  * format nothing marks it as such. In this state cons_i is
                  * never PARTIAL, so the contiguous FULL run is safe to walk;
-                 * the producer resumes storing at the slots freed here. */
-                if (b->stale_pending) {
+                 * the producer resumes storing at the slots freed here.
+                 *
+                 * Metadata formats are exempt: their consumers see the gap
+                 * in the timestamps and may legitimately want the backlog -
+                 * a scheduled capture seeks THROUGH these buffers to reach
+                 * its target timestamp, and dropping them under that seek
+                 * loses the samples the caller asked for (measured: a sweep
+                 * that overruns on every stop went from hundreds of
+                 * detections to zero with an unconditional drop here). */
+                if (b->stale_pending &&
+                    s->stream_config.format != BLADERF_FORMAT_SC16_Q11_META &&
+                    s->stream_config.format != BLADERF_FORMAT_SC8_Q7_META &&
+                    s->stream_config.format != BLADERF_FORMAT_PACKET_META) {
                     unsigned int dropped = 0;
 
                     while (b->status[b->cons_i] == SYNC_BUFFER_FULL &&

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1183,81 +1183,21 @@ static int advance_tx_buffer(struct bladerf_sync *s, struct buffer_mgmt *b)
            len = async_stream_buf_bytes(s->worker->stream);
         }
 
-        /* Hold this buffer back until the samples just ahead of it have gone
-         * to air, so the device never sits on data whose timestamp has not
-         * come due.
+        /* Do NOT pace timestamped buffers against the device clock here.
+         * A pacing loop lived in this spot briefly and it broke scheduled
+         * playback outright: the FPGA metadata engine wants each message
+         * delivered BEFORE its timestamp so META_WAIT can hold it, and
+         * releasing a buffer at (end - 2048) hands every message over after
+         * its own start tick. Measured on a bladeRF 2.0 micro loopback: with
+         * pacing a scheduled tone burst never airs (noise floor in its bin);
+         * with the buffer preloaded ahead of the timestamp the same burst
+         * plays at +87 dB starting exactly at its tick.
          *
-         * Measured on a bladeRF 2.0 micro (usbmon + loopback): samples
-         * delivered AHEAD of their timestamp are never played. The path
-         * absorbs 122880 bytes - 11 FX3 DMA buffers of 8192 plus an
-         * 8192-sample FPGA FIFO - and then the endpoint stops accepting;
-         * playback does not begin even after the scheduled time passes, every
-         * queued URB dies in the kernel at its timeout, and only the first
-         * 30720 samples ever reach the air, however long the burst. Delivered
-         * AT or PAST the timestamp, the same data plays immediately and a
-         * burst of any length streams through (40-buffer series: 164 of 164
-         * transfers completed, four series in one stream).
-         *
-         * So the release point for a buffer ending at tick E is the moment
-         * the device clock reaches E - hold: everything the buffer trails is
-         * on the air, and the buffer itself arrives as its own window opens.
-         * The wait is computed from the tick deficit and the sample rate -
-         * one sleep, one confirming read - not polled.
-         *
-         * TX_NOW is exempt: the device consumes immediately and ordinary
-         * flow control suffices. If the clock or rate cannot be read, submit
-         * as before rather than guessing. */
-        if (s->stream_config.format == BLADERF_FORMAT_SC16_Q11_META &&
-            s->meta.in_burst && !s->meta.now) {
-            /* One FX3 DMA buffer (8192 B) of slack: enough for the transport
-             * to land the buffer before its first sample is due, small
-             * enough that the device is never asked to hold future data. */
-            const uint64_t hold_samples = 2048;
-            const uint64_t end          = s->meta.curr_timestamp;
-            uint64_t waited_us          = 0;
-            const uint64_t budget_us =
-                s->stream_config.timeout_ms == 0
-                    ? UINT64_MAX
-                    : (uint64_t)s->stream_config.timeout_ms * 1000;
-            bladerf_sample_rate rate = 0;
-
-            if (end > s->meta.burst_start + hold_samples &&
-                s->dev->board->get_sample_rate(
-                    s->dev, BLADERF_CHANNEL_TX(0), &rate) == 0 &&
-                rate != 0) {
-                const uint64_t release_tick = end - hold_samples;
-
-                for (;;) {
-                    uint64_t now_ts = 0;
-                    uint64_t deficit;
-                    uint64_t wait_us;
-
-                    if (s->dev->backend->get_timestamp(s->dev, BLADERF_TX,
-                                                       &now_ts) != 0 ||
-                        now_ts >= release_tick) {
-                        break;
-                    }
-
-                    deficit = release_tick - now_ts;
-                    wait_us = deficit * 1000000 / rate;
-                    if (wait_us == 0) {
-                        wait_us = 1;
-                    }
-
-                    if (waited_us + wait_us > budget_us) {
-                        log_debug("%s: %" PRIu64 " samples still ahead of "
-                                  "the device clock at the %u ms timeout\n",
-                                  __FUNCTION__, deficit,
-                                  s->stream_config.timeout_ms);
-                        break;
-                    }
-
-                    usleep((useconds_t)wait_us);
-                    waited_us += wait_us;
-                }
-            }
-        }
-
+         * The "data ahead of its timestamp wedges the endpoint" result that
+         * justified pacing was measured while the FPGA-side AXI DAC core was
+         * left uninitialized (DAC played its DDS, never draining the DMA
+         * path). With the DAC core initialized, holding future data is
+         * exactly what the engine is designed to do. */
         status = async_submit_stream_buffer(s->worker->stream,
                                             b->buffers[idx],
                                             &len,

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -333,6 +333,34 @@ int sync_init(struct bladerf_sync *sync,
         goto error;
     }
 
+    if ((layout & BLADERF_DIRECTION_MASK) == BLADERF_TX) {
+        /* Clear a wedged FX3 TX DMA channel before the caller starts feeding.
+         *
+         * Building a second TX stream on the same device handle intermittently
+         * leaves that channel stuck: transfers go out, the FX3 takes zero
+         * bytes, and every completion returns LIBUSB_TRANSFER_TIMED_OUT with
+         * actual_length 0. The host ring fills and sync_tx() then refuses
+         * buffers permanently. It latches -- which repeat it strikes is random
+         * -- and used to need a close/open to clear.
+         *
+         * Cycling the direction through the board layer clears it. Measured:
+         * wedged then cycled gives 60/60 buffers, 4 of 4 attempts, against
+         * 15/60 for a do-nothing control in the same runs. What does NOT work,
+         * also measured: the backend vendor command alone (0 of 5), disable
+         * without re-enable (17/60), re-setting gain or frequency (15/60), an
+         * alt-setting change, and libusb_clear_halt() on the OUT endpoint.
+         * So the whole disable+enable pair through the board is required.
+         */
+        int cycle = dev->board->enable_module(dev, BLADERF_CHANNEL_TX(0), false);
+        if (cycle == 0) {
+            cycle = dev->board->enable_module(dev, BLADERF_CHANNEL_TX(0), true);
+        }
+        if (cycle != 0) {
+            log_debug("%s: could not cycle TX to clear the FX3 channel: %s\n",
+                      __FUNCTION__, bladerf_strerror(cycle));
+        }
+    }
+
     sync->initialized = true;
 
     return 0;

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -405,8 +405,27 @@ static int wait_for_buffer(struct buffer_mgmt *b,
     }
 
     if (status == THREAD_TIMEOUT) {
-        log_error("%s: Timed out waiting for buf_ready after %d ms\n",
-                  __FUNCTION__, timeout_ms);
+        /* Who owns submission matters more than the timeout itself. Once
+         * submitter is CALLBACK, only a completing transfer can hand it back,
+         * so a timeout with CALLBACK set and nothing in flight is a deadlock
+         * on this side rather than a device that went quiet. */
+        unsigned int in_flight = 0, full = 0, empty = 0, i;
+        for (i = 0; i < b->num_buffers; i++) {
+            switch (b->status[i]) {
+                case SYNC_BUFFER_IN_FLIGHT: in_flight++; break;
+                case SYNC_BUFFER_FULL:      full++;      break;
+                case SYNC_BUFFER_EMPTY:     empty++;     break;
+                default: break;
+            }
+        }
+        log_error("%s: Timed out waiting for buf_ready after %d ms "
+                  "(submitter=%s, in_flight=%u full=%u empty=%u of %u, "
+                  "prod_i=%u cons_i=%u)\n",
+                  __FUNCTION__, timeout_ms,
+                  b->submitter == SYNC_TX_SUBMITTER_CALLBACK ? "CALLBACK"
+                      : (b->submitter == SYNC_TX_SUBMITTER_FN ? "FN" : "-"),
+                  in_flight, full, empty, (unsigned)b->num_buffers,
+                  b->prod_i, b->cons_i);
         status = BLADERF_ERR_TIMEOUT;
     } else if (status != 0) {
         status = BLADERF_ERR_UNEXPECTED;
@@ -1018,6 +1037,49 @@ out:
     return status;
 }
 
+/* Try to ship the buffer the worker callback was told to ship, and take
+ * submission duty back if that works.
+ *
+ * Assumes the buffer lock is held. Drops it around the submission, the same
+ * way advance_tx_buffer() does, because submitting takes the stream lock.
+ */
+static int reclaim_tx_submission(struct bladerf_sync *s, struct buffer_mgmt *b)
+{
+    const unsigned int idx = b->cons_i;
+    size_t len;
+    int status;
+
+    if (s->stream_config.format == BLADERF_FORMAT_PACKET_META) {
+        len = b->actual_lengths[idx];
+    } else {
+        len = async_stream_buf_bytes(s->worker->stream);
+    }
+
+    b->status[idx] = SYNC_BUFFER_IN_FLIGHT;
+
+    MUTEX_UNLOCK(&b->lock);
+    status = async_submit_stream_buffer(s->worker->stream, b->buffers[idx],
+                                       &len, s->stream_config.timeout_ms,
+                                       true);
+    MUTEX_LOCK(&b->lock);
+
+    if (status == 0) {
+        b->cons_i = (idx + 1) % b->num_buffers;
+        if (b->status[b->cons_i] != SYNC_BUFFER_FULL) {
+            /* Nothing else deferred, so we own submission again. */
+            b->submitter = SYNC_TX_SUBMITTER_FN;
+            b->cons_i    = BUFFER_MGMT_INVALID_INDEX;
+        }
+        log_verbose("%s: reclaimed submission of buf[%u]\n", __FUNCTION__, idx);
+        return 0;
+    }
+
+    /* Still nothing free, or a real failure. Leave the buffer as the callback
+     * found it and let the caller wait; WOULD_BLOCK is not an error here. */
+    b->status[idx] = SYNC_BUFFER_FULL;
+    return status == BLADERF_ERR_WOULD_BLOCK ? 0 : status;
+}
+
 /* Assumes buffer lock is held */
 static int advance_tx_buffer(struct bladerf_sync *s, struct buffer_mgmt *b)
 {
@@ -1270,8 +1332,35 @@ int sync_tx(struct bladerf_sync *s,
                 if (b->status[b->prod_i] == SYNC_BUFFER_EMPTY) {
                     s->state = SYNC_STATE_BUFFER_READY;
                 } else {
-                    status =
-                        wait_for_buffer(b, timeout_ms, __FUNCTION__, b->prod_i);
+                    /* Submission may have been handed to the worker callback
+                     * back when every transfer was busy. The callback only
+                     * runs when a transfer completes, so if none ever does,
+                     * nothing hands submission back and this wait can never
+                     * be satisfied: the ring stays full, sync_tx() times out,
+                     * and only tearing the stream down clears it.
+                     *
+                     * Try the deferred buffer ourselves first. The attempt is
+                     * non-blocking, so it only succeeds if a transfer really
+                     * is free - if they are all still busy this changes
+                     * nothing and we wait exactly as before.
+                     */
+                    status = wait_for_buffer(b, timeout_ms, __FUNCTION__,
+                                             b->prod_i);
+
+                    /* The wait gave up. If submission is still parked with
+                     * the callback, try the deferred buffer ourselves before
+                     * failing: the attempt is non-blocking, so it only
+                     * succeeds when a transfer really is free, and then the
+                     * wait had no reason to fail in the first place. */
+                    if (status == BLADERF_ERR_TIMEOUT &&
+                        b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
+                        b->cons_i != BUFFER_MGMT_INVALID_INDEX &&
+                        b->status[b->cons_i] == SYNC_BUFFER_FULL) {
+                        if (reclaim_tx_submission(s, b) == 0 &&
+                            b->submitter == SYNC_TX_SUBMITTER_FN) {
+                            status = 0;
+                        }
+                    }
                 }
 
                 MUTEX_UNLOCK(&b->lock);

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1140,9 +1140,35 @@ static int advance_tx_buffer(struct bladerf_sync *s, struct buffer_mgmt *b)
             return status;
        }
     } else {
-        /* We are not submitting this buffer; this is deffered to the worker
-         * call back. Just update its state to being full of samples. */
+        /* Submission is currently the callback's job. Mark the buffer full so
+         * the callback can ship it. */
         b->status[idx] = SYNC_BUFFER_FULL;
+
+        /* Then try to ship the oldest deferred buffer ourselves.
+         *
+         * Handing submission over is meant to be temporary - the callback is
+         * supposed to give it back once nothing is left deferred. In a steady
+         * feed that never happens: sync_tx() fills buffers faster than
+         * transfers complete, so the callback always finds the next one FULL,
+         * takes the shipping branch, and never reaches the branch that
+         * restores submitter=FN. Measured on a bladeRF 2.0 micro: 588
+         * deferred submissions in one run and zero handovers back.
+         *
+         * That makes the whole feed depend on an unbroken chain of
+         * completions. Miss one and nothing submits again: the callback only
+         * runs on a completion, and this function refuses to submit while the
+         * callback owns the duty. Trying here breaks the cycle - the attempt
+         * is non-blocking, so it does nothing when transfers really are all
+         * busy, and when one is free the feed keeps moving.
+         */
+        if (b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
+            b->cons_i != BUFFER_MGMT_INVALID_INDEX &&
+            b->status[b->cons_i] == SYNC_BUFFER_FULL) {
+            status = reclaim_tx_submission(s, b);
+            if (status != 0) {
+                return status;
+            }
+        }
     }
 
     /* Advance "producer" insertion index. */

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -345,6 +345,19 @@ error:
 void sync_deinit(struct bladerf_sync *sync)
 {
     if (sync->initialized) {
+        /* Retire the handle before tearing anything down.
+         *
+         * sync_rx() and sync_tx() test sync->initialized without holding any
+         * lock - they cannot, since the lock they would take is the one being
+         * destroyed here - and then go on to take buf_mgmt.lock. Clearing the
+         * flag last leaves a window where a concurrent reader passes the test
+         * and then locks a mutex that MUTEX_DESTROY has already reclaimed.
+         * Clearing it first closes that window: a reader either sees the
+         * handle as live and finishes with the still-valid mutex, or sees it
+         * retired and returns without touching it.
+         */
+        sync->initialized = false;
+
         if ((sync->stream_config.layout & BLADERF_DIRECTION_MASK) == BLADERF_TX) {
             async_submit_stream_buffer(sync->worker->stream,
                                        BLADERF_STREAM_SHUTDOWN, NULL, 0, false);
@@ -371,8 +384,6 @@ void sync_deinit(struct bladerf_sync *sync)
         }
 
         MUTEX_DESTROY(&sync->lock);
-
-        sync->initialized = false;
     }
 }
 

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1051,6 +1051,25 @@ out:
  * already been marked IN_FLIGHT and will never come back. The data waiting to
  * go out is in the FULL buffers behind it.
  */
+/* Is submission parked on a callback with data waiting behind it?
+ *
+ * Submission duty is handed to the worker callback when every transfer is
+ * busy, and only that callback hands it back. The callback runs on a
+ * completion, and a completion that libusb delivers through its own
+ * cancellation path never reaches it. So the ring can end up with buffers
+ * FULL, the duty with the callback, and nothing able to move either.
+ *
+ * ⛔ Buffer status is not a reliable count of live transfers: IN_FLIGHT is
+ * only cleared in the sync callback, so a cancelled transfer leaves its
+ * buffer marked IN_FLIGHT forever. Which is exactly why this asks whether
+ * anything is waiting, not how many transfers are out.
+ */
+static bool tx_submission_parked(struct buffer_mgmt *b)
+{
+    return b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
+           b->cons_i != BUFFER_MGMT_INVALID_INDEX;
+}
+
 static unsigned int oldest_full_buffer(struct buffer_mgmt *b)
 {
     unsigned int i, idx;
@@ -1100,8 +1119,8 @@ static int reclaim_tx_submission(struct bladerf_sync *s, struct buffer_mgmt *b)
 
     if (status == 0) {
         b->cons_i = (idx + 1) % b->num_buffers;
-        if (b->status[b->cons_i] != SYNC_BUFFER_FULL) {
-            /* Nothing else deferred, so we own submission again. */
+        if (oldest_full_buffer(b) == BUFFER_MGMT_INVALID_INDEX) {
+            /* Nothing else waiting, so we own submission again. */
             b->submitter = SYNC_TX_SUBMITTER_FN;
             b->cons_i    = BUFFER_MGMT_INVALID_INDEX;
         }
@@ -1404,18 +1423,39 @@ int sync_tx(struct bladerf_sync *s,
                      * is free - if they are all still busy this changes
                      * nothing and we wait exactly as before.
                      */
-                    status = wait_for_buffer(b, timeout_ms, __FUNCTION__,
-                                             b->prod_i);
+                    /* Do not start waiting while the ring is in a state no
+                     * callback can get it out of. Submission duty sits with
+                     * the callback, buffers are waiting to go out, and the
+                     * callback only runs when a transfer completes - so if
+                     * none can, waiting just burns the timeout. Try the
+                     * submission here first; the attempt is non-blocking, so
+                     * when transfers really are busy nothing changes and we
+                     * wait exactly as before. */
+                    /* Loop: one submission is not enough. Each buffer still
+                     * FULL behind the first would need its own callback to be
+                     * shipped, and the callbacks that would have run were
+                     * consumed by the cancellation path. Keep going while the
+                     * backend accepts buffers - WOULD_BLOCK leaves the ring
+                     * untouched, which ends the loop. */
+                    while (status == 0 && tx_submission_parked(b)) {
+                        const unsigned int before = b->cons_i;
 
-                    /* The wait gave up. If submission is still parked with
-                     * the callback, try the deferred buffer ourselves before
-                     * failing: the attempt is non-blocking, so it only
-                     * succeeds when a transfer really is free, and then the
-                     * wait had no reason to fail in the first place. */
-                    if (status == BLADERF_ERR_TIMEOUT &&
-                        b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
-                        b->cons_i != BUFFER_MGMT_INVALID_INDEX) {
-                        if (reclaim_tx_submission(s, b) == 0 &&
+                        status = reclaim_tx_submission(s, b);
+                        if (b->cons_i == before) {
+                            break;      /* nothing moved: transfers all busy */
+                        }
+                    }
+
+                    if (status == 0 &&
+                        b->status[b->prod_i] != SYNC_BUFFER_EMPTY) {
+                        status = wait_for_buffer(b, timeout_ms, __FUNCTION__,
+                                                 b->prod_i);
+
+                        /* Same check after the wait: a completion may have
+                         * arrived and left the duty parked again. */
+                        if (status == BLADERF_ERR_TIMEOUT &&
+                            tx_submission_parked(b) &&
+                            reclaim_tx_submission(s, b) == 0 &&
                             b->submitter == SYNC_TX_SUBMITTER_FN) {
                             status = 0;
                         }

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1254,6 +1254,11 @@ int sync_tx(struct bladerf_sync *s,
                 if (status == 0) {
                     s->state = SYNC_STATE_WAIT_FOR_BUFFER;
                     log_debug("%s: Worker is now running.\n", __FUNCTION__);
+                } else {
+                    log_warning("%s: worker did not reach RUNNING in %u ms: "
+                                "%s\n", __FUNCTION__,
+                                SYNC_WORKER_START_TIMEOUT_MS,
+                                bladerf_strerror(status));
                 }
                 break;
 

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -305,6 +305,8 @@ int sync_init(struct bladerf_sync *sync,
 
             sync->meta.msg_timestamp = 0;
             sync->meta.msg_flags = 0;
+            sync->meta.have_timestamp = false;
+            sync->buf_mgmt.overrun_pending = false;
 
             sync_reset_sequence_tracking(&sync->buf_mgmt, num_transfers);
 
@@ -516,11 +518,22 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
         } else {
             user_meta->status = 0;
             target_timestamp = user_meta->timestamp;
+
+            /* Report an overrun the worker recovered from. Its recovery
+             * resubmits buffers, so the gap is not visible in the message
+             * timestamps this call will see. */
+            MUTEX_LOCK(&s->buf_mgmt.lock);
+            if (s->buf_mgmt.overrun_pending) {
+                user_meta->status |= BLADERF_META_STATUS_OVERRUN;
+                s->buf_mgmt.overrun_pending = false;
+            }
+            MUTEX_UNLOCK(&s->buf_mgmt.lock);
         }
     }
 
     b = &s->buf_mgmt;
     samples_per_buffer = s->stream_config.samples_per_buffer;
+    log_verbose("%s: stream format=%d state=%d\n", __FUNCTION__, (int)s->stream_config.format, (int)s->state);
 
     log_verbose("%s: Requests %u samples.\n", __FUNCTION__, num_samples);
 
@@ -562,6 +575,9 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                  * transfers, so the consumer index must be reset to 0 */
                 b->cons_i = 0;
                 MUTEX_UNLOCK(&b->lock);
+                /* The restarted stream begins a fresh timestamp sequence, so
+                 * its first header must not be reported as a discontinuity. */
+                s->meta.have_timestamp = false;
                 log_debug("%s: Reset buf_mgmt consumer index\n", __FUNCTION__);
                 s->state = SYNC_STATE_START_WORKER;
                 break;
@@ -638,6 +654,7 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                         assert(!"Invalid stream format");
                         status = BLADERF_ERR_UNEXPECTED;
                 }
+                log_verbose("%s: BUFFER_READY -> state=%d (format=%d)\n", __FUNCTION__, (int)s->state, (int)s->stream_config.format);
 
                 MUTEX_UNLOCK(&b->lock);
                 break;
@@ -716,13 +733,23 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
 
                         s->meta.curr_msg_off = 0;
 
-                        /* We've encountered a discontinuity and need to return
-                         * what we have so far, setting the status flags */
-                        if (copied_data &&
+                        /* We've encountered a discontinuity. Report it via
+                         * the status flags whether or not samples have been
+                         * copied yet: a gap that lands on the first message
+                         * of a read is still a gap, and the caller has no
+                         * other way to learn about it.
+                         *
+                         * Only the early return is conditional. With data
+                         * already copied we must hand it back before the
+                         * discontinuity; with none copied there is nothing
+                         * to preserve, so the read continues and returns
+                         * contiguous samples that start after the gap.
+                         */
+                        if (s->meta.have_timestamp &&
                             s->meta.msg_timestamp != s->meta.curr_timestamp) {
 
                             user_meta->status |= BLADERF_META_STATUS_OVERRUN;
-                            exit_early = true;
+                            exit_early = copied_data;
                             log_debug("Sample discontinuity detected @ "
                                       "buffer %u, message %u: Expected t=%llu, "
                                       "got t=%llu\n",
@@ -739,6 +766,7 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
                         }
 
                         s->meta.curr_timestamp = s->meta.msg_timestamp;
+                        s->meta.have_timestamp = true;
                         s->meta.state = SYNC_META_STATE_SAMPLES;
                         break;
 

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -333,34 +333,6 @@ int sync_init(struct bladerf_sync *sync,
         goto error;
     }
 
-    if ((layout & BLADERF_DIRECTION_MASK) == BLADERF_TX) {
-        /* Clear a wedged FX3 TX DMA channel before the caller starts feeding.
-         *
-         * Building a second TX stream on the same device handle intermittently
-         * leaves that channel stuck: transfers go out, the FX3 takes zero
-         * bytes, and every completion returns LIBUSB_TRANSFER_TIMED_OUT with
-         * actual_length 0. The host ring fills and sync_tx() then refuses
-         * buffers permanently. It latches -- which repeat it strikes is random
-         * -- and used to need a close/open to clear.
-         *
-         * Cycling the direction through the board layer clears it. Measured:
-         * wedged then cycled gives 60/60 buffers, 4 of 4 attempts, against
-         * 15/60 for a do-nothing control in the same runs. What does NOT work,
-         * also measured: the backend vendor command alone (0 of 5), disable
-         * without re-enable (17/60), re-setting gain or frequency (15/60), an
-         * alt-setting change, and libusb_clear_halt() on the OUT endpoint.
-         * So the whole disable+enable pair through the board is required.
-         */
-        int cycle = dev->board->enable_module(dev, BLADERF_CHANNEL_TX(0), false);
-        if (cycle == 0) {
-            cycle = dev->board->enable_module(dev, BLADERF_CHANNEL_TX(0), true);
-        }
-        if (cycle != 0) {
-            log_debug("%s: could not cycle TX to clear the FX3 channel: %s\n",
-                      __FUNCTION__, bladerf_strerror(cycle));
-        }
-    }
-
     sync->initialized = true;
 
     return 0;

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -307,6 +307,7 @@ int sync_init(struct bladerf_sync *sync,
             sync->meta.msg_flags = 0;
             sync->meta.have_timestamp = false;
             sync->buf_mgmt.overrun_pending = false;
+            sync->buf_mgmt.stale_pending = false;
 
             sync_reset_sequence_tracking(&sync->buf_mgmt, num_transfers);
 
@@ -612,6 +613,34 @@ int sync_rx(struct bladerf_sync *s, void *samples, unsigned num_samples,
 
             case SYNC_STATE_WAIT_FOR_BUFFER:
                 MUTEX_LOCK(&b->lock);
+
+                /* An overrun means every buffer that is full right now was
+                 * produced BEFORE the gap: the worker stopped storing when
+                 * the ring filled, so this backlog is the oldest data, not
+                 * the newest. Drop it and resume at the live edge. Without
+                 * this, the first (num_buffers - num_transfers) reads after
+                 * a consumer stall return history, and with a non-metadata
+                 * format nothing marks it as such. In this state cons_i is
+                 * never PARTIAL, so the contiguous FULL run is safe to walk;
+                 * the producer resumes storing at the slots freed here. */
+                if (b->stale_pending) {
+                    unsigned int dropped = 0;
+
+                    while (b->status[b->cons_i] == SYNC_BUFFER_FULL &&
+                           dropped < b->num_buffers) {
+                        b->status[b->cons_i] = SYNC_BUFFER_EMPTY;
+                        b->cons_i = (b->cons_i + 1) % b->num_buffers;
+                        dropped++;
+                    }
+
+                    b->stale_pending = false;
+
+                    if (dropped != 0) {
+                        log_debug("%s: dropped %u stale buffer%s after "
+                                  "overrun\n", __FUNCTION__, dropped,
+                                  1 == dropped ? "" : "s");
+                    }
+                }
 
                 /* Check the buffer state, as the worker may have produced one
                  * since we last queried the status */

--- a/host/libraries/libbladeRF/src/streaming/sync.h
+++ b/host/libraries/libbladeRF/src/streaming/sync.h
@@ -214,6 +214,11 @@ struct sync_meta {
         /* Used only for TX */
         struct {
             bool in_burst;
+            uint64_t burst_start; /* Timestamp the current burst was
+                                   * scheduled to begin at. Valid while
+                                   * in_burst && !now; used to bound how
+                                   * much of the burst may sit in the
+                                   * device ahead of playback. */
             bool now;
         };
     };

--- a/host/libraries/libbladeRF/src/streaming/sync.h
+++ b/host/libraries/libbladeRF/src/streaming/sync.h
@@ -92,6 +92,12 @@ struct buffer_mgmt {
      * resubmission */
     unsigned int resubmit_count;
 
+    /* Set by the RX worker when it detects an overrun, cleared once the
+     * condition has been reported to a bladerf_sync_rx() caller. The worker
+     * recovers by resubmitting buffers, so the sample stream has a gap that
+     * is otherwise invisible to the caller. */
+    bool overrun_pending;
+
     /* Applicable to TX only. Denotes which context is responsible for
      * submitting full buffers to the underlying async system */
     sync_tx_submitter submitter;
@@ -172,6 +178,11 @@ typedef enum {
 
 struct sync_meta {
     sync_meta_state state; /* State of metadata processing */
+
+    bool have_timestamp;   /* curr_timestamp holds a value read from a
+                            * message header. Until then there is nothing to
+                            * compare against, so the first header of a
+                            * stream must not be treated as a discontinuity. */
 
     uint8_t *curr_msg;            /* Points to current message in the buffer */
     size_t curr_msg_off;          /* Offset into current message (samples),

--- a/host/libraries/libbladeRF/src/streaming/sync.h
+++ b/host/libraries/libbladeRF/src/streaming/sync.h
@@ -98,6 +98,15 @@ struct buffer_mgmt {
      * is otherwise invisible to the caller. */
     bool overrun_pending;
 
+    /* Also set by the RX worker on an overrun, cleared once the consumer
+     * has dropped the buffers that were already full at that moment. Those
+     * buffers hold the OLDEST samples: everything the hardware produced
+     * after the ring filled was discarded, so on resume the consumer would
+     * read history first - up to (num_buffers - num_transfers) buffers of
+     * it. With a metadata format the timestamps expose this; without one
+     * the stale prefix is indistinguishable from live data. */
+    bool stale_pending;
+
     /* Applicable to TX only. Denotes which context is responsible for
      * submitting full buffers to the underlying async system */
     sync_tx_submitter submitter;

--- a/host/libraries/libbladeRF/src/streaming/sync_worker.c
+++ b/host/libraries/libbladeRF/src/streaming/sync_worker.c
@@ -445,6 +445,26 @@ void sync_worker_submit_request(struct sync_worker *w, unsigned int request)
     w->requests |= request;
     COND_SIGNAL(&w->requests_pending);
     MUTEX_UNLOCK(&w->request_lock);
+
+    /* A TX worker only inspects requests from inside its transfer callback,
+     * and that callback only runs when a transfer completes. With the feed
+     * stopped nothing completes, so a STOP request is never seen and the
+     * worker stays in RUNNING until sync_worker_deinit() gives up waiting and
+     * cancels the thread.
+     *
+     * Nudge the stream into SHUTTING_DOWN so the backend event loop, which
+     * spins on "state != STREAM_DONE", leaves on its own. The loop then
+     * cancels whatever is outstanding and reaches STREAM_DONE without needing
+     * a completion to arrive first.
+     */
+    if ((request & SYNC_WORKER_STOP) && w->stream != NULL &&
+        (w->stream->layout & BLADERF_DIRECTION_MASK) == BLADERF_TX) {
+        MUTEX_LOCK(&w->stream->lock);
+        if (w->stream->state == STREAM_RUNNING) {
+            w->stream->state = STREAM_SHUTTING_DOWN;
+        }
+        MUTEX_UNLOCK(&w->stream->lock);
+    }
 }
 
 int sync_worker_wait_for_state(struct sync_worker *w, sync_worker_state state,

--- a/host/libraries/libbladeRF/src/streaming/sync_worker.c
+++ b/host/libraries/libbladeRF/src/streaming/sync_worker.c
@@ -219,8 +219,12 @@ static void *rx_callback(struct bladerf *dev,
                 log_verbose("%s worker: delaying submission while reorder "
                             "queue drains\n", worker2str(s));
             } else {
-                /* TODO propagate back the RX Overrun to the sync_rx() caller */
                 log_debug("RX overrun @ buffer %u\r\n", samples_idx);
+
+                /* Recovery resubmits buffers, which leaves a gap in the
+                 * sample stream. Record it so the next bladerf_sync_rx()
+                 * can report BLADERF_META_STATUS_OVERRUN to the caller. */
+                b->overrun_pending = true;
 
                 next_buf = samples;
                 b->resubmit_count = s->stream_config.num_xfers - 1;

--- a/host/libraries/libbladeRF/src/streaming/sync_worker.c
+++ b/host/libraries/libbladeRF/src/streaming/sync_worker.c
@@ -225,6 +225,10 @@ static void *rx_callback(struct bladerf *dev,
                  * sample stream. Record it so the next bladerf_sync_rx()
                  * can report BLADERF_META_STATUS_OVERRUN to the caller. */
                 b->overrun_pending = true;
+                /* The buffers that are full right now predate the gap;
+                 * flag them so the consumer resumes at the live edge
+                 * instead of reading history first. */
+                b->stale_pending = true;
 
                 next_buf = samples;
                 b->resubmit_count = s->stream_config.num_xfers - 1;

--- a/host/libraries/libbladeRF/src/streaming/sync_worker.c
+++ b/host/libraries/libbladeRF/src/streaming/sync_worker.c
@@ -379,7 +379,7 @@ int sync_worker_init(struct bladerf_sync *s)
 
     /* Wait until the worker thread has initialized and is ready to go */
     status =
-        sync_worker_wait_for_state(s->worker, SYNC_WORKER_STATE_IDLE, 1000);
+        sync_worker_wait_for_state(s->worker, SYNC_WORKER_STATE_IDLE, 10000);
     if (status != 0) {
         log_debug("%s worker: sync_worker_wait_for_state failed: %d\n",
                   worker2str(s), status);

--- a/host/libraries/libbladeRF/src/streaming/test_oldest_full_buffer.c
+++ b/host/libraries/libbladeRF/src/streaming/test_oldest_full_buffer.c
@@ -1,0 +1,123 @@
+/*
+ * Which buffer still needs sending, when transfers were cancelled.
+ *
+ * Cancelled transfers come back through libusb's own callback path, which
+ * never runs the sync callback. So cons_i keeps pointing at a buffer that is
+ * already IN_FLIGHT and will never come back, while the data waiting to go
+ * out sits in the FULL buffers behind it. Looking only at cons_i finds
+ * nothing to do and leaves submission parked on a callback that can no longer
+ * run - the state a wire trace showed as 8 in flight, 8 full, 0 empty and no
+ * submissions for a full stream timeout.
+ *
+ * The search is a handful of lines and easy to get subtly wrong (wrap-around,
+ * the empty case), and a wedged TX feed is expensive to reproduce, so it gets
+ * a test that needs no device.
+ *
+ *   cc -o /tmp/t test_oldest_full_buffer.c && /tmp/t
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define BUFFER_MGMT_INVALID_INDEX (UINT_MAX)
+#include <limits.h>
+
+typedef enum {
+    SYNC_BUFFER_EMPTY = 0,
+    SYNC_BUFFER_PARTIAL,
+    SYNC_BUFFER_FULL,
+    SYNC_BUFFER_IN_FLIGHT,
+} sync_buffer_status;
+
+struct buffer_mgmt {
+    unsigned int num_buffers;
+    unsigned int cons_i;
+    sync_buffer_status *status;
+};
+
+/* Kept byte-for-byte in step with sync.c. */
+static unsigned int oldest_full_buffer(struct buffer_mgmt *b)
+{
+    unsigned int i, idx;
+
+    if (b->cons_i == BUFFER_MGMT_INVALID_INDEX) {
+        return BUFFER_MGMT_INVALID_INDEX;
+    }
+
+    for (i = 0; i < b->num_buffers; i++) {
+        idx = (b->cons_i + i) % b->num_buffers;
+        if (b->status[idx] == SYNC_BUFFER_FULL) {
+            return idx;
+        }
+    }
+
+    return BUFFER_MGMT_INVALID_INDEX;
+}
+
+int main(void)
+{
+    sync_buffer_status st[4];
+    struct buffer_mgmt b = { .num_buffers = 4, .cons_i = 0, .status = st };
+    unsigned int i;
+
+    /* cons_i points at what needs sending: take it. */
+    for (i = 0; i < 4; i++) {
+        st[i] = SYNC_BUFFER_EMPTY;
+    }
+    st[1] = SYNC_BUFFER_FULL;
+    b.cons_i = 1;
+    assert(oldest_full_buffer(&b) == 1);
+
+    /* The defect this exists for: cons_i was left on a cancelled transfer's
+     * buffer, and the data is behind it. Looking only at cons_i finds
+     * nothing. */
+    for (i = 0; i < 4; i++) {
+        st[i] = SYNC_BUFFER_EMPTY;
+    }
+    st[1] = SYNC_BUFFER_IN_FLIGHT;
+    st[2] = SYNC_BUFFER_FULL;
+    b.cons_i = 1;
+    assert(oldest_full_buffer(&b) == 2);
+
+    /* Wrap-around: the oldest FULL is before cons_i in index order but after
+     * it in ring order. */
+    for (i = 0; i < 4; i++) {
+        st[i] = SYNC_BUFFER_IN_FLIGHT;
+    }
+    st[0] = SYNC_BUFFER_FULL;
+    b.cons_i = 2;
+    assert(oldest_full_buffer(&b) == 0);
+
+    /* Ring order, not index order: with FULL on both sides of cons_i the one
+     * at or after cons_i wins. */
+    for (i = 0; i < 4; i++) {
+        st[i] = SYNC_BUFFER_EMPTY;
+    }
+    st[0] = SYNC_BUFFER_FULL;
+    st[3] = SYNC_BUFFER_FULL;
+    b.cons_i = 3;
+    assert(oldest_full_buffer(&b) == 3);
+
+    /* Every tracked buffer came back through the cancellation path: nothing
+     * is owed, so the caller takes submission duty back. */
+    for (i = 0; i < 4; i++) {
+        st[i] = SYNC_BUFFER_IN_FLIGHT;
+    }
+    b.cons_i = 0;
+    assert(oldest_full_buffer(&b) == BUFFER_MGMT_INVALID_INDEX);
+
+    /* PARTIAL is not ready to ship - sync_tx is still filling it. */
+    for (i = 0; i < 4; i++) {
+        st[i] = SYNC_BUFFER_EMPTY;
+    }
+    st[2] = SYNC_BUFFER_PARTIAL;
+    b.cons_i = 0;
+    assert(oldest_full_buffer(&b) == BUFFER_MGMT_INVALID_INDEX);
+
+    /* No index to start from at all. */
+    b.cons_i = BUFFER_MGMT_INVALID_INDEX;
+    assert(oldest_full_buffer(&b) == BUFFER_MGMT_INVALID_INDEX);
+
+    printf("oldest_full_buffer: ok\n");
+    return 0;
+}

--- a/host/libraries/libbladeRF/src/streaming/test_tx_submit_liveness.c
+++ b/host/libraries/libbladeRF/src/streaming/test_tx_submit_liveness.c
@@ -55,28 +55,29 @@ struct buffer_mgmt {
 
 /* --- the code under test, kept in step with sync.c --- */
 
-static bool tx_submission_parked(struct buffer_mgmt *b)
-{
-    return b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
-           b->cons_i != BUFFER_MGMT_INVALID_INDEX;
-}
-
 static unsigned int oldest_full_buffer(struct buffer_mgmt *b)
 {
     unsigned int i, idx;
-
-    if (b->cons_i == BUFFER_MGMT_INVALID_INDEX) {
-        return BUFFER_MGMT_INVALID_INDEX;
-    }
+    const unsigned int from = (b->cons_i == BUFFER_MGMT_INVALID_INDEX)
+                                  ? b->prod_i : b->cons_i;
 
     for (i = 0; i < b->num_buffers; i++) {
-        idx = (b->cons_i + i) % b->num_buffers;
+        idx = (from + i) % b->num_buffers;
         if (b->status[idx] == SYNC_BUFFER_FULL) {
             return idx;
         }
     }
 
     return BUFFER_MGMT_INVALID_INDEX;
+}
+
+static bool tx_submission_parked(struct buffer_mgmt *b)
+{
+    if (b->submitter == SYNC_TX_SUBMITTER_CALLBACK) {
+        return b->cons_i != BUFFER_MGMT_INVALID_INDEX;
+    }
+    return b->submitter == SYNC_TX_SUBMITTER_FN &&
+           oldest_full_buffer(b) != BUFFER_MGMT_INVALID_INDEX;
 }
 
 /* reclaim_tx_submission() with the submit call replaced by a stub, since the
@@ -160,8 +161,11 @@ static bool stuck(struct buffer_mgmt *b, int live_transfers)
             full++;
         }
     }
-    return full > 0 && live_transfers == 0 &&
-           b->submitter == SYNC_TX_SUBMITTER_CALLBACK;
+    /* Who holds the duty does not matter: what makes it stuck is data waiting
+     * with nothing in flight to bring the callback that would move it. Both
+     * states were seen on hardware - CALLBACK with 8 in flight and 8 full, and
+     * FN with 0 in flight and 26 full. */
+    return full > 0 && live_transfers == 0;
 }
 
 int main(void)
@@ -198,10 +202,33 @@ int main(void)
     assert(b.cons_i == BUFFER_MGMT_INVALID_INDEX);
     assert(!tx_submission_parked(&b));
 
-    /* Duty already ours: nothing to reclaim, nothing parked. */
+    /* Duty ours and nothing waiting: not parked. */
+    for (unsigned int i = 0; i < NUM_BUFFERS; i++) {
+        b.status[i] = SYNC_BUFFER_EMPTY;
+    }
     b.submitter = SYNC_TX_SUBMITTER_FN;
     b.cons_i    = BUFFER_MGMT_INVALID_INDEX;
+    b.prod_i    = 0;
     assert(!tx_submission_parked(&b));
+
+    /* Duty ours but buffers piled up while it was parked with the callback.
+     * Measured on hardware as submitter FN, 0 in flight, 26 of 64 FULL, and
+     * sync_tx timing out: it only ever submits the buffer prod_i points at,
+     * so the backlog never moves and no transfer is out to bring a callback.
+     */
+    for (unsigned int i = 0; i < NUM_BUFFERS; i++) {
+        b.status[i] = SYNC_BUFFER_EMPTY;
+    }
+    b.status[5] = SYNC_BUFFER_FULL;
+    b.status[6] = SYNC_BUFFER_FULL;
+    b.submitter = SYNC_TX_SUBMITTER_FN;
+    b.cons_i    = BUFFER_MGMT_INVALID_INDEX;
+    b.prod_i    = 0;
+    assert(stuck(&b, 0));
+    assert(tx_submission_parked(&b));
+    assert(oldest_full_buffer(&b) == 5);
+    assert(drain(&b, NUM_TRANSFERS) == 0);
+    assert(!stuck(&b, 0));
 
     printf("tx submit liveness: ok\n");
     return 0;

--- a/host/libraries/libbladeRF/src/streaming/test_tx_submit_liveness.c
+++ b/host/libraries/libbladeRF/src/streaming/test_tx_submit_liveness.c
@@ -1,0 +1,208 @@
+/*
+ * TX submission must never be parked on a callback that can no longer run.
+ *
+ * Replays the ordering a usbmon trace showed during a stalled feed:
+ *
+ *   every transfer busy -> submit returns WOULD_BLOCK
+ *   -> submission duty handed to the worker callback, cons_i records the buffer
+ *   -> those transfers come back CANCELLED, which libusb delivers through its
+ *      own callback path, so the sync callback never runs
+ *   -> cons_i still points at a buffer marked IN_FLIGHT that will not come back
+ *   -> the data waiting to go out is in the FULL buffers behind it
+ *   -> next sync_tx finds no EMPTY buffer and waits out the stream timeout
+ *
+ * On the wire that appeared as eight submissions in 86 us, none completing,
+ * all eight returning -ENOENT exactly 1000 ms later, while the RX endpoint
+ * carried 941 successful completions in the same window. The device was
+ * taking data; the host had stopped offering any.
+ *
+ * The ring here is the real one's state machine, driven by hand, so the
+ * ordering is fixed instead of waiting for a race on hardware - the device
+ * reproducer gave "stalled at repeat 1", "stalled at repeat 8" and "clean
+ * 24/24" from the same binary within an hour.
+ *
+ *   cc -o /tmp/t test_tx_submit_liveness.c && /tmp/t
+ */
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#define BUFFER_MGMT_INVALID_INDEX (UINT_MAX)
+#define NUM_BUFFERS 8
+#define NUM_TRANSFERS 4
+
+typedef enum {
+    SYNC_BUFFER_EMPTY = 0,
+    SYNC_BUFFER_PARTIAL,
+    SYNC_BUFFER_FULL,
+    SYNC_BUFFER_IN_FLIGHT,
+} sync_buffer_status;
+
+typedef enum {
+    SYNC_TX_SUBMITTER_INVALID = 0,
+    SYNC_TX_SUBMITTER_FN,
+    SYNC_TX_SUBMITTER_CALLBACK,
+} sync_tx_submitter;
+
+struct buffer_mgmt {
+    unsigned int num_buffers;
+    unsigned int prod_i;
+    unsigned int cons_i;
+    sync_tx_submitter submitter;
+    sync_buffer_status status[NUM_BUFFERS];
+};
+
+/* --- the code under test, kept in step with sync.c --- */
+
+static bool tx_submission_parked(struct buffer_mgmt *b)
+{
+    return b->submitter == SYNC_TX_SUBMITTER_CALLBACK &&
+           b->cons_i != BUFFER_MGMT_INVALID_INDEX;
+}
+
+static unsigned int oldest_full_buffer(struct buffer_mgmt *b)
+{
+    unsigned int i, idx;
+
+    if (b->cons_i == BUFFER_MGMT_INVALID_INDEX) {
+        return BUFFER_MGMT_INVALID_INDEX;
+    }
+
+    for (i = 0; i < b->num_buffers; i++) {
+        idx = (b->cons_i + i) % b->num_buffers;
+        if (b->status[idx] == SYNC_BUFFER_FULL) {
+            return idx;
+        }
+    }
+
+    return BUFFER_MGMT_INVALID_INDEX;
+}
+
+/* reclaim_tx_submission() with the submit call replaced by a stub, since the
+ * point is the ownership bookkeeping around it. free_transfers models how
+ * many transfers libusb would accept right now. */
+static int reclaim(struct buffer_mgmt *b, int free_transfers)
+{
+    const unsigned int idx = oldest_full_buffer(b);
+
+    if (idx == BUFFER_MGMT_INVALID_INDEX) {
+        b->submitter = SYNC_TX_SUBMITTER_FN;
+        b->cons_i    = BUFFER_MGMT_INVALID_INDEX;
+        return 0;
+    }
+
+    if (free_transfers <= 0) {
+        return 0;                       /* WOULD_BLOCK, buffer stays FULL */
+    }
+
+    b->status[idx] = SYNC_BUFFER_IN_FLIGHT;
+    b->cons_i      = (idx + 1) % b->num_buffers;
+    if (b->status[b->cons_i] != SYNC_BUFFER_FULL) {
+        b->submitter = SYNC_TX_SUBMITTER_FN;
+        b->cons_i    = BUFFER_MGMT_INVALID_INDEX;
+    }
+    return 0;
+}
+
+/* The loop sync_tx runs while the ring stays parked: keep submitting while
+ * the backend accepts buffers, stop as soon as nothing moves. */
+static int drain(struct buffer_mgmt *b, int free_transfers)
+{
+    int status = 0;
+
+    while (status == 0 && tx_submission_parked(b)) {
+        const unsigned int before = b->cons_i;
+
+        status = reclaim(b, free_transfers);
+        if (b->cons_i == before) {
+            break;
+        }
+        if (free_transfers > 0) {
+            free_transfers--;
+        }
+    }
+    return status;
+}
+
+/* --- the state the wire trace showed --- */
+
+static void build_stalled_ring(struct buffer_mgmt *b)
+{
+    unsigned int i;
+
+    b->num_buffers = NUM_BUFFERS;
+    b->submitter   = SYNC_TX_SUBMITTER_CALLBACK;
+
+    /* Four transfers went out and were cancelled; their buffers keep the
+     * IN_FLIGHT mark because only the sync callback clears it, and the
+     * cancellation path bypassed it. */
+    for (i = 0; i < NUM_TRANSFERS; i++) {
+        b->status[i] = SYNC_BUFFER_IN_FLIGHT;
+    }
+    /* sync_tx kept filling behind them. */
+    for (i = NUM_TRANSFERS; i < NUM_BUFFERS; i++) {
+        b->status[i] = SYNC_BUFFER_FULL;
+    }
+    /* cons_i is stuck on the first cancelled transfer's buffer. */
+    b->cons_i  = 0;
+    b->prod_i  = 0;
+}
+
+/* Forbidden state: something is waiting to be sent, the duty is with the
+ * callback, and no completion can arrive to run it. */
+static bool stuck(struct buffer_mgmt *b, int live_transfers)
+{
+    unsigned int i, full = 0;
+
+    for (i = 0; i < b->num_buffers; i++) {
+        if (b->status[i] == SYNC_BUFFER_FULL) {
+            full++;
+        }
+    }
+    return full > 0 && live_transfers == 0 &&
+           b->submitter == SYNC_TX_SUBMITTER_CALLBACK;
+}
+
+int main(void)
+{
+    struct buffer_mgmt b;
+
+    /* The wire ordering: transfers cancelled, none live, data waiting. */
+    build_stalled_ring(&b);
+    assert(stuck(&b, 0));
+    assert(tx_submission_parked(&b));
+
+    /* Transfers were cancelled, so libusb has slots free again. Draining -
+     * the loop the caller runs while the ring stays parked - must leave it in
+     * a live state. One submission is not enough: each buffer still FULL
+     * behind the first would need its own callback. */
+    assert(drain(&b, NUM_TRANSFERS) == 0);
+    assert(!stuck(&b, 0));
+
+    /* Every transfer still busy: the attempt must change nothing rather than
+     * lie about progress, and the caller waits as before. */
+    build_stalled_ring(&b);
+    assert(reclaim(&b, 0) == 0);
+    assert(stuck(&b, 0));
+    assert(tx_submission_parked(&b));
+
+    /* Nothing waiting to go out: the duty comes back with no submission, so a
+     * later sync_tx can submit for itself. */
+    build_stalled_ring(&b);
+    for (unsigned int i = NUM_TRANSFERS; i < NUM_BUFFERS; i++) {
+        b.status[i] = SYNC_BUFFER_EMPTY;
+    }
+    assert(reclaim(&b, 0) == 0);
+    assert(b.submitter == SYNC_TX_SUBMITTER_FN);
+    assert(b.cons_i == BUFFER_MGMT_INVALID_INDEX);
+    assert(!tx_submission_parked(&b));
+
+    /* Duty already ours: nothing to reclaim, nothing parked. */
+    b.submitter = SYNC_TX_SUBMITTER_FN;
+    b.cons_i    = BUFFER_MGMT_INVALID_INDEX;
+    assert(!tx_submission_parked(&b));
+
+    printf("tx submit liveness: ok\n");
+    return 0;
+}

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/adc_core.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/adc_core.c
@@ -45,7 +45,8 @@
 
 #include "adc_core.h"
 #include "platform.h"
-#include "util.h"
+/* Renamed upstream: util.h became ad9361_util.h. */
+#include "ad9361_util.h"
 
 /***************************************************************************//**
  * @brief adc_read

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/app_config.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/app_config.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (C) 2026 Nuand LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * The AD9361 driver includes app_config.h for its build-time switches. Older
+ * revisions used config.h under this name, so this file only forwards to the
+ * existing one and keeps the switches in a single place.
+ */
+
+#ifndef BLADERF2_APP_CONFIG_H_
+#define BLADERF2_APP_CONFIG_H_
+
+#include "config.h"
+
+#endif

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/bladerf2_axi_io.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/bladerf2_axi_io.c
@@ -1,0 +1,50 @@
+/*
+ * no_os_axi_io implementation for the bladeRF2.
+ *
+ * The no-OS axi_adc/axi_dac cores expect memory-mapped register access
+ * through no_os_axi_io_read/write(base, offset, ...). On this board the ADI
+ * AXI interface core lives behind the NIOS (NIOS_PKT_32x32_TARGET_ADI_AXI),
+ * so the accessors forward to the backend adi_axi_read/write. The API has no
+ * context argument, so the device handle is a file-static set by
+ * bladerf2_axi_io_set_dev() right before ad9361_init() (mirrors how the SPI
+ * and GPIO descriptors receive the handle through .extra).
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "board/board.h"
+
+#include "no_os_axi_io.h"
+
+static struct bladerf *axi_io_dev = NULL;
+
+void bladerf2_axi_io_set_dev(struct bladerf *dev)
+{
+    axi_io_dev = dev;
+}
+
+int32_t no_os_axi_io_read(uint32_t base, uint32_t offset, uint32_t *data)
+{
+    if (NULL == axi_io_dev || NULL == data) {
+        return -ENODEV;
+    }
+
+    if (axi_io_dev->backend->adi_axi_read(axi_io_dev, base + offset, data) < 0) {
+        return -EIO;
+    }
+
+    return 0;
+}
+
+int32_t no_os_axi_io_write(uint32_t base, uint32_t offset, uint32_t data)
+{
+    if (NULL == axi_io_dev) {
+        return -ENODEV;
+    }
+
+    if (axi_io_dev->backend->adi_axi_write(axi_io_dev, base + offset, data) < 0) {
+        return -EIO;
+    }
+
+    return 0;
+}

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/bladerf2_gpio.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/bladerf2_gpio.c
@@ -1,0 +1,194 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (C) 2026 Nuand LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * GPIO back end for the AD9361 driver, as a no-OS platform ops table.
+ *
+ * The AD9361 control lines the driver drives (resetb, sync, cal_sw1, cal_sw2)
+ * are bits of the FPGA's RFFE control register on this board, not pins of a
+ * GPIO controller. The register is read-modify-write, so a set is a read, a
+ * bit change and a write.
+ *
+ * The older driver revision took a single struct gpio_device and a pin number;
+ * the current one holds one struct no_os_gpio_desc per line and goes through
+ * struct no_os_gpio_platform_ops. The bit number travels in desc->number and
+ * the bladeRF device handle in desc->extra, so the mapping is unchanged - only
+ * the shape of the call is.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "board/board.h"
+
+#include "no_os_gpio.h"
+
+static int32_t bladerf2_gpio_get(struct no_os_gpio_desc **desc,
+                                 const struct no_os_gpio_init_param *param)
+{
+    struct no_os_gpio_desc *d;
+
+    if (NULL == desc || NULL == param) {
+        return -EINVAL;
+    }
+
+    d = calloc(1, sizeof(*d));
+    if (NULL == d) {
+        return -ENOMEM;
+    }
+
+    d->port = param->port;
+    d->number = param->number;
+    d->pull = param->pull;
+    d->platform_ops = param->platform_ops;
+    d->extra = param->extra;
+
+    *desc = d;
+
+    return 0;
+}
+
+static int32_t bladerf2_gpio_get_optional(struct no_os_gpio_desc **desc,
+                                          const struct no_os_gpio_init_param *param)
+{
+    /* An absent line is not an error: the driver treats a NULL descriptor as
+     * "this board does not wire that signal". */
+    if (NULL == param) {
+        if (NULL != desc) {
+            *desc = NULL;
+        }
+        return 0;
+    }
+
+    return bladerf2_gpio_get(desc, param);
+}
+
+static int32_t bladerf2_gpio_remove(struct no_os_gpio_desc *desc)
+{
+    free(desc);
+
+    return 0;
+}
+
+static int32_t bladerf2_gpio_direction_output(struct no_os_gpio_desc *desc,
+                                             uint8_t value)
+{
+    /* Every line reachable here is an output of the RFFE register; there is no
+     * direction to program. The value still has to be applied. */
+    if (NULL == desc) {
+        return -EINVAL;
+    }
+
+    return no_os_gpio_set_value(desc, value);
+}
+
+static int32_t bladerf2_gpio_direction_input(struct no_os_gpio_desc *desc)
+{
+    (void)desc;
+
+    /* No line the driver asks for is an input on this board. */
+    return -ENOTSUP;
+}
+
+static int32_t bladerf2_gpio_get_direction(struct no_os_gpio_desc *desc,
+                                           uint8_t *direction)
+{
+    if (NULL == desc || NULL == direction) {
+        return -EINVAL;
+    }
+
+    *direction = NO_OS_GPIO_OUT;
+
+    return 0;
+}
+
+static int32_t bladerf2_gpio_set_value(struct no_os_gpio_desc *desc,
+                                       uint8_t value)
+{
+    struct bladerf *dev;
+    uint32_t reg;
+    int status;
+
+    if (NULL == desc) {
+        return -EINVAL;
+    }
+
+    dev = desc->extra;
+    if (NULL == dev) {
+        return -EINVAL;
+    }
+
+    status = dev->backend->rffe_control_read(dev, &reg);
+    if (status < 0) {
+        return -EIO;
+    }
+
+    if (value) {
+        reg |= (1u << desc->number);
+    } else {
+        reg &= ~(1u << desc->number);
+    }
+
+    status = dev->backend->rffe_control_write(dev, reg);
+    if (status < 0) {
+        return -EIO;
+    }
+
+    return 0;
+}
+
+static int32_t bladerf2_gpio_get_value(struct no_os_gpio_desc *desc,
+                                       uint8_t *value)
+{
+    struct bladerf *dev;
+    uint32_t reg;
+    int status;
+
+    if (NULL == desc || NULL == value) {
+        return -EINVAL;
+    }
+
+    dev = desc->extra;
+    if (NULL == dev) {
+        return -EINVAL;
+    }
+
+    status = dev->backend->rffe_control_read(dev, &reg);
+    if (status < 0) {
+        return -EIO;
+    }
+
+    *value = (reg & (1u << desc->number)) ? 1 : 0;
+
+    return 0;
+}
+
+const struct no_os_gpio_platform_ops bladerf2_gpio_ops = {
+    .gpio_ops_get = bladerf2_gpio_get,
+    .gpio_ops_get_optional = bladerf2_gpio_get_optional,
+    .gpio_ops_remove = bladerf2_gpio_remove,
+    .gpio_ops_direction_input = bladerf2_gpio_direction_input,
+    .gpio_ops_direction_output = bladerf2_gpio_direction_output,
+    .gpio_ops_get_direction = bladerf2_gpio_get_direction,
+    .gpio_ops_set_value = bladerf2_gpio_set_value,
+    .gpio_ops_get_value = bladerf2_gpio_get_value,
+};

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/bladerf2_spi.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/bladerf2_spi.c
@@ -1,0 +1,162 @@
+/*
+ * This file is part of the bladeRF project:
+ *   http://www.github.com/nuand/bladeRF
+ *
+ * Copyright (C) 2026 Nuand LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * SPI back end for the AD9361 driver, as a no-OS platform ops table.
+ *
+ * The older driver revision this replaces had no such table: it called
+ * spi_write_then_read() directly, and the bladeRF tree carried a patch that
+ * substituted its own spi_read()/spi_write() inside the driver body behind
+ * #ifdef NUAND_MODIFICATIONS. The current driver takes the transfer through
+ * struct no_os_spi_platform_ops, so the substitution belongs here instead and
+ * the driver source stays unmodified.
+ *
+ * Buffer layout produced by the driver (see ad9361_spi_read(),
+ * ad9361_spi_write() and ad9361_spi_writem()):
+ *
+ *   buf[0] = cmd >> 8      cmd = AD_READ or AD_WRITE, | AD_CNT(n) | AD_ADDR(reg)
+ *   buf[1] = cmd & 0xFF
+ *   buf[2..] = payload, n bytes, read into or written from
+ *
+ * The bladeRF back end takes the 16-bit command and up to 8 payload bytes
+ * packed into a 64-bit word, most significant byte first, so this file only
+ * has to split the buffer and pack or unpack the payload.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "board/board.h"
+
+#include "no_os_spi.h"
+
+/* Payload bytes one transaction can carry. Mirrors MAX_MBYTE_SPI, which the
+ * driver defines as 8 in ad9361.h; kept local so this file does not need the
+ * driver's private header. */
+#define BLADERF2_SPI_MAX_PAYLOAD 8
+
+/* Command word bit that marks a write. ad9361.h defines AD_READ as (0 << 15)
+ * and AD_WRITE as (1 << 15), so bit 15 is the direction. */
+#define BLADERF2_SPI_CMD_WRITE (1u << 15)
+
+static int32_t bladerf2_spi_init(struct no_os_spi_desc **desc,
+                                 const struct no_os_spi_init_param *param)
+{
+    struct no_os_spi_desc *d;
+
+    if (NULL == desc || NULL == param) {
+        return -EINVAL;
+    }
+
+    d = calloc(1, sizeof(*d));
+    if (NULL == d) {
+        return -ENOMEM;
+    }
+
+    /* The bladeRF device handle travels in extra, set by the caller that
+     * builds the init parameters. Everything else in the descriptor is
+     * unused: the transfer goes through the device back end, not a bus
+     * peripheral this file owns. */
+    d->extra = param->extra;
+    d->platform_ops = param->platform_ops;
+
+    *desc = d;
+
+    return 0;
+}
+
+static int32_t bladerf2_spi_remove(struct no_os_spi_desc *desc)
+{
+    free(desc);
+
+    return 0;
+}
+
+static int32_t bladerf2_spi_write_and_read(struct no_os_spi_desc *desc,
+                                           uint8_t *data,
+                                           uint16_t bytes_number)
+{
+    struct bladerf *dev;
+    uint16_t cmd;
+    uint16_t payload;
+    uint64_t word;
+    uint16_t i;
+    int status;
+
+    if (NULL == desc || NULL == data) {
+        return -EINVAL;
+    }
+
+    /* Two command bytes are mandatory; anything shorter is not a transfer
+     * this driver produces. */
+    if (bytes_number < 2) {
+        return -EINVAL;
+    }
+
+    payload = (uint16_t)(bytes_number - 2);
+    if (payload > BLADERF2_SPI_MAX_PAYLOAD) {
+        return -EINVAL;
+    }
+
+    dev = desc->extra;
+    if (NULL == dev) {
+        return -EINVAL;
+    }
+
+    cmd = (uint16_t)((((uint16_t)data[0]) << 8) | data[1]);
+
+    if (cmd & BLADERF2_SPI_CMD_WRITE) {
+        /* Pack the payload most significant byte first, matching what the
+         * back end expects to shift onto the bus. */
+        word = 0;
+        for (i = 0; i < payload; i++) {
+            word |= ((uint64_t)data[2 + i]) << (8 * (7 - i));
+        }
+
+        status = dev->backend->ad9361_spi_write(dev, cmd, word);
+        if (status < 0) {
+            return -EIO;
+        }
+
+        return 0;
+    }
+
+    word = 0;
+    status = dev->backend->ad9361_spi_read(dev, cmd, &word);
+    if (status < 0) {
+        return -EIO;
+    }
+
+    /* The read replaces the payload in place; the command bytes are left
+     * alone, as the driver only looks past them. */
+    for (i = 0; i < payload; i++) {
+        data[2 + i] = (uint8_t)((word >> (8 * (7 - i))) & 0xff);
+    }
+
+    return 0;
+}
+
+const struct no_os_spi_platform_ops bladerf2_spi_ops = {
+    .init = bladerf2_spi_init,
+    .write_and_read = bladerf2_spi_write_and_read,
+    .remove = bladerf2_spi_remove,
+};

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/config.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/config.h
@@ -61,11 +61,15 @@
 //#define PICOZED_SDR
 //#define PICOZED_SDR_CMOS
 //#define CAPTURE_SCRIPT
-/* The bladeRF has no AXI ADC/DAC core: samples reach the host over USB, so
- * the driver's AXI paths must stay out. The older driver revision this tree
- * used to carry had no such paths at all, which is why the switch was left
- * off; the current one guards them with this symbol. */
-#define AXI_ADC_NOT_PRESENT
+/* The bladeRF2 FPGA DOES carry the ADI AXI interface core, reachable over
+ * NIOS_PKT_32x32_TARGET_ADI_AXI (see backend adi_axi_read/write). The core
+ * powers up held in reset; ad9361_post_setup()/axi_adc_init() are what
+ * deassert RSTN and program the channel/data-format registers. Defining
+ * AXI_ADC_NOT_PRESENT skipped all of that, which left the RX sample path
+ * dead after every cold power-up (RX timestamp frozen at 0, zero bytes on
+ * the sample endpoint) until some other build initialized the core.
+ * Measured 2026-08-31; keep the AXI path IN. */
+//#define AXI_ADC_NOT_PRESENT
 //#define TDD_SWITCH_STATE_EXAMPLE
 
 #endif

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/config.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/config.h
@@ -61,7 +61,11 @@
 //#define PICOZED_SDR
 //#define PICOZED_SDR_CMOS
 //#define CAPTURE_SCRIPT
-//#define AXI_ADC_NOT_PRESENT
+/* The bladeRF has no AXI ADC/DAC core: samples reach the host over USB, so
+ * the driver's AXI paths must stay out. The older driver revision this tree
+ * used to carry had no such paths at all, which is why the switch was left
+ * off; the current one guards them with this symbol. */
+#define AXI_ADC_NOT_PRESENT
 //#define TDD_SWITCH_STATE_EXAMPLE
 
 #endif

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/dac_core.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/dac_core.c
@@ -45,7 +45,8 @@
 
 #include "dac_core.h"
 #include "platform.h"
-#include "util.h"
+/* Renamed upstream: util.h became ad9361_util.h. */
+#include "ad9361_util.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/platform.c
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/platform.c
@@ -4,130 +4,6 @@
 
 #include "platform.h"
 
-#include "adc_core.h"
-#include "dac_core.h"
-
-/***************************************************************************//**
- * @brief spi_init
-*******************************************************************************/
-
-int spi_init(struct ad9361_rf_phy *phy, void *userdata)
-{
-    phy->spi->userdata = userdata;
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief spi_write
-*******************************************************************************/
-
-int spi_write(struct spi_device *spi, uint16_t cmd, const uint8_t *buf,
-              unsigned int len)
-{
-    struct bladerf *dev = spi->userdata;
-    int status;
-    uint64_t data;
-    unsigned int i;
-
-    /* Copy buf to data */
-    data = 0;
-    for (i = 0; i < len; i++) {
-        data |= (((uint64_t)buf[i]) << 8*(7-i));
-    }
-
-    /* SPI transaction */
-    status = dev->backend->ad9361_spi_write(dev, cmd, data);
-    if (status < 0) {
-        return -EIO;
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief spi_read
-*******************************************************************************/
-
-#include <inttypes.h>
-
-int spi_read(struct spi_device *spi, uint16_t cmd, uint8_t *buf,
-             unsigned int len)
-{
-    struct bladerf *dev = spi->userdata;
-    int status;
-    uint64_t data = 0;
-    unsigned int i;
-
-    /* SPI transaction */
-    status = dev->backend->ad9361_spi_read(dev, cmd, &data);
-    if (status < 0) {
-        return -EIO;
-    }
-
-    /* Copy data to buf */
-    for (i = 0; i < len; i++) {
-        buf[i] = (data >> 8*(7-i)) & 0xff;
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief gpio_init
-*******************************************************************************/
-
-int gpio_init(struct ad9361_rf_phy *phy, void *userdata)
-{
-    phy->gpio->userdata = userdata;
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief gpio_is_valid
-*******************************************************************************/
-
-bool gpio_is_valid(struct gpio_device *gpio, int32_t number)
-{
-    if (number == RFFE_CONTROL_RESET_N) {
-        return true;
-    } else if (number == RFFE_CONTROL_SYNC_IN) {
-        return true;
-    }
-
-    return false;
-}
-
-/***************************************************************************//**
- * @brief gpio_set_value
-*******************************************************************************/
-
-int gpio_set_value(struct gpio_device *gpio, int32_t number, bool value)
-{
-    struct bladerf *dev = gpio->userdata;
-    int status;
-    uint32_t reg;
-
-    /* Read */
-    status = dev->backend->rffe_control_read(dev, &reg);
-    if (status < 0) {
-        return -EIO;
-    }
-
-    /* Modify */
-    if (value) {
-        reg |= (1 << number);
-    } else {
-        reg &= ~(1 << number);
-    }
-
-    /* Write */
-    status = dev->backend->rffe_control_write(dev, reg);
-    if (status < 0) {
-        return -EIO;
-    }
-
-    return 0;
-}
 
 /***************************************************************************//**
  * @brief udelay
@@ -148,6 +24,24 @@ void mdelay(unsigned long msecs)
 }
 
 /***************************************************************************//**
+ * @brief no_os_udelay, no_os_mdelay
+ *
+ * The current driver revision calls the delays through no_os_delay.h. Only the
+ * names and the argument width changed, so these forward to the existing
+ * implementations rather than duplicating them.
+*******************************************************************************/
+
+void no_os_udelay(uint32_t usecs)
+{
+    udelay(usecs);
+}
+
+void no_os_mdelay(uint32_t msecs)
+{
+    mdelay(msecs);
+}
+
+/***************************************************************************//**
  * @brief msleep_interruptible
 *******************************************************************************/
 
@@ -157,139 +51,9 @@ unsigned long msleep_interruptible(unsigned int msecs)
     return 0;
 }
 
-/***************************************************************************//**
- * @brief axiadc_init
-*******************************************************************************/
-
-int axiadc_init(struct ad9361_rf_phy *phy, void *userdata)
-{
-    int status;
-
-    phy->adc_state->userdata = userdata;
-
-    status = adc_init(phy);
-    if (status < 0) {
-        return status;
-    }
-
-    status = dac_init(phy, DATA_SEL_DMA, 0);
-    if (status < 0) {
-        return status;
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief axiadc_post_setup
-*******************************************************************************/
-
-int axiadc_post_setup(struct ad9361_rf_phy *phy)
-{
-    return ad9361_post_setup(phy);
-}
-
-/***************************************************************************//**
- * @brief axiadc_read
-*******************************************************************************/
-
-int axiadc_read(struct axiadc_state *st, uint32_t addr, uint32_t *data)
-{
-    struct bladerf *dev = st->userdata;
-    int status;
-
-    /* Read */
-    status = dev->backend->adi_axi_read(dev, addr, data);
-    if (status < 0) {
-        return -EIO;
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief axiadc_write
-*******************************************************************************/
-
-int axiadc_write(struct axiadc_state *st, uint32_t addr, uint32_t data)
-{
-    struct bladerf *dev = st->userdata;
-    int status;
-
-    /* Write */
-    status = dev->backend->adi_axi_write(dev, addr, data);
-    if (status < 0) {
-        return -EIO;
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief axiadc_set_pnsel
-*******************************************************************************/
-
-int axiadc_set_pnsel(struct axiadc_state *st, unsigned int channel, enum adc_pn_sel sel)
-{
-    int status;
-    uint32_t reg;
-
-    if (PCORE_VERSION_MAJOR(st->pcore_version) > 7) {
-        status = axiadc_read(st, ADI_REG_CHAN_CNTRL_3(channel), &reg);
-        if (status != 0)
-            return status;
-
-        reg &= ~ADI_ADC_PN_SEL(~0);
-        reg |= ADI_ADC_PN_SEL(sel);
-
-        status = axiadc_write(st, ADI_REG_CHAN_CNTRL_3(channel), reg);
-        if (status != 0)
-            return status;
-    } else {
-        status = axiadc_read(st, ADI_REG_CHAN_CNTRL(channel), &reg);
-        if (status != 0)
-            return status;
-
-        if (sel == ADC_PN_CUSTOM) {
-            reg |= ADI_PN_SEL;
-        } else if (sel == ADC_PN9) {
-            reg &= ~ADI_PN23_TYPE;
-            reg &= ~ADI_PN_SEL;
-        } else {
-            reg |= ADI_PN23_TYPE;
-            reg &= ~ADI_PN_SEL;
-        }
-
-        status = axiadc_write(st, ADI_REG_CHAN_CNTRL(channel), reg);
-        if (status != 0)
-            return status;
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- * @brief axiadc_idelay_set
-*******************************************************************************/
-
-int axiadc_idelay_set(struct axiadc_state *st, unsigned int lane, unsigned int val)
-{
-    int status;
-
-    if (PCORE_VERSION_MAJOR(st->pcore_version) > 8) {
-        status = axiadc_write(st, ADI_REG_DELAY(lane), val);
-        if (status != 0)
-            return status;
-    } else {
-        status = axiadc_write(st, ADI_REG_DELAY_CNTRL, 0);
-        if (status != 0)
-            return status;
-
-        status = axiadc_write(st, ADI_REG_DELAY_CNTRL,
-                                ADI_DELAY_ADDRESS(lane) | ADI_DELAY_WDATA(val) | ADI_DELAY_SEL);
-        if (status != 0)
-            return status;
-    }
-
-    return 0;
-}
+/*
+ * The axiadc_* accessors that used to live here are gone: they served the AXI
+ * ADC/DAC cores, which this board does not have. config.h now defines
+ * AXI_ADC_NOT_PRESENT, so the driver never calls into that path, and
+ * adc_core.c / dac_core.c are out of the build for the same reason.
+ */

--- a/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/platform.h
+++ b/thirdparty/analogdevicesinc/no-OS_local/platform_bladerf2/platform.h
@@ -44,8 +44,12 @@
 /******************************************************************************/
 
 #include "stdint.h"
-#include "util.h"
+/* Renamed upstream: util.h became ad9361_util.h when the driver moved to
+ * drivers/rf-transceiver/ad9361/. */
+#include "ad9361_util.h"
 #include "config.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -143,27 +147,19 @@ enum adc_data_sel {
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
-int spi_init(struct ad9361_rf_phy *phy, void *userdata);
-int spi_write(struct spi_device *spi, uint16_t cmd, const uint8_t *buf,
-              unsigned int len);
-int spi_read(struct spi_device *spi, uint16_t cmd, uint8_t *buf,
-             unsigned int len);
-
-int gpio_init(struct ad9361_rf_phy *phy, void *userdata);
-bool gpio_is_valid(struct gpio_device *gpio, int32_t number);
-int gpio_set_value(struct gpio_device *gpio, int32_t number, bool value);
+/* SPI and GPIO reach the driver through the no-OS platform ops tables now, in
+ * bladerf2_spi.c and bladerf2_gpio.c. The driver no longer declares
+ * struct spi_device or struct gpio_device, so the old accessors are gone. */
+extern const struct no_os_spi_platform_ops bladerf2_spi_ops;
+extern const struct no_os_gpio_platform_ops bladerf2_gpio_ops;
 
 void udelay(unsigned long usecs);
 void mdelay(unsigned long msecs);
+void no_os_udelay(uint32_t usecs);
+void no_os_mdelay(uint32_t msecs);
 unsigned long msleep_interruptible(unsigned int msecs);
 
 #ifndef AXI_ADC_NOT_PRESENT
-int axiadc_init(struct ad9361_rf_phy *phy, void *userdata);
-int axiadc_post_setup(struct ad9361_rf_phy *phy);
-int axiadc_read(struct axiadc_state *st, uint32_t addr, uint32_t *data);
-int axiadc_write(struct axiadc_state *st, uint32_t addr, uint32_t data);
-int axiadc_set_pnsel(struct axiadc_state *st, unsigned int channel, enum adc_pn_sel sel);
-int axiadc_idelay_set(struct axiadc_state *st, unsigned int lane, unsigned int val);
 #endif
 
 #endif


### PR DESCRIPTION
Restoring a sample rate above the native range after operating below it fails:

```
pybladerf_set_sample_rate() failed: An unexpected error occurred (-1)
ad9361_validate_trx_clock_chain: Failed TX max rate check (245760000 > 160000000)
ad9361_calculate_rf_clock_chain: Failed to find suitable dividers: ADC clock below limit
```

## Cause

`bladerf2_set_sample_rate()` applies the new rate first and only afterwards restores the default filters. With the 4x interpolation filter still active the AD9361 computes the TX chain as `rate * 4`, so 61.44 MSPS asks for 245.76 MHz, above `MAX_TX_HB1` (160 MHz). The filter reset that follows is unreachable, because `CHECK_STATUS()` has already returned the error. Both chains are validated together in `ad9361_validate_trx_clock_chain()`, so RX-only applications hit this as well.

The low-rate path already carries a guard for this exact transition:

```c
(rate > 40e6 && current < 2083334)
```

but it sits inside `if (new_low)`, where the new rate is low by definition, so that half of the condition can never run.

## Fix

Restore the filters before applying the rate, mirroring the low-rate path, and use the same 30 MSPS intermediate step. 30 MSPS is inside the native range (no FIR required) and `30 * 4 = 120 MHz` stays under `MAX_TX_HB1`, so it is valid both with the 4x filters still active and after they are cleared.

## Measurements

bladeRF 2.0 micro xA4, same hardware and application code, only the library swapped. Read-back sample rate verified after every step.

| transition | before | after |
|---|---|---|
| 61.44 -> 1.6 MSPS | ok | ok |
| 1.6 -> 61.44 MSPS | **-1** | ok |
| 61.44 -> 0.8 MSPS | ok | ok |
| 0.8 -> 61.44 MSPS | **-1** | ok |
| 30 -> 1.0 MSPS | ok | ok |
| 1.0 -> 30 MSPS | ok | ok |
| 2.0 -> 2.5 MSPS | ok | ok |
| 61.44 -> 30.72 MSPS | ok | ok |

`1.0 -> 30 MSPS` passes without the fix because 30 MHz does not exceed the `40e6` threshold in the existing guard, which is consistent with the mechanism described above.

The original symptom appeared in an RX-only application that retunes between a wide survey rate and a narrow decode rate; every return to the wide rate failed until the device was closed and reopened.